### PR TITLE
fix(gateway): restore lint and test green

### DIFF
--- a/crates/gateway-service/src/model_access.rs
+++ b/crates/gateway-service/src/model_access.rs
@@ -282,6 +282,7 @@ mod tests {
             global_role: GlobalRole::User,
             auth_mode: AuthMode::Password,
             status: "active".to_string(),
+            must_change_password: false,
             request_logging_enabled: true,
             model_access_mode,
             created_at: OffsetDateTime::now_utc(),

--- a/crates/gateway-service/src/request_logging.rs
+++ b/crates/gateway-service/src/request_logging.rs
@@ -131,6 +131,7 @@ mod tests {
             global_role: GlobalRole::User,
             auth_mode: AuthMode::Password,
             status: "active".to_string(),
+            must_change_password: false,
             request_logging_enabled,
             model_access_mode: ModelAccessMode::All,
             created_at: OffsetDateTime::now_utc(),

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -446,12 +446,12 @@ pub async fn login_with_password(
         .store
         .get_user_by_email_normalized(&email_normalized)
         .await?
-        .ok_or_else(|| AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
+        .ok_or(AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
     let password_auth = state
         .store
         .get_user_password_auth(user.user_id)
         .await?
-        .ok_or_else(|| AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
+        .ok_or(AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
 
     if user.auth_mode != AuthMode::Password {
         return Err(AppError(GatewayError::Auth(AuthError::InvalidCredentials)));
@@ -506,7 +506,7 @@ pub async fn change_password(
         .store
         .get_user_password_auth(user.user_id)
         .await?
-        .ok_or_else(|| AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
+        .ok_or(AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
     let current_password_ok = gateway_service::verify_gateway_key_secret(
         &request.current_password,
         &password_auth.password_hash,
@@ -888,7 +888,7 @@ async fn require_authenticated_session(
 ) -> Result<UserRecord, AppError> {
     resolve_session_user(state, headers)
         .await?
-        .ok_or_else(|| AppError(GatewayError::Auth(AuthError::SessionRequired)))
+        .ok_or(AppError(GatewayError::Auth(AuthError::SessionRequired)))
 }
 
 async fn resolve_session_user(


### PR DESCRIPTION
## Description

Restore a green lint/test baseline after the recent identity and admin-auth changes.

PR title format must follow Conventional Commits, for example `feat(gateway): add release workflow`.

Use this section for review hints, explanations, discussion points, and follow-up TODOs.

- Summary of changes
  - Added `must_change_password: false` to the `UserRecord` fixtures used by `gateway-service` tests.
  - Replaced eager-Clippy `ok_or_else(...)` calls with `ok_or(...)` in gateway identity auth paths.
- Why this approach was chosen
  - The fixture updates keep the tests aligned with the current domain model instead of weakening type checks.
  - The `ok_or(...)` changes are the precise fix Clippy requested and preserve behavior.
- How it works
  - `gateway-service` test helpers now construct valid `UserRecord` values.
  - `gateway` auth/session code now uses eager error construction where the error value is trivial.
- Risks, tradeoffs, and alternatives considered
  - Low risk; these are compile/lint correctness fixes with no intended behavior change.
  - I did not add abstraction around the fixtures because the issue was limited to two direct constructors.
- Additional context for reviewers
  - Verified with `mise run lint` and `mise run test`.
  - `lint` and `test` should be run serially in this repo because both invoke Bun install and can race if launched in parallel.
