### PR TITLE
ci: add rust workflow and enforce ui-install via mise

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,31 @@
+name: rust-ci
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MISE_EXPERIMENTAL: true
+
+jobs:
+  rust-lint-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup mise + tools
+        uses: jdx/mise-action@v3
+
+      - name: Lint Rust workspace
+        run: mise exec -- cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test Rust workspace
+        run: mise exec -- cargo test --workspace

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 rust = "stable"
-bun = "latest"
+bun = "1.3.10"
 opentofu = "latest"
 
 [tasks.install]
@@ -34,6 +34,15 @@ run = "cargo run -p gateway"
 [tasks.ui-install]
 description = "Install admin UI dependencies"
 run = "bun install --cwd crates/admin-ui/web"
+
+[tasks.ui-check]
+description = "Install, lint, test, and build admin UI"
+depends = ["ui-install"]
+run = [
+  { task = "ui-lint" },
+  { task = "ui-test" },
+  { task = "ui-build" },
+]
 
 [tasks.ui-dev]
 description = "Run admin UI dev server"


### PR DESCRIPTION
## Description

This PR adds baseline CI coverage for Rust crates and hardens frontend task execution through `mise`.

- Summary of changes
  - Added `.github/workflows/rust-ci.yml` to run Rust linting and tests on pull requests and pushes to `main`.
  - Pinned `bun` in `mise.toml` from `latest` to `1.3.10`.
  - Added `ui-check` task in `mise.toml` with `depends = ["ui-install"]` so frontend dependency install is enforced before lint/test/build.
- Why this approach was chosen
  - Rust workflow is focused on workspace crates only, matching the requested CI scope.
  - Pinning Bun removes toolchain drift between local and CI environments.
  - `mise` task dependencies are the built-in mechanism to guarantee task order.
- How it works
  - `rust-ci` uses `jdx/mise-action@v3`, then runs `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` via `mise exec`.
  - `ui-check` runs `ui-install` first, then `ui-lint`, `ui-test`, and `ui-build`.
- Risks, tradeoffs, and alternatives considered
  - `ui-check` currently surfaces an existing `ui-build` PostCSS/Tailwind path error; this change does not introduce that issue but makes it reproducible in a single task.
  - Kept the Rust workflow single-job sequential per requested design; parallel jobs would give faster failure feedback but were intentionally not used.
- Additional context for reviewers
  - Only `mise.toml` and `.github/workflows/rust-ci.yml` are included in this PR; unrelated untracked files were intentionally excluded.
