### PR TITLE
feat(deploy): add local and GHCR compose stacks

### DIFF
--- a/compose.local.yaml
+++ b/compose.local.yaml
@@ -1,0 +1,57 @@
+services:
+  gateway:
+    image: oceans-llm-gateway:local
+    build:
+      context: .
+      dockerfile: crates/gateway/Dockerfile
+    depends_on:
+      admin-ui:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    environment:
+      PORT: "8080"
+      GATEWAY_CONFIG: /app/gateway.yaml
+      ADMIN_UI_UPSTREAM: http://admin-ui:3000
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GATEWAY_API_KEY: ${GATEWAY_API_KEY:-gwk_localdev.replace-me}
+    ports:
+      - "${GATEWAY_PORT:-8080}:8080"
+    volumes:
+      - ./deploy/config/gateway.yaml:/app/gateway.yaml:ro
+      - gateway-data:/data
+    restart: unless-stopped
+
+  admin-ui:
+    image: oceans-llm-admin-ui:local
+    build:
+      context: .
+      dockerfile: crates/admin-ui/web/Dockerfile
+    environment:
+      PORT: "3000"
+    expose:
+      - "3000"
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-oceans_llm}
+      POSTGRES_USER: ${POSTGRES_USER:-oceans}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-oceans}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped
+
+volumes:
+  gateway-data:
+  postgres-data:

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,9 @@
+OCEANS_LLM_VERSION=latest
+GATEWAY_PORT=8080
+
+POSTGRES_DB=oceans_llm
+POSTGRES_USER=oceans
+POSTGRES_PASSWORD=change-me
+
+OPENAI_API_KEY=
+GATEWAY_API_KEY=gwk_deploy.replace-me

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,25 @@
+# Deploy Compose
+
+This directory contains the user-facing Docker Compose setup that pulls the published images from GHCR:
+
+- `ghcr.io/ahstn/oceans-llm-gateway`
+- `ghcr.io/ahstn/oceans-llm-admin-ui`
+
+## Files
+
+- `compose.yaml`: compose stack for gateway, admin UI, and Postgres.
+- `config/gateway.yaml`: example gateway config mounted into the gateway container.
+- `.env.example`: example environment values for image tag selection and secrets.
+
+## Usage
+
+```bash
+cp deploy/.env.example deploy/.env
+docker compose -f deploy/compose.yaml up -d
+```
+
+The gateway is published on `http://localhost:8080` by default, and the admin UI is available through the gateway at `/admin`.
+
+## Database note
+
+The stack includes Postgres because the deployment shape requested a Postgres service, but the current gateway runtime still uses a local libsql/SQLite database file configured at `/data/gateway.db`. The mounted `config/gateway.yaml` reflects the current runtime behavior.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,49 @@
+services:
+  gateway:
+    image: ghcr.io/ahstn/oceans-llm-gateway:${OCEANS_LLM_VERSION:-latest}
+    depends_on:
+      admin-ui:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    environment:
+      PORT: "8080"
+      GATEWAY_CONFIG: /app/gateway.yaml
+      ADMIN_UI_UPSTREAM: http://admin-ui:3000
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GATEWAY_API_KEY: ${GATEWAY_API_KEY:-gwk_deploy.replace-me}
+    ports:
+      - "${GATEWAY_PORT:-8080}:8080"
+    volumes:
+      - ./config/gateway.yaml:/app/gateway.yaml:ro
+      - gateway-data:/data
+    restart: unless-stopped
+
+  admin-ui:
+    image: ghcr.io/ahstn/oceans-llm-admin-ui:${OCEANS_LLM_VERSION:-latest}
+    environment:
+      PORT: "3000"
+    expose:
+      - "3000"
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-oceans_llm}
+      POSTGRES_USER: ${POSTGRES_USER:-oceans}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-oceans}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped
+
+volumes:
+  gateway-data:
+  postgres-data:

--- a/deploy/config/gateway.yaml
+++ b/deploy/config/gateway.yaml
@@ -1,0 +1,28 @@
+server:
+  bind: "0.0.0.0:8080"
+  log_format: "json"
+
+database:
+  # The current gateway runtime persists to a local libsql/SQLite file.
+  path: "/data/gateway.db"
+
+auth:
+  seed_api_keys:
+    - name: default
+      value: env.GATEWAY_API_KEY
+
+providers:
+  - id: openai-prod
+    type: openai_compat
+    base_url: https://api.openai.com/v1
+    pricing_provider_id: openai
+    auth:
+      kind: bearer
+      token: env.OPENAI_API_KEY
+
+models:
+  - id: openai-fast
+    description: OpenAI via the compatible provider adapter
+    routes:
+      - provider: openai-prod
+        upstream_model: gpt-5


### PR DESCRIPTION
## Description

Add two Docker Compose entrypoints for the current container layout:

- a local stack that builds `crates/gateway/Dockerfile` and `crates/admin-ui/web/Dockerfile`
- a deploy stack under `deploy/` that pulls the published GHCR images

This also adds a mounted example `gateway.yaml`, a deploy `.env.example`, and a short deploy README that documents the current runtime caveat: the gateway still persists to libsql/SQLite even though the stack now also brings up Postgres. Related follow-up issue: #14.

- Summary of changes
  - Add `compose.local.yaml` for local image builds plus `gateway`, `admin-ui`, and `postgres` services
  - Add `deploy/compose.yaml` for GHCR-based deployment
  - Add `deploy/config/gateway.yaml`, `deploy/.env.example`, and `deploy/README.md`
- Why this approach was chosen
  - It matches the existing split gateway/admin-ui runtime model without changing application code
  - It gives a production-facing deployment bundle while keeping local iteration simple
- How it works
  - The gateway mounts a config file at `/app/gateway.yaml`
  - The admin UI runs as a separate container and is reached by the gateway through `ADMIN_UI_UPSTREAM`
  - Postgres is provisioned alongside both stacks, while the mounted gateway config persists the current libsql database to `/data/gateway.db`
- Risks, tradeoffs, and alternatives considered
  - The stack shape includes Postgres before the runtime actually supports it, so the README calls that out explicitly to avoid implying a completed migration
  - I kept the deploy image tag configurable via `OCEANS_LLM_VERSION`, defaulting to `latest` from the release workflow
- Additional context for reviewers
  - Validated with `docker compose -f compose.local.yaml config`
  - Validated with `docker compose -f deploy/compose.yaml config`
