### PR TITLE
docs: add dedicated feature/bug issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,105 @@
+---
+name: Bug Report
+about: Capture actionable bugs with reproducible details, impact, and closure criteria.
+title: "[Bug]: <concise summary>"
+labels: ["bug", "needs-triage"]
+assignees: []
+---
+
+## Summary
+
+<!--
+1-2 sentences.
+What is broken and who/what is affected?
+-->
+
+## Problem
+
+<!--
+Describe the observed issue clearly.
+Include where it occurs (route, endpoint, flow, CLI command, etc.).
+-->
+
+## Expected Behavior
+
+<!--
+Describe what should happen instead.
+-->
+
+## Actual Behavior
+
+<!--
+Describe what actually happened.
+Include visible errors, unexpected output, or incorrect state.
+-->
+
+## Reproduction Steps
+
+<!--
+Provide deterministic steps with exact inputs when possible.
+If this is flaky, describe frequency and known triggers.
+-->
+
+1.
+2.
+3.
+
+## Environment
+
+<!--
+Record environment details needed to reproduce quickly.
+Use N/A if unknown.
+-->
+
+- Commit/Branch:
+- Runtime/Tooling versions:
+- OS/Browser:
+- Config/Env vars:
+
+## Impact
+
+<!--
+State severity and blast radius.
+Describe user-facing impact, data/cost risk, and blocked workflows.
+-->
+
+- Severity:
+- Affected scope:
+- User-visible impact:
+
+## Evidence
+
+<!--
+Paste logs, stack traces, request IDs, screenshots, or payload snippets.
+Redact secrets and sensitive data.
+-->
+
+```text
+Paste relevant logs/errors here
+```
+
+## Suspected Area (Optional)
+
+<!--
+List likely modules/files if you have a strong lead.
+-->
+
+- `crates/...`
+
+## Acceptance Criteria
+
+<!--
+Conditions required to close this bug.
+Keep each item objective and verifiable.
+-->
+
+- [ ] Root cause is identified and documented.
+- [ ] Fix resolves the repro path without regressions.
+- [ ] Automated test(s) or checks cover the failing scenario.
+- [ ] Docs/runbooks are updated if behavior or operation changed.
+
+## Notes
+
+<!--
+Include workarounds, rollout/backfill notes, and links to related issues/PRs.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
-name: Work Item
-about: Capture feature requests and implementation issues with clear scope and acceptance criteria.
-title: "<short imperative title>"
+name: Feature Request
+about: Capture feature requests and enhancements with clear scope and acceptance criteria.
+title: "[Feature]: <short imperative title>"
 labels: ["needs-triage"]
 assignees: []
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,5 @@ Use `mise` for all repo tooling and task execution.
 - Use `gh` CLI for creating pull requests.
   - For new pull requests, use `.github/PULL_REQUEST_TEMPLATE.md` as the content reference.
 - Use `gh` CLI for creating issues.
-  - For new issues, use `.github/ISSUE_TEMPLATE/work-item.md` as the content structure/reference.
+  - Use `.github/ISSUE_TEMPLATE/feature_request.md` for new features/enhancements (new capability, scoped change, acceptance criteria).
+  - Use `.github/ISSUE_TEMPLATE/bug_report.md` for bugs/issues (unexpected behavior, repro details, expected vs actual).


### PR DESCRIPTION
## Description

Adds structured GitHub issue templating and updates agent guidance so issue/PR creation stays consistent and actionable.

- Summary of changes
  - Replaced the single work-item issue template with a dedicated feature request template: `.github/ISSUE_TEMPLATE/feature_request.md`.
  - Added a dedicated bug template: `.github/ISSUE_TEMPLATE/bug_report.md`.
  - Added `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` to enforce template selection.
  - Updated `AGENTS.md` to clarify `gh` issue usage and when to use each template.
- Why this approach was chosen
  - Feature and bug issues need different prompts to capture high-signal details for planning, triage, and execution.
  - A required template picker improves consistency and prevents low-context freeform issues.
- How it works
  - GitHub now shows two issue templates in the chooser (feature request and bug report).
  - Blank issue creation is disabled by config.
  - Agent instructions now explicitly map issue type to template path.
- Risks, tradeoffs, and alternatives considered
  - Slightly more structure when filing issues, but higher triage quality and less clarification churn.
  - Kept the existing feature template structure to preserve the style used in existing issues.
- Additional context for reviewers
  - This PR includes only docs/template/process changes (no runtime code changes).
  - Existing unrelated untracked files (`.DS_Store`, `docs/`) were intentionally not included.
