### PR TITLE
docs: harden documentation graph and workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,3 +158,26 @@ Keep the docs graph intact when you document new behavior:
 - update the canonical doc that owns the behavior instead of copying policy into several files,
 - add or update an ADR in [docs/adr/](docs/adr/) when the change is architectural,
 - link to source files and workflow files when those are the true source of operational detail.
+
+## Docs Maintenance
+
+When behavior changes, update the owning page instead of adding a second explanation.
+
+- startup flow, bootstrap admin, seeded API keys:
+  - [docs/runtime-bootstrap-and-access.md](docs/runtime-bootstrap-and-access.md)
+- topology, same-origin runtime model, local-vs-prod differences:
+  - [docs/deploy-and-operations.md](docs/deploy-and-operations.md)
+- recovery and upgrade steps:
+  - [docs/operator-runbooks.md](docs/operator-runbooks.md)
+- config syntax and defaults:
+  - [docs/configuration-reference.md](docs/configuration-reference.md)
+- identity lifecycle and ownership rules:
+  - [docs/identity-and-access.md](docs/identity-and-access.md)
+- OIDC and SSO boundary:
+  - [docs/oidc-and-sso-status.md](docs/oidc-and-sso-status.md)
+- admin contract generation and drift rules:
+  - [docs/admin-api-contract-workflow.md](docs/admin-api-contract-workflow.md)
+- request routing, pricing, spend, and logging as one path:
+  - [docs/request-lifecycle-and-failure-modes.md](docs/request-lifecycle-and-failure-modes.md)
+
+Run `mise run docs-check` after touching Markdown in the canonical docs set.

--- a/README.md
+++ b/README.md
@@ -8,62 +8,20 @@ Rust-first LLM gateway workspace with an embedded TanStack Start admin control p
 
 ## Overview
 
-
-- `crates/gateway`: Rust HTTP runtime for `/healthz`, `/readyz`, `/v1/*`, and `/api/v1/admin/*`
-- `crates/gateway-core`: shared domain types, traits, OpenAI-compatible DTOs, and errors
-- `crates/gateway-store`: libsql/SQLite and PostgreSQL stores, migrations, and seed behavior
-- `crates/gateway-service`: auth, model resolution, routing, accounting, and request logging
-- `crates/gateway-providers`: provider adapters and transport helpers
-- `crates/admin-ui`: Rust reverse proxy integration for `/admin*`
-- `crates/admin-ui/web`: TanStack Start + React admin UI
-
-
-
-## Gateway config
-
-- `PORT`: helper-script/container env used when launching the gateway process (the gateway listener itself comes from `server.bind` in the active config)
-- `GATEWAY_CONFIG`: gateway config file path (default `./gateway.yaml`, prod helper uses `./gateway.prod.yaml`)
-- `GATEWAY_RUN_MIGRATIONS`: control `gateway serve --run-migrations` (default `true`)
-- `GATEWAY_BOOTSTRAP_ADMIN`: control `gateway serve --bootstrap-admin` (default `true`)
-- `GATEWAY_SEED_CONFIG`: control `gateway serve --seed-config` (default `true`)
-- `POSTGRES_URL`: PostgreSQL connection string used by production-shaped configs (for example `postgres://oceans:oceans@localhost:5432/oceans_llm`)
-- `TEST_POSTGRES_URL`: PostgreSQL connection string used by Postgres-focused test helpers (defaults to `POSTGRES_URL` in the local pitchfork flow)
-- `OCEANS_POSTGRES_HOST` / `OCEANS_POSTGRES_PORT` / `OCEANS_POSTGRES_DB` / `OCEANS_POSTGRES_USER` / `OCEANS_POSTGRES_PASSWORD`: local pitchfork Postgres defaults used to derive `POSTGRES_URL` and `TEST_POSTGRES_URL`
-- `ADMIN_UI_BASE_PATH`: UI mount path (default `/admin`)
-- `ADMIN_UI_UPSTREAM`: SSR upstream URL (default `http://localhost:3001`)
-- `ADMIN_UI_CONNECT_TIMEOUT_MS`: Proxy connect timeout (default `750`)
-- `ADMIN_UI_REQUEST_TIMEOUT_MS`: Proxy request timeout (default `10000`)
-- `ADMIN_UI_INTERNAL_PORT`: Internal Bun SSR port used by helper scripts (default `3001`)
-
-
-## Runtime Model
-
-The repo runs as a same-origin control plane:
-
-1. The gateway listens on `server.bind` from the active config file.
-2. The admin UI SSR process runs separately, typically on internal port `3001`.
-3. The gateway reverse-proxies `/admin*` to `ADMIN_UI_UPSTREAM`.
-
-Checked-in configs keep the local-development default on libsql/SQLite and the production-shaped default on PostgreSQL.
-
-## Docs Map
-
-Use the canonical docs for behavior and policy details:
-
-- [Contributing](CONTRIBUTING.md)
-- [Documentation Hub](docs/README.md)
-- [Configuration Reference](docs/configuration-reference.md)
-- [Identity and Access](docs/identity-and-access.md)
-- [Model Routing and API Behavior](docs/model-routing-and-api-behavior.md)
-- [Budgets and Spending](docs/budgets-and-spending.md)
-- [Pricing Catalog and Accounting](docs/pricing-catalog-and-accounting.md)
-- [Observability and Request Logs](docs/observability-and-request-logs.md)
-- [Data Relationships](docs/data-relationships.md)
-- [Admin Control Plane](docs/admin-control-plane.md)
-- [End-to-End Contract Tests](docs/e2e-contract-tests.md)
-- [Deploy and Operations](docs/deploy-and-operations.md)
-- [Release Process](docs/release-process.md)
-- [Deploy Compose](deploy/README.md)
+- `crates/gateway`
+  - Rust HTTP runtime for `/healthz`, `/readyz`, `/v1/*`, and `/api/v1/admin/*`
+- `crates/gateway-core`
+  - shared domain types, traits, OpenAI-compatible DTOs, and errors
+- `crates/gateway-store`
+  - libsql or SQLite and PostgreSQL stores, migrations, and seed behavior
+- `crates/gateway-service`
+  - auth, model resolution, routing, accounting, and request logging
+- `crates/gateway-providers`
+  - provider adapters and transport helpers
+- `crates/admin-ui`
+  - Rust reverse-proxy integration for `/admin*`
+- `crates/admin-ui/web`
+  - TanStack Start and React admin UI
 
 ## Quick Start
 
@@ -83,134 +41,89 @@ Run the local development stack:
 
 Default local endpoints:
 
-- Gateway API: `http://localhost:8080`
-- Admin UI: `http://localhost:8080/admin`
-- Active config: `./gateway.yaml`
-- Database backend: local libsql/SQLite
+- gateway API: `http://localhost:8080`
+- admin UI: `http://localhost:8080/admin`
+- active config: `./gateway.yaml`
+- database backend: local libsql or SQLite
 
-For contributor setup, workspace layout, task conventions, CI workflow references, and editor recommendations, see [CONTRIBUTING.md](CONTRIBUTING.md).
+## Core Commands
+
+- local gateway:
+  - `mise run gateway-serve`
+- explicit migration:
+  - `mise run gateway-migrate`
+- explicit bootstrap admin:
+  - `mise run gateway-bootstrap-admin`
+- explicit config seed:
+  - `mise run gateway-seed-config`
+- admin contract generation:
+  - `mise run admin-contract-generate`
+- admin contract drift check:
+  - `mise run admin-contract-check`
+- full lint:
+  - `mise run lint`
+- full test:
+  - `mise run test`
+- E2E contract suite:
+  - `mise run e2e-test`
+
+## Documentation Map
+
+Use the canonical docs instead of treating this file as the full operator manual.
+
+- repo workflow:
+  - [Contributing](CONTRIBUTING.md)
+- docs graph:
+  - [Documentation Hub](docs/README.md)
+- startup and first access:
+  - [Runtime Bootstrap and Access](docs/runtime-bootstrap-and-access.md)
+- config contract:
+  - [Configuration Reference](docs/configuration-reference.md)
+- identity:
+  - [Identity and Access](docs/identity-and-access.md)
+- routing:
+  - [Model Routing and API Behavior](docs/model-routing-and-api-behavior.md)
+- cross-cutting request flow:
+  - [Request Lifecycle and Failure Modes](docs/request-lifecycle-and-failure-modes.md)
+- pricing and spend:
+  - [Pricing Catalog and Accounting](docs/pricing-catalog-and-accounting.md)
+  - [Budgets and Spending](docs/budgets-and-spending.md)
+- observability:
+  - [Observability and Request Logs](docs/observability-and-request-logs.md)
+- admin UI:
+  - [Admin Control Plane](docs/admin-control-plane.md)
+- deploy quick start:
+  - [Deploy Compose](deploy/README.md)
+
+## Same-Origin Runtime Model
+
+The product runs as a same-origin control plane:
+
+1. the gateway listens on the configured bind address
+2. the admin UI SSR process runs separately
+3. the gateway reverse-proxies `/admin*` to the admin UI upstream
+
+This is part of the product contract, not only a local-dev trick.
 
 ## Admin Contract Generation
 
-The live admin control plane now ships checked-in contract artifacts:
+The live admin control plane ships checked-in contract artifacts:
 
-- gateway OpenAPI artifact: `crates/gateway/openapi/admin-api.json`
-- generated admin UI types: `crates/admin-ui/web/src/generated/admin-api.ts`
+- gateway OpenAPI artifact:
+  - `crates/gateway/openapi/admin-api.json`
+- generated admin UI types:
+  - `crates/admin-ui/web/src/generated/admin-api.ts`
 
-Refresh them locally with:
+Regenerate them with:
 
 ```bash
 mise run admin-contract-generate
 ```
 
-Verify they are current with:
+Verify drift with:
 
 ```bash
 mise run admin-contract-check
 ```
 
-`mise run lint` and CI both enforce this drift check.
-
-## Gateway Commands
-
-The runtime exposes explicit operational commands:
-
-- `gateway serve`
-- `gateway migrate --status|--check|--apply`
-- `gateway bootstrap-admin`
-- `gateway seed-config`
-
-Matching `mise` tasks:
-
-- `mise run gateway-serve`
-- `mise run gateway-migrate`
-- `mise run gateway-bootstrap-admin`
-- `mise run gateway-seed-config`
-
-`gateway serve` remains the default startup path. It reads `GATEWAY_CONFIG` or `./gateway.yaml`, runs migrations, seeds providers and models, ensures the bootstrap admin exists, and then starts serving traffic.
-
-## Configuration Entry Points
-
-Important env vars:
-
-- `GATEWAY_CONFIG`: config file path, default `./gateway.yaml`
-- `PORT`: helper-script/container port input
-- `POSTGRES_URL`: PostgreSQL connection string for production-shaped configs
-- `GATEWAY_RUN_MIGRATIONS`
-- `GATEWAY_BOOTSTRAP_ADMIN`
-- `GATEWAY_SEED_CONFIG`
-- `ADMIN_UI_UPSTREAM`
-- `ADMIN_UI_INTERNAL_PORT`
-
-For config shape, defaults, provider-specific constraints, and env-backed secret references, see [Configuration Reference](docs/configuration-reference.md). For request behavior and routing semantics, see [Model Routing and API Behavior](docs/model-routing-and-api-behavior.md).
-
-## Production-Shaped Local Run
-
-Start PostgreSQL and run the production-shaped config locally:
-
-Pitchfork-first local Postgres:
-
-```bash
-mise run postgres-start
-eval "$(mise run postgres-env)"
-export OPENAI_API_KEY="${OPENAI_API_KEY:-test-openai-key}"
-mise run ui-build
-./scripts/start-prod.sh
-```
-
-Default local values emitted by `mise run postgres-env`:
-
-- `POSTGRES_URL=postgres://oceans:oceans@127.0.0.1:5432/oceans_llm`
-- `TEST_POSTGRES_URL=postgres://oceans:oceans@127.0.0.1:5432/oceans_llm`
-
-`start-prod.sh` defaults `GATEWAY_CONFIG` to `./gateway.prod.yaml`, which now expects PostgreSQL through `POSTGRES_URL`, keeps the bootstrap admin enabled for first-time setup, and forces a password change after initial sign-in.
-
-For one-off operational actions against the configured database:
-
-```bash
-mise run gateway-migrate
-mise run gateway-seed-config
-mise run gateway-bootstrap-admin
-cargo run -p gateway --bin gateway -- --config gateway.prod.yaml serve --run-migrations=false --bootstrap-admin=false --seed-config=false
-```
-
-These maintenance tasks default to `gateway.prod.yaml`. Override `GATEWAY_CONFIG` if you need to point them at another config file.
-
-For deploy-oriented usage, image tags, and compose layout, see [deploy/README.md](deploy/README.md).
-
-Bring up local Postgres (pitchfork-first):
-
-```bash
-mise run postgres-start
-eval "$(mise run postgres-env)"
-export OPENAI_API_KEY="${OPENAI_API_KEY:-test-openai-key}"
-```
-
-Libsql-first local validation:
-
-```bash
-mise run check
-mise run lint
-mise run test
-```
-
-Focused PostgreSQL validation:
-
-```bash
-docker compose -f compose.local.yaml up -d postgres
-export TEST_POSTGRES_URL="postgres://oceans:oceans@localhost:5432/oceans_llm"
-export POSTGRES_URL="$TEST_POSTGRES_URL"
-export OPENAI_API_KEY="${OPENAI_API_KEY:-test-openai-key}"
-mise run check-rust-postgres
-mise run test-rust-postgres
-mise run test-gateway-postgres-smoke
-```
-
-CI runs `mise run check-rust-postgres`, `mise run test-rust-postgres`, and `mise run test-gateway-postgres-smoke` so the PostgreSQL path stays visible in the workflow and exercised before merge.
-`mise run sync-pricing-catalog` refreshes the vendored pricing snapshot used to seed model pricing history for deterministic spend accounting.
-
-Release-readiness checklist for Postgres runtime parity:
-
-- `mise run check-rust-postgres`
-- `mise run test-rust-postgres`
-- `mise run test-gateway-postgres-smoke`
+For the full maintainer workflow, use [Admin API Contract Workflow](docs/admin-api-contract-workflow.md).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,19 +1,19 @@
 # Deploy Compose
 
-`Owns`: the GHCR-based compose deployment entrypoint in `deploy/`.
+`Owns`: the GHCR-based compose quick start in `deploy/`.
 `Depends on`: [../README.md](../README.md), [../docs/deploy-and-operations.md](../docs/deploy-and-operations.md)
-`See also`: [../docs/model-routing-and-api-behavior.md](../docs/model-routing-and-api-behavior.md), [../docs/identity-and-access.md](../docs/identity-and-access.md)
+`See also`: [../docs/runtime-bootstrap-and-access.md](../docs/runtime-bootstrap-and-access.md), [../docs/operator-runbooks.md](../docs/operator-runbooks.md)
 
-This directory contains the user-facing Docker Compose setup that pulls the published images from GHCR:
-
-- `ghcr.io/ahstn/oceans-llm-gateway`
-- `ghcr.io/ahstn/oceans-llm-admin-ui`
+This directory is the quick start for the checked-in compose deploy path.
 
 ## Files
 
-- `compose.yaml`: gateway, admin UI, and PostgreSQL
-- `config/gateway.yaml`: mounted production-shaped gateway config
-- `.env.example`: image-tag and secret inputs
+- `compose.yaml`
+  - gateway, admin UI, and PostgreSQL
+- `config/gateway.yaml`
+  - mounted production-shaped gateway config
+- `.env.example`
+  - image tags and secret inputs
 
 ## Usage
 
@@ -22,24 +22,53 @@ cp deploy/.env.example deploy/.env
 docker compose -f deploy/compose.yaml up -d
 ```
 
-Default local endpoint:
+Default endpoint:
 
-- gateway: `http://localhost:8080`
-- admin UI: `http://localhost:8080/admin`
+- gateway and admin UI:
+  - `http://localhost:8080`
 
-## What This Stack Assumes
+## What Gets Created
 
-- PostgreSQL is the runtime database
-- the gateway applies migrations and idempotent startup seed behavior on boot
-- the Postgres container is not preloaded with application rows through `docker-entrypoint-initdb.d`
-- this stack is compose-oriented and does not document every runtime/auth variation by itself
+The checked-in stack creates:
 
-For the wider runtime and policy model, use the canonical docs instead of this deploy note:
+- a PostgreSQL container
+- a gateway container
+- an admin UI container
+- config-seeded runtime objects on gateway boot
 
-- [Identity and Access](../docs/identity-and-access.md)
-- [Configuration Reference](../docs/configuration-reference.md)
-- [Model Routing and API Behavior](../docs/model-routing-and-api-behavior.md)
-- [Pricing Catalog and Accounting](../docs/pricing-catalog-and-accounting.md)
-- [Budgets and Spending](../docs/budgets-and-spending.md)
-- [Observability and Request Logs](../docs/observability-and-request-logs.md)
-- [Deploy and Operations](../docs/deploy-and-operations.md)
+The gateway can run migrations and seed config-backed objects on startup.
+
+## Access After Boot
+
+The checked-in compose path guarantees:
+
+- data-plane access through the seeded `GATEWAY_API_KEY`
+
+The checked-in compose path does not guarantee:
+
+- a bootstrap admin user
+- a first-login password flow
+- hardened OIDC or SSO bootstrap
+
+Admin access depends on the mounted runtime config and any existing admin rows in the database.
+
+## What This Quick Start Does Not Configure
+
+- no checked-in OTLP collector
+- no checked-in bootstrap-admin block
+- no declarative users, teams, or budgets
+
+That missing declarative identity path is part of the future config-as-code direction tracked in [issue #64](https://github.com/ahstn/oceans-llm/issues/64) and [issue #65](https://github.com/ahstn/oceans-llm/issues/65).
+
+## Follow The Canonical Docs
+
+Use the quick start here, then switch to the canonical pages for the rest:
+
+- startup and first access:
+  - [Runtime Bootstrap and Access](../docs/runtime-bootstrap-and-access.md)
+- topology and caveats:
+  - [Deploy and Operations](../docs/deploy-and-operations.md)
+- action-oriented recovery:
+  - [Operator Runbooks](../docs/operator-runbooks.md)
+- config contract:
+  - [Configuration Reference](../docs/configuration-reference.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,82 @@
 # Documentation Hub
 
-`Owns`: the documentation map, canonical doc graph, and doc maturity overview.
+`Owns`: the documentation map, the canonical doc graph, and the audience-level entry points into the repo docs.
 `Depends on`: [../README.md](../README.md)
 `See also`: [adr/](adr/), [internal/](internal/)
 
-This repository uses a documentation graph instead of repeating the same policy in many files.
+This repo uses a docs graph instead of repeating the same policy in many places.
 
-- Canonical docs own facts.
+- Canonical docs explain current behavior.
 - ADRs explain why a decision was made.
-- Internal docs capture background research and inception context.
+- Internal notes hold background research that should not be treated as the live contract.
 
-## Start Here
+## Operator Guides
 
-| Type | Document | Owns |
-| --- | --- | --- |
-| Guide | [../CONTRIBUTING.md](../CONTRIBUTING.md) | contributor setup, task workflow, CI map, workspace primer |
-| Reference | [Configuration Reference](configuration-reference.md) | gateway config shape, defaults, and validation rules |
-| Guide | [Identity and Access](identity-and-access.md) | bootstrap admin, users, teams, onboarding, OIDC status, access overlays |
-| Guide | [Model Routing and API Behavior](model-routing-and-api-behavior.md) | model aliases, `tag:` selection, capabilities, `/v1/*` behavior |
-| Guide | [Budgets and Spending](budgets-and-spending.md) | ledger semantics, budget enforcement, spend APIs, current deferrals |
-| Reference | [Pricing Catalog and Accounting](pricing-catalog-and-accounting.md) | pricing inputs, effective-dated pricing rows, and unpriced behavior |
-| Guide | [Observability and Request Logs](observability-and-request-logs.md) | OTLP model, metrics/logging, payload capture, observability APIs |
-| Reference | [Data Relationships](data-relationships.md) | tables, ownership graph, schema-level relationships |
-| Guide | [Admin Control Plane](admin-control-plane.md) | what the admin UI can do today, and what is still preview-backed |
-| Guide | [End-to-End Contract Tests](e2e-contract-tests.md) | test harness scope and extension rules |
-| Guide | [Deploy and Operations](deploy-and-operations.md) | topology, auth bootstrap differences, and operational caveats |
-| Guide | [Release Process](release-process.md) | maintainer release runbook and tag-triggered CI flow |
-| Guide | [../deploy/README.md](../deploy/README.md) | deploy compose usage |
+| Document | Owns |
+| --- | --- |
+| [Runtime Bootstrap and Access](runtime-bootstrap-and-access.md) | startup behavior, first access, bootstrap admin, seeded API keys |
+| [Deploy and Operations](deploy-and-operations.md) | runtime topology, same-origin contract, local-vs-prod differences |
+| [Operator Runbooks](operator-runbooks.md) | first deploy, upgrade, recovery, rotation checkpoints |
+| [Configuration Reference](configuration-reference.md) | gateway YAML shape, defaults, validation, auth modes |
+| [Identity and Access](identity-and-access.md) | users, teams, onboarding, ownership, access overlays |
+| [OIDC and SSO Status](oidc-and-sso-status.md) | current OIDC boundary, hardened direction, missing test-IdP story |
+| [Model Routing and API Behavior](model-routing-and-api-behavior.md) | model identity, selectors, planner inputs, `/v1/*` behavior |
+| [Request Lifecycle and Failure Modes](request-lifecycle-and-failure-modes.md) | end-to-end request path across routing, logging, pricing, and spend |
+| [Pricing Catalog and Accounting](pricing-catalog-and-accounting.md) | pricing inputs, effective-dated pricing rows, exact-only coverage |
+| [Budgets and Spending](budgets-and-spending.md) | spend ledger rules, hard limits, budget alerts, spend APIs |
+| [Observability and Request Logs](observability-and-request-logs.md) | OTLP model, request-log shape, payload policy, observability APIs |
+| [Data Relationships](data-relationships.md) | schema-level relationships and cross-table invariants |
+| [Admin Control Plane](admin-control-plane.md) | what the admin UI can do today and what is still preview-backed |
+| [../deploy/README.md](../deploy/README.md) | compose quick start for GHCR deploys |
+
+## Maintainer Guides
+
+| Document | Owns |
+| --- | --- |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | contributor setup, repo workflow, CI map |
+| [Admin API Contract Workflow](admin-api-contract-workflow.md) | generated admin contract artifacts, drift rules, same-origin client boundary |
+| [End-to-End Contract Tests](e2e-contract-tests.md) | E2E harness intent, scope rules, extension rules |
+| [Release Process](release-process.md) | release authoring flow, tag-triggered CI, release verification |
+
+## Decision History
+
+Start here when the current docs are clear but the reasons are not.
+
+- [Identity Foundation](adr/2026-03-05-identity-foundation.md)
+- [Model Aliases and Provider Route Config](adr/2026-03-10-model-aliases-and-provider-route-config.md)
+- [Capability-Aware Route Gating](adr/2026-03-13-capability-aware-route-gating.md)
+- [OTLP Observability and Request Log Payloads](adr/2026-03-15-otlp-observability-and-request-log-payloads.md)
+- [Generated Admin API Contract and Typed Same-Origin Client](adr/2026-03-28-generated-admin-api-contract-and-typed-same-origin-client.md)
+- [Live Admin API-Key Management and Contract Coverage](adr/2026-03-29-live-admin-api-key-management-and-contract-coverage.md)
+
+## Internal Background
+
+The docs in [internal/](internal/) stay useful for maintainers:
+
+- front-end stack research
+- provider API research
+- inception architecture notes
+
+They are context, not policy.
+
+## Common Questions
+
+Use the map. Do not hunt through unrelated pages.
+
+- Model shows up but fails:
+  - [Model Routing and API Behavior](model-routing-and-api-behavior.md)
+  - [Request Lifecycle and Failure Modes](request-lifecycle-and-failure-modes.md)
+- Request succeeds but is not charged:
+  - [Pricing Catalog and Accounting](pricing-catalog-and-accounting.md)
+  - [Budgets and Spending](budgets-and-spending.md)
+  - [Request Lifecycle and Failure Modes](request-lifecycle-and-failure-modes.md)
+- Compose boot finishes but admin access is unclear:
+  - [Runtime Bootstrap and Access](runtime-bootstrap-and-access.md)
+  - [Deploy and Operations](deploy-and-operations.md)
+  - [Operator Runbooks](operator-runbooks.md)
+- Live admin contract changed and the UI drifted:
+  - [Admin API Contract Workflow](admin-api-contract-workflow.md)
+  - [End-to-End Contract Tests](e2e-contract-tests.md)
 
 ## Graph
 
@@ -35,16 +85,21 @@ graph TD
     root["README.md"]
     hub["docs/README.md"]
     contributing["CONTRIBUTING.md"]
+    bootstrap["runtime-bootstrap-and-access.md"]
+    ops["deploy-and-operations.md"]
+    runbooks["operator-runbooks.md"]
     config["configuration-reference.md"]
     identity["identity-and-access.md"]
+    oidc["oidc-and-sso-status.md"]
     routing["model-routing-and-api-behavior.md"]
-    spend["budgets-and-spending.md"]
+    lifecycle["request-lifecycle-and-failure-modes.md"]
     pricing["pricing-catalog-and-accounting.md"]
-    observability["observability-and-request-logs.md"]
+    spend["budgets-and-spending.md"]
+    obs["observability-and-request-logs.md"]
     data["data-relationships.md"]
     admin["admin-control-plane.md"]
+    contract["admin-api-contract-workflow.md"]
     e2e["e2e-contract-tests.md"]
-    ops["deploy-and-operations.md"]
     release["release-process.md"]
     deploy["deploy/README.md"]
     adrs["docs/adr/*"]
@@ -52,71 +107,38 @@ graph TD
 
     root --> hub
     root --> contributing
-    hub --> identity
+    hub --> bootstrap
+    hub --> ops
+    hub --> runbooks
     hub --> config
+    hub --> identity
+    hub --> oidc
     hub --> routing
-    hub --> spend
+    hub --> lifecycle
     hub --> pricing
-    hub --> observability
+    hub --> spend
+    hub --> obs
     hub --> data
     hub --> admin
+    hub --> contract
     hub --> e2e
-    hub --> ops
     hub --> release
     hub --> deploy
-    hub --> contributing
 
-    config --> routing
-    config --> pricing
-    identity --> data
-    routing --> data
-    spend --> data
-    pricing --> data
-    observability --> data
+    bootstrap --> identity
+    bootstrap --> config
+    ops --> bootstrap
+    runbooks --> bootstrap
+    runbooks --> ops
+    identity --> oidc
+    routing --> lifecycle
+    pricing --> lifecycle
+    spend --> lifecycle
+    obs --> lifecycle
+    admin --> contract
     admin --> identity
-    admin --> spend
-    admin --> observability
-    ops --> config
-    ops --> identity
+    e2e --> contract
     release --> ops
-
-    identity --> adrs
-    routing --> adrs
-    spend --> adrs
-    pricing --> adrs
-    observability --> adrs
+    hub --> adrs
     hub --> internal
 ```
-
-## Admin Surface Maturity
-
-The admin UI is intentionally mixed maturity right now:
-
-- Live gateway-backed surfaces: API Keys, Identity, Spend Controls, Usage Costs, Request Logs, auth/session flows
-- Preview-backed surfaces: Models
-
-That distinction is part of the current product contract. See [Admin Control Plane](admin-control-plane.md) for the operator-facing view and linked follow-up issues.
-
-## ADRs
-
-Use ADRs for decision history and rationale, not as the primary operator manual.
-
-Suggested starting points:
-
-- [Identity Foundation](adr/2026-03-05-identity-foundation.md)
-- [Admin Team Management Flow](adr/2026-03-08-admin-team-management-flow.md)
-- [Model Aliases and Provider Route Config](adr/2026-03-10-model-aliases-and-provider-route-config.md)
-- [Capability-Aware Route Gating](adr/2026-03-13-capability-aware-route-gating.md)
-- [V1 Runtime Simplification](adr/2026-03-15-v1-runtime-simplification.md)
-- [Spend Control Plane Reporting and Team Hard Limits](adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md)
-- [OTLP Observability and Request Log Payloads](adr/2026-03-15-otlp-observability-and-request-log-payloads.md)
-
-## Internal Background
-
-The docs in [internal/](internal/) remain useful background for maintainers:
-
-- front-end stack evaluation
-- provider API research
-- inception architecture and MVP framing
-
-Treat them as background context, not as the canonical operator contract.

--- a/docs/admin-api-contract-workflow.md
+++ b/docs/admin-api-contract-workflow.md
@@ -1,0 +1,121 @@
+# Admin API Contract Workflow
+
+`Owns`: the generated admin API contract pipeline, checked-in artifacts, same-origin client boundary, drift rules, and the maintainer update flow when admin APIs change.
+`Depends on`: [admin-control-plane.md](admin-control-plane.md), [e2e-contract-tests.md](e2e-contract-tests.md)
+`See also`: [../README.md](../README.md), [../mise.toml](../mise.toml), [../crates/gateway/openapi/admin-api.json](../crates/gateway/openapi/admin-api.json), [../crates/admin-ui/web/src/generated/admin-api.ts](../crates/admin-ui/web/src/generated/admin-api.ts), [adr/2026-03-28-generated-admin-api-contract-and-typed-same-origin-client.md](adr/2026-03-28-generated-admin-api-contract-and-typed-same-origin-client.md), [adr/2026-03-29-live-admin-api-key-management-and-contract-coverage.md](adr/2026-03-29-live-admin-api-key-management-and-contract-coverage.md)
+
+This page is maintainer-facing. It explains how the live admin contract is generated and why the checked-in artifacts are part of the review surface.
+
+## Source of Truth
+
+- contract DTOs and OpenAPI document: [../crates/gateway/src/http/admin_contract.rs](../crates/gateway/src/http/admin_contract.rs)
+- route annotations: [../crates/gateway/src/http/identity.rs](../crates/gateway/src/http/identity.rs), [../crates/gateway/src/http/spend.rs](../crates/gateway/src/http/spend.rs), [../crates/gateway/src/http/observability.rs](../crates/gateway/src/http/observability.rs), [../crates/gateway/src/http/api_keys.rs](../crates/gateway/src/http/api_keys.rs)
+- OpenAPI export binary: [../crates/gateway/src/bin/export_admin_openapi.rs](../crates/gateway/src/bin/export_admin_openapi.rs)
+- generated artifact: [../crates/gateway/openapi/admin-api.json](../crates/gateway/openapi/admin-api.json)
+- generated TypeScript types: [../crates/admin-ui/web/src/generated/admin-api.ts](../crates/admin-ui/web/src/generated/admin-api.ts)
+- same-origin client: [../crates/admin-ui/web/src/server/gateway-client.server.ts](../crates/admin-ui/web/src/server/gateway-client.server.ts)
+
+## Contract Boundary
+
+The live admin contract belongs to the gateway HTTP layer.
+
+- Rust handler annotations and transport DTOs define the contract
+- the generated OpenAPI file is the reviewable snapshot
+- the admin UI consumes generated types directly for live surfaces
+
+The contract does not live in `gateway-core`. `gateway-core` owns domain types and repository traits, not the HTTP wire contract.
+
+## Same-Origin Client Boundary
+
+The admin UI is same-origin by design.
+
+- the gateway serves `/admin`
+- server-side admin loaders call back into the gateway
+- cookies and forwarded origin state pass through the same-origin client layer
+
+That is why a backend contract change can break the admin UI even when a page component did not change.
+
+## Generated Artifacts
+
+The checked-in artifacts are:
+
+- OpenAPI document:
+  - `crates/gateway/openapi/admin-api.json`
+- generated TypeScript types:
+  - `crates/admin-ui/web/src/generated/admin-api.ts`
+
+These are not throwaway build files. They are part of the live contract review surface.
+
+## Update Flow
+
+When a live admin API changes:
+
+1. update the gateway handler DTOs or route annotations
+2. regenerate the artifacts
+3. update the admin UI code if the wire contract changed
+4. run contract drift checks
+5. update operator docs if the user-visible behavior changed
+
+Commands:
+
+```bash
+mise run admin-contract-generate
+mise run admin-contract-check
+```
+
+## Drift Rules
+
+Drift is treated as a failure, not a suggestion.
+
+- checked-in OpenAPI must match the gateway HTTP source
+- checked-in TypeScript must match the OpenAPI artifact
+- CI and local lint both enforce this
+
+The normal drift guard is `mise run admin-contract-check`.
+
+## Live Versus Preview-Backed Surfaces
+
+Only live gateway-backed surfaces should use this contract pipeline.
+
+Current live surfaces:
+
+- auth and session flows
+- API keys
+- identity
+- spend
+- request logs
+
+Current preview-backed surface:
+
+- Models
+
+That split matters when deciding whether a UI page belongs in this workflow or in preview-only code.
+
+## API-Key Architecture Note
+
+Recent API-key work tightened the control-plane boundary.
+
+- runtime auth stays in `ApiKeyRepository`
+- admin lifecycle moved into `AdminApiKeyRepository`
+- lifecycle policy moved into [../crates/gateway-service/src/admin_api_keys.rs](../crates/gateway-service/src/admin_api_keys.rs)
+
+That split keeps a security-sensitive control-plane feature from living as optional runtime-auth behavior.
+
+## What To Update When Behavior Changes
+
+Use this rough rule:
+
+- route shape, query params, or response envelopes changed:
+  - update this page
+- admin UI capability changed:
+  - update [admin-control-plane.md](admin-control-plane.md)
+- test coverage rules changed:
+  - update [e2e-contract-tests.md](e2e-contract-tests.md)
+- architectural reasoning changed:
+  - update the related ADR and link back here
+
+## What This Page Does Not Own
+
+- operator-facing UI capability map: [admin-control-plane.md](admin-control-plane.md)
+- browser and HTTP contract test scope: [e2e-contract-tests.md](e2e-contract-tests.md)
+- local quick-start commands: [../README.md](../README.md)

--- a/docs/admin-control-plane.md
+++ b/docs/admin-control-plane.md
@@ -1,10 +1,10 @@
 # Admin Control Plane
 
-`Owns`: the current admin UI capability map, live versus preview-backed surfaces, and operator expectations for the control plane.
+`Owns`: the current admin UI capability map, the live-versus-preview surface split, and operator expectations for the control plane.
 `Depends on`: [identity-and-access.md](identity-and-access.md), [budgets-and-spending.md](budgets-and-spending.md), [observability-and-request-logs.md](observability-and-request-logs.md)
-`See also`: [e2e-contract-tests.md](e2e-contract-tests.md), [../crates/gateway/src/http/admin_contract.rs](../crates/gateway/src/http/admin_contract.rs), [../crates/gateway/src/http/api_keys.rs](../crates/gateway/src/http/api_keys.rs), [../crates/gateway-service/src/admin_api_keys.rs](../crates/gateway-service/src/admin_api_keys.rs), [../crates/gateway-core/src/traits.rs](../crates/gateway-core/src/traits.rs), [../crates/admin-ui/web/src/routes/api-keys.tsx](../crates/admin-ui/web/src/routes/api-keys.tsx), [../crates/admin-ui/web/src/routes/api-keys/-use-api-keys-page.ts](../crates/admin-ui/web/src/routes/api-keys/-use-api-keys-page.ts), [../crates/gateway/openapi/admin-api.json](../crates/gateway/openapi/admin-api.json), [../crates/admin-ui/web/src/generated/admin-api.ts](../crates/admin-ui/web/src/generated/admin-api.ts)
+`See also`: [admin-api-contract-workflow.md](admin-api-contract-workflow.md), [e2e-contract-tests.md](e2e-contract-tests.md), [oidc-and-sso-status.md](oidc-and-sso-status.md)
 
-This document describes what operators can actually do in the admin UI today.
+This page describes what operators can actually do in the admin UI today.
 
 ## Same-Origin Control Plane
 
@@ -12,16 +12,10 @@ The control plane is served through the gateway at `/admin`.
 
 Normal runtime model:
 
-- gateway handles auth, admin APIs, and reverse proxying
-- the Bun SSR app calls back into the gateway using a typed same-origin client with forwarded-origin resolution
+- the gateway handles auth, admin APIs, and reverse proxying
+- the SSR app calls back into the gateway through the same-origin client boundary
 
-Live admin and auth surfaces now use a generated contract pipeline:
-
-- Rust transport DTOs and handler annotations live in [../crates/gateway/src/http/admin_contract.rs](../crates/gateway/src/http/admin_contract.rs)
-- the checked-in OpenAPI artifact lives at [../crates/gateway/openapi/admin-api.json](../crates/gateway/openapi/admin-api.json)
-- the admin UI consumes generated types from [../crates/admin-ui/web/src/generated/admin-api.ts](../crates/admin-ui/web/src/generated/admin-api.ts)
-
-For local direct UI dev on `:3001`, the server-side gateway client falls back to `:8080` unless `ADMIN_GATEWAY_ORIGIN` is explicitly set.
+For the generated contract and artifact workflow, use [admin-api-contract-workflow.md](admin-api-contract-workflow.md).
 
 ## Live Gateway-Backed Surfaces
 
@@ -30,61 +24,52 @@ These areas are backed by real gateway APIs today:
 - sign-in, session lookup, and password rotation
 - API key inventory, creation, and revocation
 - identity users and lifecycle management
-- identity teams and member transfer/removal workflows
-- password invites and onboarding links
+- identity teams and member transfer or removal workflows
+- password invite and onboarding links
 - OIDC pre-provisioning flows
 - spend usage reporting
 - spend budget management for users and teams
 - request-log list and detail inspection
 
-Those live surfaces are expected to track the generated gateway contract directly. We do not keep a separate hand-maintained frontend transport model for them.
-
 ## Preview-Backed Surfaces
 
-These pages are still powered by local preview data in the admin UI:
+These pages still use local preview data in the admin UI:
 
 - Models
 
-That is not just an implementation detail. It affects both operator expectations and test scope.
-
-Tracked follow-ups:
-
-- [issue #27](https://github.com/ahstn/oceans-llm/issues/27): replace preview model inventory with live routing and provider state
+That split matters for operator expectations and test scope.
 
 ## Operator-Visible Maturity Cues
 
-The admin UI currently teaches this maturity split in live copy and tests:
+The current product contract is mixed on purpose:
 
-- identity and spend surfaces are live gateway-backed contracts
-- models remain intentionally preview-backed in this slice
+- identity, spend, API keys, and request logs are live gateway-backed surfaces
+- Models is still preview-backed in this slice
 
-That message is part of the operator contract and should be treated as owned by this page rather than only by UI fixture code or E2E assertions.
+Tracked follow-up:
 
-## API Key Workflows Available Today
+- [issue #27](https://github.com/ahstn/oceans-llm/issues/27)
 
-Operators can currently:
+## API-Key Workflows Available Today
 
-- list API keys with owner summary, grant list, issuance timestamps, and revoke state
+Operators can:
+
+- list API keys with owner summary and grant list
 - create a new key for an explicit user or team owner
 - grant access to an explicit set of gateway models at creation time
-- copy the raw key exactly once from the create response
-- revoke a key so the runtime rejects it immediately
+- copy the raw key once from the create response
+- revoke a key so runtime auth rejects it immediately
 
-Current scope limits:
+Current limits:
 
-- keys cannot be renamed after creation
-- granted models are fixed at create time in this slice
-- revoked keys are not restorable
-- model selection is limited to the current live gateway model catalog
+- no rename flow
+- no in-place grant edit flow
+- no restore-from-revoked flow
+- model choice is limited to the live gateway model catalog
 
-Implementation boundary:
-
-- the HTTP layer at [../crates/gateway/src/http/api_keys.rs](../crates/gateway/src/http/api_keys.rs) owns session auth, request parsing, and response envelopes
-- the lifecycle policy lives in [../crates/gateway-service/src/admin_api_keys.rs](../crates/gateway-service/src/admin_api_keys.rs)
-- admin persistence is split between runtime auth in `ApiKeyRepository` and control-plane lifecycle in `AdminApiKeyRepository` inside [../crates/gateway-core/src/traits.rs](../crates/gateway-core/src/traits.rs)
 ## Identity Workflows Available Today
 
-Operators can currently:
+Operators can:
 
 - sign in as the bootstrap or existing platform admin
 - rotate the bootstrap password when required
@@ -98,56 +83,58 @@ Operators can currently:
 - remove team members
 - transfer team members between teams with an explicit destination role
 
-Current scope limits:
+Current limits:
 
-- no admin logout/session-management flow yet
-- owner memberships are visible but blocked from removal/transfer in this slice
+- no admin logout flow yet
+- owner memberships stay blocked from removal or transfer in this slice
 - auth-mode switching is limited to invited users
-- OIDC remains development-style, not hardened
+- OIDC is still development-style
 
-## Auth And Session UX Limits
+## Admin Auth and Session Behavior
 
-Current session state is mostly implicit:
+Current session behavior is mostly implicit:
 
 - browser cookie state carries the admin session
-- `/api/v1/auth/session` is the main machine-readable session lookup
-- there is not yet a dedicated logout/session-management shell in the control plane
+- `/api/v1/auth/session` is the machine-readable session lookup
+- expired or missing session state sends the operator back through the auth flow
+- bootstrap admin and regular admin accounts share the same session mechanics after sign-in
 
-Related follow-ups:
+What is still missing:
 
-- [issue #34](https://github.com/ahstn/oceans-llm/issues/34)
-- [issue #33](https://github.com/ahstn/oceans-llm/issues/33)
-- [issue #46](https://github.com/ahstn/oceans-llm/issues/46)
+- a dedicated logout shell
+- broader session-management UI
 
 ## Spend and Observability Workflows Available Today
 
-Operators can currently:
+Operators can:
 
-- inspect 7- and 30-day spend windows
+- inspect 7-day and 30-day spend windows
 - filter spend by owner kind
 - manage user and team budgets
 - inspect request-log summaries
 - filter request logs by caller service, component, environment, and one bespoke tag match
 - inspect sanitized request-log payload detail
 
-Current scope limits:
+Current limits:
 
-- spend reporting does not yet include provider breakdown
-- request-log detail missing rows now return `404 not_found`
-- request-log filtering and ergonomics still have follow-up work
+- spend reporting still lacks provider breakdown
+- request-log detail missing rows return `404 not_found`
+- request-log filtering ergonomics still have follow-up work
 
-Related follow-ups:
+## Current Gaps
 
-- [issue #45](https://github.com/ahstn/oceans-llm/issues/45)
-- [issue #20](https://github.com/ahstn/oceans-llm/issues/20)
-- [issue #50](https://github.com/ahstn/oceans-llm/issues/50)
+- no logout or richer session management yet:
+  - [issue #34](https://github.com/ahstn/oceans-llm/issues/34)
+- OIDC still development-style:
+  - [oidc-and-sso-status.md](oidc-and-sso-status.md)
+- Models page still preview-backed:
+  - [issue #27](https://github.com/ahstn/oceans-llm/issues/27)
 
 ## Relationship to Testing
 
 The E2E harness treats only live gateway-backed surfaces as contract flows.
 
 - live surfaces should gain targeted cross-layer coverage as they harden
-- preview-backed pages can appear in landing assertions, but not as business-flow coverage
-- user lifecycle and team member workflows now belong in the live contract suite
+- preview-backed pages can appear in smoke coverage, not business-flow coverage
 
-See [e2e-contract-tests.md](e2e-contract-tests.md).
+Use [e2e-contract-tests.md](e2e-contract-tests.md) for the test boundary.

--- a/docs/adr/2026-03-05-identity-foundation.md
+++ b/docs/adr/2026-03-05-identity-foundation.md
@@ -10,6 +10,12 @@
   - [../data-relationships.md](../data-relationships.md)
   - [../admin-control-plane.md](../admin-control-plane.md)
 
+## Current state
+
+- [../identity-and-access.md](../identity-and-access.md)
+- [../runtime-bootstrap-and-access.md](../runtime-bootstrap-and-access.md)
+- [../data-relationships.md](../data-relationships.md)
+
 ## Context
 
 The original gateway foundation treated API keys as the primary identity boundary. That was enough for seeded model access, but it did not give us a durable way to represent:

--- a/docs/adr/2026-03-05-vertex-first-provider-foundation.md
+++ b/docs/adr/2026-03-05-vertex-first-provider-foundation.md
@@ -3,6 +3,12 @@
 - Date: 2026-03-05
 - Status: Accepted
 
+## Current state
+
+- [../configuration-reference.md](../configuration-reference.md)
+- [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
+- [../pricing-catalog-and-accounting.md](../pricing-catalog-and-accounting.md)
+
 ## Context
 
 The gateway exposed an OpenAI-compatible API surface (`/v1/chat/completions`, `/v1/embeddings`) but chat execution was not implemented end-to-end. We needed a production-ready first provider slice that:

--- a/docs/adr/2026-03-06-hybrid-pricing-catalog.md
+++ b/docs/adr/2026-03-06-hybrid-pricing-catalog.md
@@ -3,6 +3,12 @@
 - Date: 2026-03-06
 - Status: Accepted
 
+## Current state
+
+- [../pricing-catalog-and-accounting.md](../pricing-catalog-and-accounting.md)
+- [../budgets-and-spending.md](../budgets-and-spending.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+
 ## Context
 
 Implemented by:

--- a/docs/adr/2026-03-06-release-versioning-and-ghcr-publishing.md
+++ b/docs/adr/2026-03-06-release-versioning-and-ghcr-publishing.md
@@ -3,6 +3,11 @@
 - Date: 2026-03-06
 - Status: Accepted
 
+## Current state
+
+- [../release-process.md](../release-process.md)
+- [../deploy-and-operations.md](../deploy-and-operations.md)
+
 ## Context
 
 Implemented by:

--- a/docs/adr/2026-03-08-admin-team-management-flow.md
+++ b/docs/adr/2026-03-08-admin-team-management-flow.md
@@ -9,6 +9,11 @@
   - [../identity-and-access.md](../identity-and-access.md)
   - [../admin-control-plane.md](../admin-control-plane.md)
 
+## Current state
+
+- [../identity-and-access.md](../identity-and-access.md)
+- [../admin-control-plane.md](../admin-control-plane.md)
+
 ## Context
 
 The admin UI already had an identity foundation for users, invitations, team membership storage, and one-team-per-user enforcement, but the `Teams` page was still mock data. Admins could not:

--- a/docs/adr/2026-03-09-runtime-database-policy.md
+++ b/docs/adr/2026-03-09-runtime-database-policy.md
@@ -3,6 +3,11 @@
 - Date: 2026-03-09
 - Status: Accepted
 
+## Current state
+
+- [../deploy-and-operations.md](../deploy-and-operations.md)
+- [../runtime-bootstrap-and-access.md](../runtime-bootstrap-and-access.md)
+
 ## Context
 
 The gateway started with a local libsql/SQLite runtime, which was a good fit for single-node development and early product slices. That runtime was no longer a good default for production-shaped and pre-production environments because:

--- a/docs/adr/2026-03-10-model-aliases-and-provider-route-config.md
+++ b/docs/adr/2026-03-10-model-aliases-and-provider-route-config.md
@@ -9,6 +9,12 @@
   - [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
   - [../data-relationships.md](../data-relationships.md)
 
+## Current state
+
+- [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
+- [../configuration-reference.md](../configuration-reference.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+
 ## Context
 
 The gateway already separates two concepts:

--- a/docs/adr/2026-03-12-durable-usage-ledger-accounting.md
+++ b/docs/adr/2026-03-12-durable-usage-ledger-accounting.md
@@ -3,6 +3,12 @@
 - Date: 2026-03-12
 - Status: Accepted
 
+## Current state
+
+- [../pricing-catalog-and-accounting.md](../pricing-catalog-and-accounting.md)
+- [../budgets-and-spending.md](../budgets-and-spending.md)
+- [../data-relationships.md](../data-relationships.md)
+
 ## Context
 
 The gateway already had identity-aware ownership, request logging, user budgets, and a hybrid pricing catalog, but spend accounting was still incomplete in ways that would have made enforcement unsafe:

--- a/docs/adr/2026-03-13-capability-aware-route-gating.md
+++ b/docs/adr/2026-03-13-capability-aware-route-gating.md
@@ -8,6 +8,11 @@
 - Canonical docs:
   - [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
 
+## Current state
+
+- [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+
 ## Context
 
 Issue #35 requires richer capability modeling and deterministic request validation before provider execution. The previous model exposed only coarse booleans and allowed incompatible requests to fall through to provider-specific runtime errors.

--- a/docs/adr/2026-03-13-protocol-neutral-core-request-boundary.md
+++ b/docs/adr/2026-03-13-protocol-neutral-core-request-boundary.md
@@ -3,6 +3,11 @@
 - Date: 2026-03-13
 - Status: Accepted
 
+## Current state
+
+- [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+
 ## Context
 
 Issue #23 requires the gateway to stop coupling execution directly to OpenAI wire DTOs. The prior shape made provider adapters and handler flow implicitly OpenAI-centric, which increases long-term risk as model APIs evolve toward Responses-style and multimodal-first interfaces.

--- a/docs/adr/2026-03-15-openai-compat-streaming-and-embeddings-runtime-parity.md
+++ b/docs/adr/2026-03-15-openai-compat-streaming-and-embeddings-runtime-parity.md
@@ -3,6 +3,12 @@
 - Date: 2026-03-15
 - Status: Accepted
 
+## Current state
+
+- [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+- [../observability-and-request-logs.md](../observability-and-request-logs.md)
+
 ## Context
 
 Two high-priority runtime gaps remained open:

--- a/docs/adr/2026-03-15-otlp-observability-and-request-log-payloads.md
+++ b/docs/adr/2026-03-15-otlp-observability-and-request-log-payloads.md
@@ -9,6 +9,11 @@
   - [../observability-and-request-logs.md](../observability-and-request-logs.md)
   - [../admin-control-plane.md](../admin-control-plane.md)
 
+## Current state
+
+- [../observability-and-request-logs.md](../observability-and-request-logs.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+
 ## Context
 
 The gateway already had:

--- a/docs/adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md
+++ b/docs/adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md
@@ -9,6 +9,11 @@
   - [../budgets-and-spending.md](../budgets-and-spending.md)
   - [../admin-control-plane.md](../admin-control-plane.md)
 
+## Current state
+
+- [../budgets-and-spending.md](../budgets-and-spending.md)
+- [../admin-control-plane.md](../admin-control-plane.md)
+
 ## Context
 
 Issues #4 and #7 established a durable, idempotent usage ledger and exact fixed-point pricing/accounting behavior. That work made `usage_cost_events` trustworthy as a charging source, but the control plane still lacked spend-facing capabilities needed by operations:

--- a/docs/adr/2026-03-15-v1-runtime-simplification.md
+++ b/docs/adr/2026-03-15-v1-runtime-simplification.md
@@ -9,6 +9,11 @@
   - [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
   - [../observability-and-request-logs.md](../observability-and-request-logs.md)
 
+## Current state
+
+- [../model-routing-and-api-behavior.md](../model-routing-and-api-behavior.md)
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+
 ## Context
 
 After closing the initial runtime gaps for embeddings and OpenAI-compatible streaming, the request path still contained compatibility-era complexity:

--- a/docs/adr/2026-03-17-migration-atomicity-and-local-postgres-ops-hardening.md
+++ b/docs/adr/2026-03-17-migration-atomicity-and-local-postgres-ops-hardening.md
@@ -3,6 +3,12 @@
 - Date: 2026-03-17
 - Status: Accepted
 
+## Current state
+
+- [../deploy-and-operations.md](../deploy-and-operations.md)
+- [../runtime-bootstrap-and-access.md](../runtime-bootstrap-and-access.md)
+- [../operator-runbooks.md](../operator-runbooks.md)
+
 ## Context
 
 Two operational concerns were open at the same time:

--- a/docs/adr/2026-03-17-post-success-accounting-and-strict-request-log-lookups.md
+++ b/docs/adr/2026-03-17-post-success-accounting-and-strict-request-log-lookups.md
@@ -3,6 +3,12 @@
 - Date: 2026-03-17
 - Status: Accepted
 
+## Current state
+
+- [../request-lifecycle-and-failure-modes.md](../request-lifecycle-and-failure-modes.md)
+- [../observability-and-request-logs.md](../observability-and-request-logs.md)
+- [../budgets-and-spending.md](../budgets-and-spending.md)
+
 ## Context
 
 Two follow-up issues exposed gaps in the contracts established by earlier work:

--- a/docs/adr/2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md
+++ b/docs/adr/2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md
@@ -9,6 +9,11 @@
   - [2026-03-05-identity-foundation.md](./2026-03-05-identity-foundation.md)
   - [2026-03-08-admin-team-management-flow.md](./2026-03-08-admin-team-management-flow.md)
 
+## Current state
+
+- [../identity-and-access.md](../identity-and-access.md)
+- [../admin-control-plane.md](../admin-control-plane.md)
+
 ## Context
 
 The earlier identity and team-management slices established the basic control-plane shape:

--- a/docs/adr/2026-03-26-request-log-caller-tags.md
+++ b/docs/adr/2026-03-26-request-log-caller-tags.md
@@ -7,6 +7,10 @@
   - [#20: Improve admin request-log filtering and detail UX](https://github.com/ahstn/oceans-llm/issues/20)
   - [#54: Harden chat observability metrics and streamed request-log parsing](https://github.com/ahstn/oceans-llm/issues/54)
 
+## Current state
+
+- [../observability-and-request-logs.md](../observability-and-request-logs.md)
+
 ## Context
 
 Before this change, request logs already had a useful split:
@@ -75,8 +79,8 @@ We store bespoke tags in `request_log_tags`, keyed by `(request_log_id, tag_key)
 
 The schema change is implemented in:
 
-- [`V14__request_log_tags.sql` for PostgreSQL](../../crates/gateway-store/migrations/postgres/V14__request_log_tags.sql)
-- [`V14__request_log_tags.sql` for libSQL](../../crates/gateway-store/migrations/V14__request_log_tags.sql)
+- [`V15__request_log_tags.sql` for PostgreSQL](../../crates/gateway-store/migrations/postgres/V15__request_log_tags.sql)
+- [`V15__request_log_tags.sql` for libSQL](../../crates/gateway-store/migrations/V15__request_log_tags.sql)
 
 Repository implementations were updated in:
 

--- a/docs/adr/2026-03-28-generated-admin-api-contract-and-typed-same-origin-client.md
+++ b/docs/adr/2026-03-28-generated-admin-api-contract-and-typed-same-origin-client.md
@@ -11,6 +11,12 @@
   - [2026-03-17-post-success-accounting-and-strict-request-log-lookups.md](./2026-03-17-post-success-accounting-and-strict-request-log-lookups.md)
   - [2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md](./2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md)
 
+## Current state
+
+- [../admin-api-contract-workflow.md](../admin-api-contract-workflow.md)
+- [../admin-control-plane.md](../admin-control-plane.md)
+- [../e2e-contract-tests.md](../e2e-contract-tests.md)
+
 ## Context
 
 The admin control plane had reached the point where the gateway owned the real behavior, but the contract between the gateway and the admin UI was still partly hand-maintained. That created a familiar failure mode:

--- a/docs/adr/2026-03-29-live-admin-api-key-management-and-contract-coverage.md
+++ b/docs/adr/2026-03-29-live-admin-api-key-management-and-contract-coverage.md
@@ -10,6 +10,11 @@
   - [2026-03-15-v1-runtime-simplification.md](./2026-03-15-v1-runtime-simplification.md)
   - [2026-03-17-post-success-accounting-and-strict-request-log-lookups.md](./2026-03-17-post-success-accounting-and-strict-request-log-lookups.md)
 
+## Current state
+
+- [../admin-control-plane.md](../admin-control-plane.md)
+- [../admin-api-contract-workflow.md](../admin-api-contract-workflow.md)
+
 ## Context
 
 Before this change, the control plane had an architectural split that was useful for early UI work but no longer acceptable for the product shape we are trying to keep stable:

--- a/docs/budgets-and-spending.md
+++ b/docs/budgets-and-spending.md
@@ -1,24 +1,28 @@
 # Budgets and Spending
 
-`Owns`: spend ledger semantics, budget enforcement rules, spend APIs, and current spend-policy deferrals.
-`Depends on`: [data-relationships.md](data-relationships.md), [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md)
-`See also`: [identity-and-access.md](identity-and-access.md), [admin-control-plane.md](admin-control-plane.md), [adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md](adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md)
+`Owns`: spend ledger semantics, budget enforcement rules, budget alerts, spend APIs, and current spend-policy deferrals.
+`Depends on`: [data-relationships.md](data-relationships.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md)
+`See also`: [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md), [identity-and-access.md](identity-and-access.md), [admin-control-plane.md](admin-control-plane.md), [adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md](adr/2026-03-15-spend-control-plane-reporting-and-team-hard-limits.md)
 
-This document describes the live spend contract in the gateway.
+This page describes the live spend contract in the gateway.
 
 ## Source of Truth
 
-- Spend ledger: `usage_cost_events`
-- Request-path enforcement: [../crates/gateway-service/src/budget_guard.rs](../crates/gateway-service/src/budget_guard.rs)
-- Ledger writes: [../crates/gateway-service/src/service.rs](../crates/gateway-service/src/service.rs)
-- Admin spend APIs: [../crates/gateway/src/http/spend.rs](../crates/gateway/src/http/spend.rs)
+- spend ledger:
+  - `usage_cost_events`
+- request-path enforcement:
+  - [../crates/gateway-service/src/budget_guard.rs](../crates/gateway-service/src/budget_guard.rs)
+- ledger writes:
+  - [../crates/gateway-service/src/service.rs](../crates/gateway-service/src/service.rs)
+- admin spend APIs:
+  - [../crates/gateway/src/http/spend.rs](../crates/gateway/src/http/spend.rs)
 
-## Pricing and Accounting Source of Truth
+## Ledger Contract
 
 - `usage_cost_events` is the canonical usage and spend ledger
-- Request accounting is idempotent on `(request_id, ownership_scope_key)`
-- Pricing is resolved from the internal hybrid catalog and persisted into the ledger row
-- Spend math uses fixed-point money (`usd * 10_000`) and integer arithmetic
+- request accounting is idempotent on `(request_id, ownership_scope_key)`
+- pricing is resolved from the internal pricing catalog and persisted into the ledger row
+- spend math uses fixed-point money and integer arithmetic
 
 Pricing states are explicit:
 
@@ -29,16 +33,14 @@ Pricing states are explicit:
 
 Only `priced` and `legacy_estimated` rows count toward spend totals and budget windows.
 
-For why successful requests can still become `unpriced` or `usage_missing`, see [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md).
-
 ## Runtime Enforcement
 
-Pre-provider hard-limit checks run on the live request path for both current write paths:
+Pre-provider hard-limit checks run on the live request path for:
 
 - `POST /v1/chat/completions`
 - `POST /v1/embeddings`
 
-The gateway enforces budgets by owner scope:
+Budgets are enforced by owner scope:
 
 - user-owned API keys use the active user budget
 - team-owned API keys use the active team budget
@@ -48,90 +50,85 @@ Hard-limit behavior:
 - if projected spend in the active window would exceed the configured amount and `hard_limit = true`, the request fails with `budget_exceeded`
 - the HTTP status is `429`
 
-Idempotent replay behavior:
+## Two-Phase Enforcement
 
-- duplicate `(request_id, ownership_scope_key)` is a no-op for charging and enforcement
+Budget enforcement has two phases:
 
-## Two-Phase Enforcement Contract
-
-Budget enforcement has two important phases:
-
-1. pre-provider blocking against the current priced spend in the active window
+1. pre-provider blocking against current priced spend
 2. post-provider projected-cost blocking before the priced ledger row is inserted
 
-This matters because duplicate `(request_id, ownership_scope_key)` requests bypass both phases as a no-op and because post-provider ledger-write behavior is where the current stream/non-stream inconsistency still exists.
+This matters because duplicate requests bypass both phases as a no-op, and because the current stream versus non-stream difference still lives in the later ledger-write stage.
 
 Ownership scope keys:
 
-- user: `user:<user_id>`
-- team: `team:<team_id>:actor:none`
+- user:
+  - `user:<user_id>`
+- team:
+  - `team:<team_id>:actor:none`
 
-`actor:none` is the current team attribution contract. Acting-user attribution remains deferred.
+`actor:none` is the current team attribution contract. Acting-user attribution is still deferred.
 
 ## Ledger Write Semantics
 
-- Successful request handling writes a ledger row when provider usage can be normalized
-- If usage is missing, the ledger row is marked `usage_missing`
-- If pricing cannot be matched exactly, the ledger row is marked `unpriced`
-- `unpriced` and `usage_missing` rows remain visible in reporting but do not count toward spend totals
+- successful request handling writes a ledger row when provider usage can be normalized
+- if usage is missing, the row is marked `usage_missing`
+- if pricing cannot be matched exactly, the row is marked `unpriced`
+- `unpriced` and `usage_missing` rows stay visible in reporting but do not count toward spend totals
 
-Common `unpriced` causes include:
-
-- missing or unsupported pricing-provider mapping
-- unsupported Vertex publisher or location
-- unsupported billing modifiers such as `service_tier` / `serviceTier`
-- missing exact pricing-rate coverage
-
-One important known rough edge remains:
-
-- stream and non-stream chat requests do not yet share identical post-provider ledger failure semantics
-
-That follow-up is tracked in [issue #49](https://github.com/ahstn/oceans-llm/issues/49).
+Use [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md) for the cross-cutting path from request execution to ledger state.
 
 ## Budget Configuration Model
 
 - `user_budgets` stores active and inactive user budgets
 - `team_budgets` stores active and inactive team budgets
-- each table enforces one active budget per owner through a partial unique index
+- each table enforces one active budget per owner
 
 Budget fields:
-- `cadence`: `daily`, `weekly`, or `monthly`
+
+- `cadence`
+  - `daily`, `weekly`, or `monthly`
 - `amount_10000`
 - `hard_limit`
 - `timezone`
 
-`timezone` is stored now, but current enforcement windows remain UTC-anchored.
+`timezone` is stored now, but enforcement windows still use UTC.
 
 ## Budget Threshold Alerts
 
-- Budget alerts are persisted as audit rows in `budget_alerts`
-- Per-recipient delivery attempts are persisted in `budget_alert_deliveries`
-- The initial threshold is fixed at `20%` remaining budget
-- Alert creation happens:
-  - after a new chargeable usage ledger row is written
-  - after a budget upsert, if current spend is already at or below the threshold
-- Delivery is durable-first:
-  - request handling writes the alert row and queued delivery rows
-  - a background dispatcher sends email later
-- Email delivery is owner-only:
-  - user budgets notify the user email
-  - team budgets notify active team owners/admins with emails
-- Delivery failures remain queryable in alert history
+Budget alerts have deeper behavior than a plain email side effect.
+
+- alerts are stored durably in `budget_alerts`
+- per-recipient delivery attempts are stored in `budget_alert_deliveries`
+- the initial threshold is fixed at `20%` remaining budget
+- monthly cadence is supported end to end
+
+Alert creation happens:
+
+- after a new chargeable ledger row is written
+- after a budget upsert, if the current spend is already at or below the threshold
+
+Delivery behavior:
+
+- alert creation is durable-first
+- request handling writes alert rows and queued delivery rows first
+- a background dispatcher sends email later
+- delivery is single-attempt oriented in this slice
+- email is the only live channel today, but the schema is channel-aware
+
+Recipient readiness:
+
+- user budgets notify the user email
+- team budgets notify active team owners or admins with emails
+
+That means email readiness is part of the practical identity setup for alerting.
 
 ## Spend Reporting APIs
 
 Live admin spend APIs:
 
 - `GET /api/v1/admin/spend/report`
-  - daily windowed series
-  - owner breakdown (`user` and `team`)
-  - model breakdown
-  - totals for priced cost and request counts by pricing state
 - `GET /api/v1/admin/spend/budgets`
-  - current user and team budget state
-  - current-window spend
 - `GET /api/v1/admin/spend/budget-alerts`
-  - newest-first budget alert audit history with owner/channel/status filters
 - `PUT /api/v1/admin/spend/budgets/users/{user_id}`
 - `DELETE /api/v1/admin/spend/budgets/users/{user_id}`
 - `PUT /api/v1/admin/spend/budgets/teams/{team_id}`
@@ -141,19 +138,27 @@ These routes require an authenticated platform-admin session.
 
 ## Window Semantics
 
-- Budget and reporting windows are UTC-based
-- Daily windows start at `00:00:00 UTC`
-- Weekly windows start at `Monday 00:00:00 UTC`
-- Monthly windows start at `00:00:00 UTC` on the first day of the calendar month
-- `Sunday 23:59:59 UTC` is included in the previous weekly window
+- daily windows start at `00:00:00 UTC`
+- weekly windows start at `Monday 00:00:00 UTC`
+- monthly windows start at `00:00:00 UTC` on the first day of the month
+- `Sunday 23:59:59 UTC` is still part of the previous weekly window
 
-## Scope and Deferrals
+## Current Gaps
 
-Current explicit deferrals:
-
-- provider breakdown is not included in spend reporting v1
+- provider breakdown is not part of spend reporting v1
 - acting-user attribution for team-owned keys remains `actor:none`
-- timezone-aware windows are deferred even though timezone is stored
-- request-log payload retention and request-log performance policy are separate from spend accounting
+- timezone-aware budget windows are still deferred
+- declarative config-driven budgets are not supported yet
+  - [issue #64](https://github.com/ahstn/oceans-llm/issues/64)
+  - [issue #65](https://github.com/ahstn/oceans-llm/issues/65)
 
-For the operator surface built on top of these rules, see [admin-control-plane.md](admin-control-plane.md).
+## What This Page Does Not Own
+
+- exact pricing coverage and `unpriced` causes:
+  - [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md)
+- end-to-end request path:
+  - [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md)
+- operator-facing admin UI behavior:
+  - [admin-control-plane.md](admin-control-plane.md)
+- identity lifecycle and email readiness:
+  - [identity-and-access.md](identity-and-access.md)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -1,16 +1,18 @@
 # Configuration Reference
 
-`Owns`: gateway config shape, defaults, validation rules, provider-specific config constraints, and env-backed secret references.
+`Owns`: gateway YAML shape, defaults, validation rules, provider auth modes, and env-backed secret references.
 `Depends on`: [../README.md](../README.md)
-`See also`: [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md), [deploy-and-operations.md](deploy-and-operations.md), [adr/2026-03-10-model-aliases-and-provider-route-config.md](adr/2026-03-10-model-aliases-and-provider-route-config.md)
+`See also`: [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md), [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md), [oidc-and-sso-status.md](oidc-and-sso-status.md)
 
-This page is the canonical reference for gateway YAML config. Runtime policy and API behavior live in neighboring docs; this page only owns the config contract itself.
+This page owns config syntax and parse-time rules. It does not own the full runtime story after a request starts moving.
 
 ## Source of Truth
 
-- Config parsing and validation: [../crates/gateway/src/config.rs](../crates/gateway/src/config.rs)
-- Provider capability defaults: [../crates/gateway-core/src/domain.rs](../crates/gateway-core/src/domain.rs)
-- Checked-in examples:
+- config parsing and validation:
+  - [../crates/gateway/src/config.rs](../crates/gateway/src/config.rs)
+- provider capability defaults:
+  - [../crates/gateway-core/src/domain.rs](../crates/gateway-core/src/domain.rs)
+- checked-in examples:
   - [../gateway.yaml](../gateway.yaml)
   - [../gateway.prod.yaml](../gateway.prod.yaml)
   - [../deploy/config/gateway.yaml](../deploy/config/gateway.yaml)
@@ -25,7 +27,7 @@ This page is the canonical reference for gateway YAML config. Runtime policy and
 
 ## Value Sources
 
-Checked-in config supports literal values and env references.
+The config supports literal values and env references.
 
 Common patterns:
 
@@ -33,7 +35,76 @@ Common patterns:
 - `env.OPENAI_API_KEY`
 - `env.POSTGRES_URL`
 
-Operationally, this means the YAML file defines structure while secrets and deploy-specific values should usually come from the environment.
+The YAML holds structure. Secrets and deploy-specific values usually come from the environment.
+
+## Minimal Local Example
+
+```yaml
+server:
+  bind: "127.0.0.1:8080"
+
+database:
+  kind: libsql
+  path: "./var/oceans.db"
+
+auth:
+  bootstrap_admin:
+    email: "admin@local"
+    password: "admin"
+    require_password_change: false
+
+providers:
+  - id: openai
+    type: openai_compat
+    base_url: "https://api.openai.com/v1"
+    pricing_provider_id: openai
+    auth:
+      kind: bearer
+      token: env.OPENAI_API_KEY
+
+models:
+  - id: gpt-4o-mini
+    routes:
+      - provider: openai
+        upstream_model: gpt-4o-mini
+```
+
+## Production-Shaped Example
+
+```yaml
+server:
+  bind: "0.0.0.0:8080"
+
+database:
+  kind: postgres
+  url: env.POSTGRES_URL
+
+auth:
+  bootstrap_admin:
+    email: "admin@local"
+    password: "admin"
+    require_password_change: true
+  seed_api_keys:
+    - name: "gateway"
+      key: env.GATEWAY_API_KEY
+
+providers:
+  - id: vertex
+    type: gcp_vertex
+    project_id: env.GCP_PROJECT_ID
+    location: global
+    auth:
+      mode: service_account
+      service_account_json: env.GCP_SERVICE_ACCOUNT_JSON
+
+models:
+  - id: gemini-2.0-flash
+    routes:
+      - provider: vertex
+        upstream_model: google/gemini-2.0-flash
+```
+
+The checked-in examples are opinionated. They are not the full config space.
 
 ## Defaults That Matter
 
@@ -46,9 +117,8 @@ Important defaults from config parsing and domain deserialization:
 - route capability flags default to all enabled
 - Vertex `location` defaults to `global`
 - Vertex `api_host` defaults to `aiplatform.googleapis.com`
-- bootstrap admin defaults to enabled with `admin@local`
 
-Those defaults materially affect routing and operator expectations, so they should be treated as part of the runtime contract rather than implementation trivia.
+The startup meaning of bootstrap-admin and seeded API keys lives in [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md).
 
 ## `server`
 
@@ -60,16 +130,16 @@ Important fields:
 - `otel_metrics_endpoint`
 - `otel_export_interval_secs`
 
-For observability semantics and current collector assumptions, see [observability-and-request-logs.md](observability-and-request-logs.md).
+For collector assumptions and request-log implications, see [observability-and-request-logs.md](observability-and-request-logs.md).
 
 ## `database`
 
-Checked-in examples use two runtime shapes:
+The checked-in configs use two runtime shapes:
 
-- local development: libsql/SQLite with `path`
-- production-shaped and deploy flows: PostgreSQL with `kind: postgres` and `url`
-
-For topology, migrations, and local-vs-deploy differences, see [deploy-and-operations.md](deploy-and-operations.md).
+- local development:
+  - libsql or SQLite with `path`
+- production-shaped and deploy flows:
+  - PostgreSQL with `kind: postgres` and `url`
 
 ## `auth`
 
@@ -80,18 +150,26 @@ Important fields:
 
 Important distinctions:
 
-- `seed_api_keys` is used in deploy-style or test-style setups to pre-create gateway keys
-- `bootstrap_admin` controls whether the gateway ensures a platform admin exists at startup
-- `bootstrap_admin.require_password_change` changes first-login behavior and is part of the live auth contract
+- `seed_api_keys` creates data-plane access
+- `bootstrap_admin` creates control-plane access
+- `bootstrap_admin.require_password_change` changes first-login behavior
 
-Identity semantics are owned by [identity-and-access.md](identity-and-access.md).
+For startup behavior and first access after boot, use [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md).
 
-## Provider Config
+## Provider Types
 
 Supported provider types in the checked-in configs:
 
 - `openai_compat`
 - `gcp_vertex`
+
+### Provider Auth Modes
+
+| Provider type | Auth field | Expected secret material |
+| --- | --- | --- |
+| `openai_compat` | `auth.token` | bearer-style token |
+| `gcp_vertex` | `auth.mode: adc` | ADC available in the runtime environment |
+| `gcp_vertex` | `auth.mode: service_account` | service-account JSON or equivalent secret source |
 
 ### `openai_compat`
 
@@ -103,12 +181,10 @@ Important fields:
 - `auth.kind`
 - `auth.token`
 
-Validation rules that matter operationally:
+Validation rules that matter:
 
 - `pricing_provider_id` cannot be empty
-- `pricing_provider_id` must be one of the supported internal pricing providers
-
-That pricing mapping is part of accounting integrity, not just config hygiene. See [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md).
+- `pricing_provider_id` must map to a supported internal pricing family
 
 ### `gcp_vertex`
 
@@ -120,16 +196,11 @@ Important fields:
 - `api_host`
 - `auth.mode`
 
-Current checked-in auth examples:
+Routing and pricing caveats:
 
-- `adc`
-- `service_account`
-
-Routing and accounting caveats:
-
-- `upstream_model` must use the `<publisher>/<model_id>` form
+- `upstream_model` must use `<publisher>/<model_id>`
 - pricing identity is inferred from the publisher prefix
-- Anthropic-on-Vertex is only priced for `location=global`
+- Anthropic-on-Vertex pricing is only supported for `location=global`
 
 ## Model Config
 
@@ -149,8 +220,6 @@ Important fields:
 - `routes`
 - `alias_of`
 
-Alias resolution and request-time behavior are owned by [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md).
-
 ## Route Config
 
 Important fields:
@@ -164,23 +233,38 @@ Important fields:
 - `extra_headers`
 - `extra_body`
 
-Capability flags default permissively, but runtime execution still intersects route config with provider adapter truth. A route can constrain provider capability, not expand it.
+Capability flags default permissively. A route can constrain provider capability. It cannot expand provider truth.
 
-## Validation And Failure Boundaries
+## Validation and Failure Boundaries
 
 Config load catches several classes of failure up front:
 
 - invalid or empty provider fields
 - unsupported pricing-provider mappings
-- invalid model alias references
-- invalid route/provider wiring
+- invalid alias references
+- invalid route or provider wiring
 
-At runtime, config shape is already fixed. Later failures are usually about request resolution, missing providers, capability mismatch, or pricing coverage.
+Later failures are usually runtime problems such as:
+
+- request resolution failure
+- missing providers
+- capability mismatch
+- exact-pricing gaps
+
+## Current Gaps
+
+- Declarative teams, users, and budgets are not part of the config contract yet.
+- The future direction is tracked in [issue #64](https://github.com/ahstn/oceans-llm/issues/64) and [issue #65](https://github.com/ahstn/oceans-llm/issues/65).
 
 ## What This Page Does Not Own
 
-- request routing and `/v1/*` behavior: [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)
-- identity/onboarding semantics: [identity-and-access.md](identity-and-access.md)
-- spend enforcement and budget windows: [budgets-and-spending.md](budgets-and-spending.md)
-- pricing coverage and unpriced reasons: [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md)
-- deploy topology and release/ops workflow: [deploy-and-operations.md](deploy-and-operations.md), [release-process.md](release-process.md)
+- startup behavior and first access:
+  - [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md)
+- request routing and `/v1/*` behavior:
+  - [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)
+- cross-cutting request cause and effect:
+  - [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md)
+- spend windows and budget policy:
+  - [budgets-and-spending.md](budgets-and-spending.md)
+- hardened OIDC status:
+  - [oidc-and-sso-status.md](oidc-and-sso-status.md)

--- a/docs/deploy-and-operations.md
+++ b/docs/deploy-and-operations.md
@@ -1,10 +1,10 @@
 # Deploy and Operations
 
-`Owns`: runtime topology, local-vs-deploy differences, bootstrap/seed expectations, and deployment-time operational caveats.
+`Owns`: runtime topology, the same-origin admin model, local-vs-prod differences, and deploy-time caveats that are easy to miss from one config file.
 `Depends on`: [../README.md](../README.md), [configuration-reference.md](configuration-reference.md)
-`See also`: [../deploy/README.md](../deploy/README.md), [identity-and-access.md](identity-and-access.md), [observability-and-request-logs.md](observability-and-request-logs.md), [release-process.md](release-process.md)
+`See also`: [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md), [operator-runbooks.md](operator-runbooks.md), [../deploy/README.md](../deploy/README.md), [release-process.md](release-process.md)
 
-This page owns the runtime topology and operator caveats that are otherwise easy to miss when reading only a compose file or startup script.
+This page owns the runtime shape. It does not own the action-by-action runbooks.
 
 ## Runtime Topology
 
@@ -14,55 +14,63 @@ The product runs as a same-origin control plane:
 2. the admin UI SSR server runs separately
 3. the gateway reverse-proxies `/admin*` to `ADMIN_UI_UPSTREAM`
 
-This same-origin model is part of the product contract, not just a local-dev trick.
+This is a product constraint, not only a local-dev convenience.
 
 ## Common Runtime Shapes
 
 ### Local development
 
-- config: [../gateway.yaml](../gateway.yaml)
-- database: libsql/SQLite
-- admin bootstrap: enabled, no forced password change
-- typical entry point: [../scripts/start-dev-stack.sh](../scripts/start-dev-stack.sh)
+- config:
+  - [../gateway.yaml](../gateway.yaml)
+- database:
+  - libsql or SQLite
+- entry point:
+  - [../scripts/start-dev-stack.sh](../scripts/start-dev-stack.sh)
+- bootstrap admin:
+  - enabled, no forced password change
 
 ### Production-shaped local run
 
-- config: [../gateway.prod.yaml](../gateway.prod.yaml)
-- database: PostgreSQL
-- admin bootstrap: enabled with forced password rotation
-- entry point: [../scripts/start-prod.sh](../scripts/start-prod.sh)
+- config:
+  - [../gateway.prod.yaml](../gateway.prod.yaml)
+- database:
+  - PostgreSQL
+- entry point:
+  - [../scripts/start-prod.sh](../scripts/start-prod.sh)
+- bootstrap admin:
+  - enabled, forced password rotation
 
 ### GHCR compose deployment
 
-- compose: [../deploy/compose.yaml](../deploy/compose.yaml)
-- config: [../deploy/config/gateway.yaml](../deploy/config/gateway.yaml)
-- database: PostgreSQL
-- gateway auth bootstrap: seeded API key, no checked-in bootstrap admin block
+- compose:
+  - [../deploy/compose.yaml](../deploy/compose.yaml)
+- config:
+  - [../deploy/config/gateway.yaml](../deploy/config/gateway.yaml)
+- database:
+  - PostgreSQL
+- checked-in first access:
+  - seeded API key, no checked-in bootstrap-admin block
 
-That means the compose deployment path and the production-shaped local path do not have the same initial auth story.
+That means the compose deploy path and the production-shaped local path do not teach the same first-access story.
 
-## Bootstrap vs Seeded Access
+## Why The Same-Origin Model Matters
 
-There are two distinct startup patterns in this repo:
+The same-origin model changes more than routing.
 
-- bootstrap admin creation for the control plane
-- seeded API key creation for API access
+It affects:
 
-Production-shaped local runs emphasize bootstrap admin login.
-
-The GHCR compose deployment emphasizes seeded API access via `GATEWAY_API_KEY` and leaves admin bootstrap behavior to the mounted config and runtime settings you provide.
-
-For the identity contract behind these choices, see [identity-and-access.md](identity-and-access.md).
+- deploy topology
+- admin UI local debugging
+- E2E scope
+- release risk when backend contract changes land
 
 ## Admin UI Local Development
 
-Direct UI development on `:3001` still depends on the gateway:
+Direct UI work on `:3001` still depends on the gateway:
 
 - server-side admin loaders call back into gateway APIs
-- same-origin behavior is the normal contract
-- changing gateway routes or backend response contracts can require a gateway restart even when the UI is running separately
-
-This is why admin UI changes can still break cross-layer behavior without touching visible page code.
+- same-origin behavior is still the normal contract
+- backend route changes can require a gateway restart even when the UI server is already running
 
 ## Observability Wiring
 
@@ -74,14 +82,9 @@ Relevant config knobs:
 - `server.otel_metrics_endpoint`
 - `server.otel_export_interval_secs`
 
-Current repo deploy files do not ship a collector by default. Operators should decide whether they are:
+The checked-in deploy path does not ship a collector by default.
 
-- running with OTLP export configured to an external collector, or
-- running without a collector and relying on logs plus request-log storage
-
-For request-log semantics and known limits, see [observability-and-request-logs.md](observability-and-request-logs.md).
-
-## Database And Migration Notes
+## Database and Migration Notes
 
 PostgreSQL is the intended production and pre-production runtime backend.
 
@@ -89,10 +92,27 @@ Operationally important context:
 
 - the gateway can run migrations on startup
 - startup can also seed config and bootstrap auth state
-- pre-v1 migration flattening is still tracked as follow-up work in [issue #44](https://github.com/ahstn/oceans-llm/issues/44)
+- pre-v1 migration flattening is still tracked as follow-up work
+
+## Image and Release Caveats
+
+Current image support is not symmetric:
+
+- gateway image:
+  - `linux/amd64`
+- admin UI image:
+  - `linux/amd64`
+  - `linux/arm64`
+
+Release mechanics live in [release-process.md](release-process.md). Upgrade and recovery steps live in [operator-runbooks.md](operator-runbooks.md).
 
 ## What This Page Does Not Own
 
-- compose file usage details: [../deploy/README.md](../deploy/README.md)
-- release authoring and tag workflow: [release-process.md](release-process.md)
-- request routing and API semantics: [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)
+- startup behavior and first access:
+  - [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md)
+- compose quick start:
+  - [../deploy/README.md](../deploy/README.md)
+- action-oriented recovery:
+  - [operator-runbooks.md](operator-runbooks.md)
+- request routing semantics:
+  - [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)

--- a/docs/e2e-contract-tests.md
+++ b/docs/e2e-contract-tests.md
@@ -1,7 +1,7 @@
 # End-to-End Contract Tests
 
-`Owns`: the E2E harness shape, scope rules, and extension rules for cross-layer contract coverage.
-`Depends on`: [admin-control-plane.md](admin-control-plane.md), [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)
+`Owns`: the E2E harness shape, the reason it mixes browser and HTTP checks, and the extension rules for cross-layer contract coverage.
+`Depends on`: [admin-control-plane.md](admin-control-plane.md), [admin-api-contract-workflow.md](admin-api-contract-workflow.md)
 `See also`: [../crates/admin-ui/web/e2e/](../crates/admin-ui/web/e2e/), [../mise.toml](../mise.toml)
 
 The E2E harness boots three real processes:
@@ -16,14 +16,26 @@ Run it locally with:
 mise run e2e-test
 ```
 
+## Why This Harness Exists
+
+The product is same-origin and cross-layer by design.
+
+That means a pure browser suite would miss backend contract breaks, and a pure HTTP suite would miss same-origin auth and SSR behavior. The harness exists because the real failure surface sits across both.
+
 ## Fixed Test Credentials
 
 The harness uses deterministic seed values:
 
-- bootstrap admin email: `admin@local`
-- bootstrap admin password: `admin`
-- bootstrap admin replacement password: `s3cur3-passw0rd`
-- seed gateway API key: `gwk_e2e.secret-value`
+- bootstrap admin email:
+  - `admin@local`
+- bootstrap admin password:
+  - `admin`
+- replacement password:
+  - `s3cur3-passw0rd`
+- seeded gateway API key:
+  - `gwk_e2e.secret-value`
+
+Those values match the bootstrap and seed assumptions in the test stack.
 
 ## Scope Rule
 
@@ -38,7 +50,7 @@ Current intended coverage:
 
 ## Covered Today
 
-The current suite already covers more than a browser-only smoke pass:
+The current suite already covers:
 
 - browser auth and forced password-rotation flow
 - public `/v1/models`
@@ -49,11 +61,6 @@ The current suite already covers more than a browser-only smoke pass:
 - strict `404` behavior for missing request-log detail
 - live identity-user create-and-list API coverage
 
-Planned contract coverage is now expected for:
-
-- user lifecycle management
-- team member removal and transfer
-
 ## Preview-Backed Surface Rule
 
 Preview-backed pages may appear in smoke or landing assertions, but they are not treated as business-flow coverage until the underlying data is live.
@@ -62,31 +69,28 @@ Today that matters for:
 
 - Models
 
-Model inventory still uses local preview data in the admin UI. See [admin-control-plane.md](admin-control-plane.md).
+## Browser Flow Versus HTTP Assertion
 
-## Extension Rule
+Use a browser flow when the contract depends on:
 
-When adding new browser scenarios:
+- same-origin auth behavior
+- SSR loader behavior
+- user-visible workflow sequencing
 
-- prefer one critical cross-layer flow per newly live surface
-- keep the suite contract-focused rather than broad UI regression coverage
-- avoid treating mock or preview-only pages as durable product workflows
-- assert invalid transitions directly at the HTTP boundary when that is the clearest contract
+Use a direct HTTP assertion when the contract is clearer at the boundary:
 
-## Coverage Shape
+- exact status codes
+- invalid transitions
+- response envelope shape
+- admin API contract drift
 
-The harness is intentionally mixed:
+## Generated Contract Boundary
 
-- browser-admin flows for same-origin control-plane behavior
-- raw API contract assertions for gateway and admin endpoints
-
-Generated admin contract maintenance belongs in the same durability bucket:
+Generated admin contract maintenance belongs in the same durability bucket.
 
 - refresh artifacts with `mise run admin-contract-generate`
 - verify drift with `mise run admin-contract-check`
-- keep E2E assertions aligned with the checked-in gateway contract for live surfaces
-
-That split is intentional because some critical contracts are better asserted directly at the HTTP boundary than through page interactions.
+- keep E2E assertions aligned with the checked-in contract for live surfaces
 
 ## Still Missing
 

--- a/docs/identity-and-access.md
+++ b/docs/identity-and-access.md
@@ -1,121 +1,104 @@
 # Identity and Access
 
-`Owns`: bootstrap admin behavior, users, teams, onboarding, ownership model, request-logging preference, and access overlays.
+`Owns`: user and team lifecycle, onboarding, ownership rules, request-logging preference, and model-access overlays.
 `Depends on`: [data-relationships.md](data-relationships.md)
-`See also`: [admin-control-plane.md](admin-control-plane.md), [budgets-and-spending.md](budgets-and-spending.md), [adr/2026-03-05-identity-foundation.md](adr/2026-03-05-identity-foundation.md), [adr/2026-03-08-admin-team-management-flow.md](adr/2026-03-08-admin-team-management-flow.md), [adr/2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md](adr/2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md)
+`See also`: [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md), [oidc-and-sso-status.md](oidc-and-sso-status.md), [admin-control-plane.md](admin-control-plane.md), [budgets-and-spending.md](budgets-and-spending.md), [adr/2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md](adr/2026-03-26-admin-identity-lifecycle-and-team-member-workflows.md)
 
-This document describes the live identity and access model across the gateway and admin control plane.
+This page describes the live identity model across the gateway and admin control plane.
 
 ## Source of Truth
 
-- Identity APIs: [../crates/gateway/src/http/identity.rs](../crates/gateway/src/http/identity.rs)
-- Access evaluation: [../crates/gateway-service/src/model_access.rs](../crates/gateway-service/src/model_access.rs)
-- Bootstrap admin creation: [../crates/gateway/src/main.rs](../crates/gateway/src/main.rs)
+- identity APIs:
+  - [../crates/gateway/src/http/identity.rs](../crates/gateway/src/http/identity.rs)
+- lifecycle policy:
+  - [../crates/gateway/src/http/identity_lifecycle.rs](../crates/gateway/src/http/identity_lifecycle.rs)
+- access evaluation:
+  - [../crates/gateway-service/src/model_access.rs](../crates/gateway-service/src/model_access.rs)
 
 ## Ownership Model
 
-The product uses first-class users, teams, and API key ownership:
+The product uses first-class users, teams, and API-key ownership.
 
-- API keys are either user-owned or team-owned
-- teams are durable ownership boundaries for team budgets and future team-owned resources
-- one user belongs to at most one team in this slice
-- users can exist without a team
-- team transfers are future-membership changes only; they do not migrate historical request logs, spend, budgets, or API-key ownership
-
-Legacy keys are preserved through the reserved `system-legacy` team.
+- API keys are either user-owned or team-owned.
+- Teams are durable ownership boundaries for team budgets and future team-owned resources.
+- One user belongs to at most one team in this slice.
+- Users can exist without a team.
+- Legacy keys are preserved through the reserved `system-legacy` team.
 
 ## User Lifecycle
 
-User status is a typed lifecycle rather than an incidental string:
+User status is typed, not free-form text.
 
 - `invited`
 - `active`
 - `disabled`
 
-The lifecycle rules are intentionally conservative:
+Important rules:
 
-- auth-mode changes are allowed only while a user is still `invited`
-- deactivation revokes runtime access and outstanding invite state
-- reactivation restores access only when the current auth proof still exists
-- reset-onboarding returns the user to `invited` and reissues the onboarding link
+- auth-mode changes are only allowed while the user is still `invited`
+- deactivation revokes runtime access
+- reactivation only restores access when the current auth proof still exists
+- reset-onboarding returns the user to `invited`
 - the last active platform admin cannot be deactivated or demoted
-- bootstrap admin remains out of band and is excluded from normal user-management views
+- the bootstrap admin stays out of normal user-management views
 
 ## Bootstrap Admin
 
-The gateway can ensure a bootstrap platform admin exists at startup.
+Bootstrap admin is the first control-plane access path, not a normal user-management path.
 
-Default checked-in behavior:
+- local config keeps it enabled without forced password rotation
+- production-shaped local config keeps it enabled with forced password rotation
+- the active config and startup toggles decide whether it is created on boot
 
-- local config (`gateway.yaml`): `admin@local` / `admin`, no forced password change
-- production-shaped config (`gateway.prod.yaml`): `admin@local` / `admin`, forced password change on first login
+For the startup and first-access path, use [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md).
 
-Relevant controls:
+## Onboarding Model
 
-- `GATEWAY_BOOTSTRAP_ADMIN`
-- `gateway bootstrap-admin`
-- `auth.bootstrap_admin` in the active YAML config
-
-## Admin Auth and Onboarding
-
-The current admin/auth surface includes:
-
-- password login
-- password rotation
-- password invite validation and completion
-- pre-provisioned OIDC sign-in
-- authenticated admin session lookup
-
-Password onboarding:
-
-- invited password users receive a time-limited invitation token
-- setting the password activates the user
-
-OIDC onboarding:
-
-- the admin UI can pre-provision an invited OIDC user against an enabled provider
-- first successful callback activates the user and creates the durable provider subject link
-
-## Onboarding Handoff Model
-
-Admin onboarding is intentionally operator-mediated today:
+Current onboarding is operator-mediated.
 
 - admins create users or invite them into teams
-- the control plane generates password invite URLs or OIDC sign-in URLs
-- the admin then shares that onboarding link out of band
+- the control plane generates password invite links or OIDC sign-in links
+- the admin shares that link out of band
 
-That handoff model is part of the current product contract. There is no separate self-service discovery flow in this slice.
+There is no self-service discovery flow in this slice.
 
-## Important Current Limitation: OIDC Is Still Development-Style
-
-Current OIDC behavior is intentionally not a hardened standards-complete provider flow.
-
-Today the implementation still:
-
-- redirects `oidc_start` directly into the callback path
-- accepts callback identity through query parameters
-- synthesizes the provider subject as `mock:{provider_key}:{email}` when no explicit subject is provided
-
-That is useful for local and slice-level testing, but it is not the final production design. The follow-up direction is tracked in [issue #46](https://github.com/ahstn/oceans-llm/issues/46), and the earlier hardening intent is recorded in [issue #29](https://github.com/ahstn/oceans-llm/issues/29).
-
-## Teams
+## Team Lifecycle
 
 Current team-management rules:
 
 - teams can be created before users exist
 - teams can be created with zero admins
-- the admin UI can add existing teamless users or invite new members directly into a team
+- the admin UI can add existing teamless users or invite new users directly into a team
 - cross-team reassignment is rejected in this slice
-- `owner` remains visible but is not removable or transferable through the admin UI in this slice
+- `owner` memberships are visible but blocked from casual lifecycle edits
 
-## Current Team Lifecycle Boundaries
+## Team Transfer Rule
 
-Additional boundaries that are easy to miss from one page or one API response:
+Team transfer is easy to overread. The rule is narrow on purpose.
 
-- `team_key` is server-generated and durable
-- empty teams are valid and expected
-- current edit flows now include explicit member removal and transfer actions
-- owner memberships remain blocked from casual lifecycle edits until the broader ownership model is defined
+Transfer changes:
+
+- the user’s current membership
+- future membership-derived access
+
+Transfer does not change:
+
+- historical request logs
+- historical spend rows
+- existing budgets
+- API-key ownership
+
+That boundary is a policy rule, not a UI shortcut.
+
+## OIDC Boundary
+
+OIDC exists in the product, but it is still development-style in this slice.
+
+- pre-provisioned OIDC users are supported
+- OIDC onboarding links exist
+- hardened production-grade SSO is still a follow-up
+
+Use [oidc-and-sso-status.md](oidc-and-sso-status.md) for the practical boundary and future direction.
 
 ## Model Access Overlays
 
@@ -125,19 +108,32 @@ Effective model access is layered:
 2. team allowlist when the team is `restricted`
 3. user allowlist when the user is `restricted`
 
-This keeps API key grants as the baseline contract while allowing narrower team or user restrictions above them.
+This keeps API-key grants as the baseline contract while allowing narrower restrictions above them.
 
 ## Request Logging Preference
 
-Request logging policy is owned partly by identity:
+Request logging policy is partly owned by identity.
 
 - user-owned requests honor `users.request_logging_enabled`
 - team-owned requests always persist request logs
 
-Request-log storage and observability behavior are documented in [observability-and-request-logs.md](observability-and-request-logs.md).
+## Current Gaps
+
+- Hardened OIDC flow is still pending:
+  - [issue #29](https://github.com/ahstn/oceans-llm/issues/29)
+- Self-hosted test-IdP guidance is still pending:
+  - [issue #46](https://github.com/ahstn/oceans-llm/issues/46)
+- Declarative config-driven identity is still pending:
+  - [issue #64](https://github.com/ahstn/oceans-llm/issues/64)
+  - [issue #65](https://github.com/ahstn/oceans-llm/issues/65)
 
 ## Where Identity Appears Operationally
 
-- [Admin Control Plane](admin-control-plane.md): what admins can manage today
-- [Budgets and Spending](budgets-and-spending.md): how user and team ownership affects spend enforcement
-- [Model Routing and API Behavior](model-routing-and-api-behavior.md): how model grants and overlays affect `/v1/models` and request resolution
+- admin workflows:
+  - [admin-control-plane.md](admin-control-plane.md)
+- startup and first access:
+  - [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md)
+- spend ownership effects:
+  - [budgets-and-spending.md](budgets-and-spending.md)
+- request resolution effects:
+  - [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)

--- a/docs/model-routing-and-api-behavior.md
+++ b/docs/model-routing-and-api-behavior.md
@@ -1,39 +1,44 @@
 # Model Routing and API Behavior
 
-`Owns`: model identity, aliases, `tag:` selectors, route planning inputs, capability gating, and `/v1/*` behavior.
+`Owns`: model identity, aliases, `tag:` selectors, route-planning inputs, capability gating, and `/v1/*` behavior.
 `Depends on`: [configuration-reference.md](configuration-reference.md), [data-relationships.md](data-relationships.md), [identity-and-access.md](identity-and-access.md)
-`See also`: [budgets-and-spending.md](budgets-and-spending.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md), [observability-and-request-logs.md](observability-and-request-logs.md), [adr/2026-03-10-model-aliases-and-provider-route-config.md](adr/2026-03-10-model-aliases-and-provider-route-config.md), [adr/2026-03-13-capability-aware-route-gating.md](adr/2026-03-13-capability-aware-route-gating.md), [adr/2026-03-15-v1-runtime-simplification.md](adr/2026-03-15-v1-runtime-simplification.md)
+`See also`: [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md), [observability-and-request-logs.md](observability-and-request-logs.md), [adr/2026-03-10-model-aliases-and-provider-route-config.md](adr/2026-03-10-model-aliases-and-provider-route-config.md), [adr/2026-03-13-capability-aware-route-gating.md](adr/2026-03-13-capability-aware-route-gating.md)
 
-This document describes how requests move from the public `/v1/*` surface to a concrete provider route.
+This page explains how the public `/v1/*` surface resolves a request into one concrete route.
 
 ## Source of Truth
 
-- Config parsing: [../crates/gateway/src/config.rs](../crates/gateway/src/config.rs)
-- Model access and tag selection: [../crates/gateway-service/src/model_access.rs](../crates/gateway-service/src/model_access.rs)
-- Alias resolution: [../crates/gateway-service/src/model_resolution.rs](../crates/gateway-service/src/model_resolution.rs)
-- Route planning: [../crates/gateway-service/src/route_planner.rs](../crates/gateway-service/src/route_planner.rs)
-- HTTP handlers: [../crates/gateway/src/http/handlers.rs](../crates/gateway/src/http/handlers.rs)
+- config parsing:
+  - [../crates/gateway/src/config.rs](../crates/gateway/src/config.rs)
+- model access and tag selection:
+  - [../crates/gateway-service/src/model_access.rs](../crates/gateway-service/src/model_access.rs)
+- alias resolution:
+  - [../crates/gateway-service/src/model_resolution.rs](../crates/gateway-service/src/model_resolution.rs)
+- route planning:
+  - [../crates/gateway-service/src/route_planner.rs](../crates/gateway-service/src/route_planner.rs)
+- HTTP handlers:
+  - [../crates/gateway/src/http/handlers.rs](../crates/gateway/src/http/handlers.rs)
 
 ## Public Endpoints
 
-The gateway exposes:
+The live public endpoints are:
 
 - `GET /v1/models`
 - `POST /v1/chat/completions`
 - `POST /v1/embeddings`
 
-All three endpoints are authenticated.
+All are authenticated.
 
-The router also sets and propagates `x-request-id` across the public `/v1/*` surface and into provider calls.
+## Requested Versus Resolved Model Identity
 
-## Requested vs Resolved Model Identity
+The gateway keeps two model identities in play:
 
-The gateway distinguishes between:
+- requested model
+  - what the caller asked for
+- resolved model
+  - the canonical execution target after alias resolution
 
-- the requested model: what the client asked for
-- the resolved model: the canonical execution target after alias resolution
-
-That distinction is persisted into request logs so operators can see both the client-facing contract and the execution identity.
+That distinction is persisted into request logs.
 
 ## Model Forms
 
@@ -44,21 +49,18 @@ Configured gateway models are either:
 
 A model cannot define both routes and `alias_of`.
 
-## `tag:` Model Selectors
+## `tag:` Selectors
 
-The request `model` field can be a concrete gateway model key or a tag selector:
+The request `model` field can be:
 
-- `tag:fast`
-- `tag:fast,cheap`
+- a concrete gateway model key
+- a tag selector such as `tag:fast`
 
-Tag selectors use AND semantics:
+Tag selectors use AND semantics.
 
-- every requested tag must be present on the chosen model
+- every requested tag must exist on the chosen model
 - selection only considers models already allowed for the authenticated API key
 - candidates are ordered by model `rank`, then model key
-- empty tag fragments are ignored
-
-If no effective model matches the requested tag set, the runtime returns `ModelNotFound("tag:...")`.
 
 ## Routes, Priority, and Weight
 
@@ -76,18 +78,18 @@ Each route can define:
 Current planner behavior:
 
 - lower `priority` is attempted first
-- weights apply only within the same priority bucket
-- disabled routes or routes with non-positive weight are excluded
+- `weight` only matters within the same priority bucket
+- disabled routes and routes with non-positive weight are excluded
 
-Important runtime nuance:
+Current runtime nuance:
 
-- weighted routing is not multi-route fallback in v1
-- the planner produces an ordered route list by priority, then weighted random choice within each priority bucket
-- the handler executes only the first capability-compatible viable route
+- weighted routing is not multi-route fallback
+- the planner produces an ordered route list
+- the handler executes only the first eligible route
 
 ## Capability-Aware Gating
 
-Routes are filtered before provider execution based on request requirements and effective route capability.
+Routes are filtered before provider execution based on request requirements and route capability.
 
 Current capability dimensions:
 
@@ -99,51 +101,44 @@ Current capability dimensions:
 - `json_schema`
 - `developer_role`
 
-If no compatible route remains, the gateway returns a deterministic `400 invalid_request` instead of relying on provider-specific behavior.
+Capability metadata exists to fail early at the gateway edge. It is not a copy of provider marketing language.
 
-## Current V1 Runtime Behavior
+## Worked Request Path
 
-The runtime is intentionally simplified in this slice:
+One plain path looks like this:
 
-- single-route execution only
-- no retry or fallback loop in the live request path
-- no idempotency-gated route retries
-- strict capability filtering before provider execution
+- request model:
+  - `tag:fast`
+- allowed model set:
+  - `gpt-4o-mini`, `claude-3-5-haiku`
+- selection result:
+  - `gpt-4o-mini`
+- alias result:
+  - `openai-gpt-4o-mini`
+- planned route order:
+  - `openai-primary`, then `openai-backup`
+- capability filter:
+  - `openai-primary` stays eligible
+- execution:
+  - the handler uses `openai-primary`
+- request-log fields:
+  - `model_key = gpt-4o-mini`
+  - `resolved_model_key = openai-gpt-4o-mini`
+  - `provider_key = openai-primary`
 
-This means the request flow is:
-
-1. authenticate
-2. resolve allowed requested model
-3. canonicalize aliases
-4. plan routes
-5. filter by capability
-6. execute the first eligible route
-7. record usage and logs
-
-## Defaults and Validation
-
-Important config defaults and validation rules are owned by [configuration-reference.md](configuration-reference.md). The defaults that materially shape runtime behavior are:
-
-- model `rank` default `100`
-- route `priority` default `100`
-- route `weight` default `1.0`
-- route capability defaults all enabled
-
-Alias handling also has runtime safeguards:
-
-- alias references are validated at config load
-- runtime still detects cycles defensively
-- runtime alias depth is capped at `8`
+Use [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md) for the later logging, pricing, and budget effects.
 
 ## `/v1/models`
 
-`GET /v1/models` returns the models visible to the authenticated API key after grants and access overlays are applied.
+`GET /v1/models` returns the gateway models visible to the authenticated API key.
 
 Important notes:
 
-- it reflects gateway model identity, not raw upstream provider catalogs
-- it does not expose `tag:` selectors directly; tags remain a request-time convenience
-- it returns effective granted gateway model keys, not provider catalog entries
+- it reflects gateway model identity, not raw provider catalogs
+- it shows grant-visible identities
+- it does not promise executable routes
+
+That last point matters. A model can be visible and still fail if route viability or capability checks remove every route.
 
 ## `/v1/chat/completions`
 
@@ -151,44 +146,48 @@ Current behavior highlights:
 
 - request IDs are propagated through `x-request-id`
 - budget checks run before provider execution
-- successful requests write usage into the spend ledger when usage can be normalized
+- successful requests write usage when usage can be normalized
 - request logs store both requested and resolved model identity
-
-Known current rough edge:
-
-- stream and non-stream chat paths still differ when a post-provider ledger write fails
-
-That follow-up is tracked in [issue #49](https://github.com/ahstn/oceans-llm/issues/49).
 
 ## `/v1/embeddings`
 
-`POST /v1/embeddings` is live in the runtime and follows the same high-level execution model:
+`POST /v1/embeddings` follows the same high-level path:
 
 - authenticate
-- resolve requested model and alias
+- resolve the requested model
 - capability-filter the route set
 - execute the first eligible route
 - write usage when usage can be normalized
 
 Current limitation:
 
-- Vertex embeddings remain out of scope in this slice and are expected to be excluded by capability gating
+- Vertex embeddings remain out of scope in this slice and should be excluded by capability gating
 
-## Config Notes That Matter Operationally
+## Route Viability Versus Capability Mismatch
 
-- `openai_compat` providers must declare a supported `pricing_provider_id`
-- `gcp_vertex` routes require `upstream_model` in `<publisher>/<model_id>` form
-- route capabilities default permissively unless explicitly constrained in config
+| Symptom | Meaning |
+| --- | --- |
+| `invalid_request` | the model resolved, but capability filtering removed every route |
+| `no_routes_available` | the model exists, but no usable route survived provider and route-viability checks |
 
-For the full config contract, use [configuration-reference.md](configuration-reference.md). For pricing coverage and unpriced routes, use [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md).
+That distinction is one of the fastest ways to debug a visible-but-unusable model.
 
-## Failure Modes That Matter
+## Current V1 Behavior
 
-Two failure classes are easy to confuse operationally:
+The live runtime is intentionally narrow in this slice:
 
-- `invalid_request`: the model resolved, but capability filtering left no compatible route for the requested operation
-- `no_routes_available`: the model exists, but provider existence filtering and route viability filtering left no usable route at all
+- single-route execution only
+- no retry loop
+- no live fallback loop
+- strict capability filtering before provider execution
 
-That distinction matters when debugging a model that is visible in `/v1/models` but cannot actually serve traffic.
+## What This Page Does Not Own
 
-For the operator-facing admin view built on top of these rules, see [admin-control-plane.md](admin-control-plane.md).
+- config field syntax and defaults:
+  - [configuration-reference.md](configuration-reference.md)
+- full cross-cutting request path:
+  - [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md)
+- exact pricing coverage:
+  - [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md)
+- spend enforcement and budget windows:
+  - [budgets-and-spending.md](budgets-and-spending.md)

--- a/docs/observability-and-request-logs.md
+++ b/docs/observability-and-request-logs.md
@@ -1,19 +1,23 @@
 # Observability and Request Logs
 
-`Owns`: OTLP observability model, request-log storage shape, payload redaction and truncation boundaries, and admin observability API behavior.
+`Owns`: the OTLP observability model, request-log storage shape, payload redaction and truncation boundaries, and admin observability API behavior.
 `Depends on`: [data-relationships.md](data-relationships.md), [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)
-`See also`: [admin-control-plane.md](admin-control-plane.md), [budgets-and-spending.md](budgets-and-spending.md), [deploy-and-operations.md](deploy-and-operations.md), [adr/2026-03-15-otlp-observability-and-request-log-payloads.md](adr/2026-03-15-otlp-observability-and-request-log-payloads.md), [../crates/gateway/src/http/admin_contract.rs](../crates/gateway/src/http/admin_contract.rs)
+`See also`: [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md), [admin-control-plane.md](admin-control-plane.md), [deploy-and-operations.md](deploy-and-operations.md), [adr/2026-03-15-otlp-observability-and-request-log-payloads.md](adr/2026-03-15-otlp-observability-and-request-log-payloads.md)
 
 This document describes the live observability contract for the gateway.
 
 ## Source of Truth
 
-- Observability bootstrap: [../crates/gateway/src/observability.rs](../crates/gateway/src/observability.rs)
-- HTTP request instrumentation: [../crates/gateway/src/http/handlers.rs](../crates/gateway/src/http/handlers.rs)
-- Request-log lifecycle: [../crates/gateway-service/src/request_logging.rs](../crates/gateway-service/src/request_logging.rs)
-- Redaction policy: [../crates/gateway-service/src/redaction.rs](../crates/gateway-service/src/redaction.rs)
-- Admin APIs: [../crates/gateway/src/http/observability.rs](../crates/gateway/src/http/observability.rs)
-- Generated admin contract: [../crates/gateway/openapi/admin-api.json](../crates/gateway/openapi/admin-api.json)
+- observability bootstrap:
+  - [../crates/gateway/src/observability.rs](../crates/gateway/src/observability.rs)
+- HTTP request instrumentation:
+  - [../crates/gateway/src/http/handlers.rs](../crates/gateway/src/http/handlers.rs)
+- request-log lifecycle:
+  - [../crates/gateway-service/src/request_logging.rs](../crates/gateway-service/src/request_logging.rs)
+- redaction policy:
+  - [../crates/gateway-service/src/redaction.rs](../crates/gateway-service/src/redaction.rs)
+- admin APIs:
+  - [../crates/gateway/src/http/observability.rs](../crates/gateway/src/http/observability.rs)
 
 ## OTLP-First Model
 
@@ -25,7 +29,7 @@ Current config knobs:
 - `server.otel_metrics_endpoint`
 - `server.otel_export_interval_secs`
 
-The intended deployment path for this slice is collector-friendly OTLP export rather than an in-process Prometheus endpoint.
+The intended deploy path is collector-friendly OTLP export rather than an in-process Prometheus endpoint.
 
 ## What Gets Recorded
 
@@ -36,62 +40,39 @@ The runtime emits bounded request-level signals for:
 - token totals
 - operational cost totals
 - usage-record totals by pricing status
-- caller request tags in request-log storage for filtering and attribution
+- caller request tags for filtering and attribution
 
-The request path also records tracing spans enriched with routing and ownership context.
-
-Metric contract:
-
-- `gateway.chat.requests` describes routed request outcomes, including budget rejections after model resolution
-- the gateway does not emit separate provider-attempt or fallback counters for chat completions
-
-Request correlation is anchored on `x-request-id`:
-
-- the gateway generates or propagates it at the HTTP edge
-- public `/v1/*` responses return it
-- provider adapters forward it upstream
-- admin request-log lookup can use it as the operator-visible correlation key
+Request correlation is anchored on `x-request-id`.
 
 ## Request Tagging Contract
 
-Callers can attach bounded attribution metadata to requests with these headers:
+Callers can attach bounded attribution metadata with:
 
 - `x-oceans-service`
 - `x-oceans-component`
 - `x-oceans-env`
 - `x-oceans-tags`
 
-Intended use:
-
-- use the universal headers for the stable dimensions most teams will filter on repeatedly
-- use `x-oceans-tags` only for a small number of extra exact-match tags
-
 `x-oceans-tags` uses `key=value; key2=value2` formatting.
 
-Examples:
+Validation rules:
 
-- `x-oceans-service: checkout`
-- `x-oceans-component: pricing_api`
-- `x-oceans-env: prod`
-- `x-oceans-tags: feature=guest_checkout; cohort=beta`
-
-Current validation rules:
-
-- universal headers may only be sent once each
+- the universal headers may only be sent once each
 - `x-oceans-tags` may only be sent once
 - bespoke tags are capped at 5 entries
-- bespoke keys must be unique inside the header
-- bespoke keys may not reuse reserved universal names: `service`, `component`, `env`
-- keys must start with a lowercase ASCII letter and then use only lowercase ASCII letters, digits, `.`, `_`, or `-`
-- values must use only lowercase ASCII letters, digits, `.`, `_`, `-`, `/`, or `:`
-- malformed or duplicate tags are rejected as `400 invalid_request`
+- bespoke keys must be unique
+- reserved universal names cannot be reused as bespoke keys
 
 ## Request Log Storage Shape
 
 Request logs are intentionally split:
 
-- `request_logs`: hot summary row
-- `request_log_payloads`: sanitized payload bodies
+- `request_logs`
+  - hot summary row
+- `request_log_payloads`
+  - sanitized request and response bodies
+- `request_log_tags`
+  - bounded bespoke caller tags
 
 The summary row stores:
 
@@ -102,34 +83,22 @@ The summary row stores:
 - universal caller tags
 - status, latency, and usage totals
 - truncation flags
-- metadata (`operation` and `stream`)
-
-The payload row stores:
-
-- sanitized request JSON
-- sanitized response JSON
-
-The gateway also stores bespoke caller tags in a bounded side table:
-
-- `request_log_tags`
+- metadata such as `operation` and `stream`
 
 Streaming requests persist a bounded transcript payload rather than raw transport bytes.
-Stream payload capture is incremental and boundary-safe across UTF-8 and SSE chunk splits, and the stored `usage` snapshot always reflects the latest coherent usage frame seen before stream termination.
-Postgres cleanup migrations that need to inspect request-log metadata parse legacy `metadata_json` defensively and skip malformed rows rather than failing the entire migration for one bad historical value.
 
 ## Redaction and Truncation Boundaries
 
-Current redaction is key- and header-driven.
+Current redaction is key-driven and header-driven.
 
 Sensitive headers include:
 
 - `authorization`
-- `proxy-authorization`
 - `cookie`
 - `set-cookie`
 - `x-api-key`
 
-Sensitive JSON keys include common fields such as:
+Sensitive JSON keys include:
 
 - `token`
 - `access_token`
@@ -137,15 +106,22 @@ Sensitive JSON keys include common fields such as:
 - `secret`
 - `password`
 
-Current payload policy is intentionally heuristic and bounded. It is not yet a deployment-configurable policy surface. That hardening follow-up is tracked in [issue #18](https://github.com/ahstn/oceans-llm/issues/18).
+Current payload policy is still heuristic and bounded. It is not operator-configurable yet.
 
-## Current Limits and Gaps
+## Recent Contract Cleanup
 
-Operationally important limits that are not configurable today:
+Recent cleanup changed the contract in a few important ways.
 
-- there is no documented retention or archival policy yet for `request_log_payloads`
-- deploy examples do not ship an OTLP collector by default
-- request-log payload policy is bounded and heuristic rather than operator-configurable
+- fallback-era request metadata is gone
+- missing request-log detail rows return strict `404 not_found`
+- stream payload parsing is more boundary-safe than the earlier chunk-by-chunk behavior
+
+Operators and maintainers should stop expecting:
+
+- fallback metadata columns to appear in new request rows
+- nullable detail lookups for missing rows
+
+The remaining stream and ledger mismatch still lives in a smaller rough edge, not in the old fallback-era contract.
 
 ## Admin Observability APIs
 
@@ -170,22 +146,20 @@ Current list filters:
 - `tag_key`
 - `tag_value`
 
-## Important Current Rough Edges
+## Current Gaps
 
-Current behavior that operators and maintainers should know plainly:
-
-- request-log detail lookups return `404 not_found` for missing rows
+- no documented retention or archival policy yet for `request_log_payloads`
+- deploy examples do not ship an OTLP collector by default
+- request-log payload policy is not operator-configurable yet
+  - [issue #18](https://github.com/ahstn/oceans-llm/issues/18)
 - stream and non-stream chat paths still differ on post-provider ledger-write failure behavior
-
-Tracked follow-ups:
-
-- [issue #49](https://github.com/ahstn/oceans-llm/issues/49): unify post-provider ledger failure semantics
+  - [issue #49](https://github.com/ahstn/oceans-llm/issues/49)
 
 ## Relationship to Spend Reporting
 
-Request logs and spend accounting are related but intentionally separate:
+Request logs and spend accounting are related, but intentionally separate.
 
-- request logs describe the user-visible request outcome and payload context
+- request logs describe the user-visible request outcome
 - `usage_cost_events` is the canonical spend ledger
 
-For spend policy and budget windows, see [budgets-and-spending.md](budgets-and-spending.md).
+For the full request path across both systems, use [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md).

--- a/docs/oidc-and-sso-status.md
+++ b/docs/oidc-and-sso-status.md
@@ -1,0 +1,81 @@
+# OIDC and SSO Status
+
+`Owns`: the current OIDC state, the boundary of the development-style flow, the planned hardened direction, and the missing local test-IdP story.
+`Depends on`: [identity-and-access.md](identity-and-access.md), [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md)
+`See also`: [configuration-reference.md](configuration-reference.md), [deploy-and-operations.md](deploy-and-operations.md), [admin-control-plane.md](admin-control-plane.md), [adr/2026-03-05-identity-foundation.md](adr/2026-03-05-identity-foundation.md)
+
+This page exists because the current OIDC story is easy to overread. OIDC exists in the product, but it is not hardened production-grade SSO yet.
+
+## Current State
+
+The live product supports pre-provisioned OIDC users and OIDC-flavored onboarding flows in the admin control plane.
+
+What exists today:
+
+- OIDC providers can be configured
+- admins can pre-provision invited OIDC users
+- first successful callback activates the invited user
+- durable user and provider-link records are stored
+
+What does not exist yet:
+
+- a hardened standards-complete login flow
+- a finished self-hosted local test-IdP story
+- declarative config-as-code support for SSO-backed users and team assignment
+
+## Development-Style Boundary
+
+The current flow is intentionally development-style.
+
+Today the implementation still:
+
+- redirects `oidc_start` into the callback path directly
+- accepts callback identity through query parameters
+- synthesizes a provider subject when one is not supplied
+
+That is enough for slice-level testing and UI wiring. It is not enough to describe as finished enterprise SSO.
+
+## Practical Operator Impact
+
+Operators should assume these boundaries:
+
+- OIDC is usable for controlled environments and development-style testing
+- OIDC is not the hardened final story for production sign-in policy
+- local testing still lacks a checked-in IdP recommendation and workflow
+- deploy docs should not imply that SSO-first bootstrap is solved
+
+## Planned Direction
+
+The current forward path is visible in repo history.
+
+- Harden the OIDC flow itself:
+  - [issue #29](https://github.com/ahstn/oceans-llm/issues/29)
+- Pick and document a self-hosted test IdP story:
+  - [issue #46](https://github.com/ahstn/oceans-llm/issues/46)
+- Extend declarative config once hardened identity matching exists:
+  - [issue #65](https://github.com/ahstn/oceans-llm/issues/65)
+
+That sequence matters. Declarative SSO-backed users depend on the hardened identity contract, not the other way around.
+
+## Local Test-IdP Gap
+
+The repo does not yet ship a recommended local IdP stack for realistic OIDC testing.
+
+That means:
+
+- local validation remains ad hoc
+- the current OIDC path is easier to demo than to validate against real provider quirks
+- manual test guidance should stay conservative until the IdP choice is made
+
+## Current Gaps
+
+- Hardened OIDC flow: [issue #29](https://github.com/ahstn/oceans-llm/issues/29)
+- Self-hosted test-IdP research: [issue #46](https://github.com/ahstn/oceans-llm/issues/46)
+- Declarative SSO-backed identity config: [issue #65](https://github.com/ahstn/oceans-llm/issues/65)
+
+## What This Page Does Not Own
+
+- user lifecycle and team rules: [identity-and-access.md](identity-and-access.md)
+- config field syntax for providers: [configuration-reference.md](configuration-reference.md)
+- admin UI capability map: [admin-control-plane.md](admin-control-plane.md)
+- deploy topology and first-access behavior: [deploy-and-operations.md](deploy-and-operations.md), [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md)

--- a/docs/operator-runbooks.md
+++ b/docs/operator-runbooks.md
@@ -1,0 +1,135 @@
+# Operator Runbooks
+
+`Owns`: step-by-step operator actions for first deploy, upgrades, migration recovery, admin access recovery, provider auth failures, missing OTLP collectors, and secret rotation checkpoints.
+`Depends on`: [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md), [deploy-and-operations.md](deploy-and-operations.md)
+`See also`: [../deploy/README.md](../deploy/README.md), [configuration-reference.md](configuration-reference.md), [identity-and-access.md](identity-and-access.md), [observability-and-request-logs.md](observability-and-request-logs.md)
+
+This page is action-oriented. It is not the place for broad topology or config reference detail.
+
+## First Deploy
+
+- copy `deploy/.env.example` to `deploy/.env`
+- set image tags and secret values
+- inspect the mounted config at [../deploy/config/gateway.yaml](../deploy/config/gateway.yaml)
+- start the stack:
+
+```bash
+docker compose -f deploy/compose.yaml up -d
+```
+
+- confirm the containers are healthy
+- call `/healthz` and `/readyz`
+- confirm whether admin bootstrap is enabled in the mounted config before assuming `/admin` is ready
+- confirm the seeded gateway key works for `/v1/models`
+
+If the deploy path is meant to support the admin UI on first boot, the mounted config needs a real bootstrap-admin plan or a pre-existing admin row.
+
+## Upgrade Flow
+
+- pick the target image tags
+- review release notes and image caveats
+- confirm database backup or recreate policy for the target environment
+- update `deploy/.env`
+- restart the stack with the new tags
+- recheck `/readyz`
+- recheck admin login or seeded API-key access
+- spot-check one live `/v1/*` request
+
+If the change touches admin APIs, also recheck the live admin-backed pages rather than only the public API.
+
+## Failed Migration Recovery
+
+Start with the least destructive path.
+
+- inspect gateway logs
+- run the explicit migrate command against the active config:
+
+```bash
+mise run gateway-migrate
+```
+
+- confirm the database URL points at the intended backend
+- confirm the process did not start with migrations disabled
+
+Pre-v1 migration flattening is still pending. That follow-up is tracked in [issue #44](https://github.com/ahstn/oceans-llm/issues/44).
+
+If the environment is disposable pre-v1 state, recreation can be safer than manual repair. If the environment is not disposable, stop and inspect the migration error before retrying.
+
+## Broken Admin Login
+
+Work through these checks in order:
+
+- confirm `/admin` is being served through the gateway, not only through the UI server on `:3001`
+- confirm bootstrap admin is enabled in the active config if this is a fresh environment
+- confirm the bootstrap admin command against the active config:
+
+```bash
+mise run gateway-bootstrap-admin
+```
+
+- confirm the expected first-login rule
+  - local config does not force password rotation
+  - production-shaped local config does force password rotation
+- confirm the session is not simply expired or stale
+
+If the environment relies on OIDC, also review [oidc-and-sso-status.md](oidc-and-sso-status.md). The current OIDC flow is still development-style.
+
+## Provider Auth Failure
+
+Provider auth failures usually come from config shape or missing secrets.
+
+- confirm the provider exists in the active config
+- confirm the secret references resolve in the runtime environment
+- confirm `openai_compat` providers have a supported `pricing_provider_id`
+- confirm Vertex routes use `<publisher>/<model_id>` in `upstream_model`
+- confirm the route is enabled and has positive weight
+- confirm the model is not only visible in `/v1/models`, but actually viable for the requested operation
+
+If the symptom is “model is visible but fails,” follow [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md).
+
+## Missing OTLP Collector
+
+The checked-in deploy path does not ship a collector by default.
+
+If OTLP export is configured but no collector is reachable:
+
+- inspect gateway startup logs
+- confirm `server.otel_endpoint` and `server.otel_metrics_endpoint`
+- confirm the collector address is reachable from the gateway container
+- decide whether the environment should:
+  - wire a real collector, or
+  - run without one and rely on logs plus request-log storage
+
+The request-log admin APIs can still work without a collector. OTLP export and request-log persistence are related, but they are not the same dependency.
+
+## Secret Rotation Checkpoints
+
+When rotating secrets, check the dependent path instead of rotating blindly.
+
+### Gateway API key
+
+- update the config source
+- restart or reseed as needed
+- verify `/v1/models` with the new key
+- verify the old key fails if revocation was intended
+
+### Bootstrap admin password
+
+- rotate through the admin UI or the normal auth flow
+- confirm the new password works
+- confirm the old password does not
+
+### Provider token or service account
+
+- update the runtime secret source
+- restart or reload the affected service path
+- run one live request through the affected provider
+- confirm request logs show the expected provider key
+
+## What This Page Does Not Own
+
+- compose file syntax: [../deploy/README.md](../deploy/README.md)
+- startup and first-access rules: [runtime-bootstrap-and-access.md](runtime-bootstrap-and-access.md)
+- topology and same-origin contract: [deploy-and-operations.md](deploy-and-operations.md)
+- identity lifecycle rules: [identity-and-access.md](identity-and-access.md)
+- request-log payload policy: [observability-and-request-logs.md](observability-and-request-logs.md)

--- a/docs/pricing-catalog-and-accounting.md
+++ b/docs/pricing-catalog-and-accounting.md
@@ -1,55 +1,58 @@
 # Pricing Catalog and Accounting
 
-`Owns`: pricing catalog sources, effective-dated pricing rows, pricing coverage limits, and unpriced-accounting behavior.
+`Owns`: pricing catalog source layers, effective-dated pricing rows, exact-only coverage limits, and `unpriced` accounting behavior.
 `Depends on`: [configuration-reference.md](configuration-reference.md), [data-relationships.md](data-relationships.md)
-`See also`: [budgets-and-spending.md](budgets-and-spending.md), [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md), [adr/2026-03-06-hybrid-pricing-catalog.md](adr/2026-03-06-hybrid-pricing-catalog.md)
+`See also`: [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md), [budgets-and-spending.md](budgets-and-spending.md), [adr/2026-03-06-hybrid-pricing-catalog.md](adr/2026-03-06-hybrid-pricing-catalog.md)
 
 This page explains how the gateway turns provider usage into durable pricing records and why some successful requests are intentionally not charged.
 
 ## Source of Truth
 
-- Pricing resolution and refresh logic: [../crates/gateway-service/src/pricing_catalog.rs](../crates/gateway-service/src/pricing_catalog.rs)
-- Spend ledger writes: [../crates/gateway-service/src/service.rs](../crates/gateway-service/src/service.rs)
-- Cache and pricing-row persistence:
+- pricing resolution and refresh logic:
+  - [../crates/gateway-service/src/pricing_catalog.rs](../crates/gateway-service/src/pricing_catalog.rs)
+- spend ledger writes:
+  - [../crates/gateway-service/src/service.rs](../crates/gateway-service/src/service.rs)
+- cache and pricing-row persistence:
   - [../crates/gateway-store/src/libsql_store/pricing_catalog.rs](../crates/gateway-store/src/libsql_store/pricing_catalog.rs)
   - [../crates/gateway-store/src/postgres_store/pricing_catalog.rs](../crates/gateway-store/src/postgres_store/pricing_catalog.rs)
-- Vendored fallback snapshot: [../crates/gateway-service/data/pricing_catalog_fallback.json](../crates/gateway-service/data/pricing_catalog_fallback.json)
+- vendored fallback snapshot:
+  - [../crates/gateway-service/data/pricing_catalog_fallback.json](../crates/gateway-service/data/pricing_catalog_fallback.json)
 
 ## Catalog Layers
 
-The runtime does not price directly from a live remote response on every request. It uses a layered model:
+The runtime does not price directly from a live remote response on every request.
+
+It uses three layers:
 
 1. vendored normalized fallback snapshot in the repo
 2. cached normalized remote snapshot in `pricing_catalog_cache`
-3. effective-dated `model_pricing` rows used for historical pricing lookup at request time
+3. effective-dated `model_pricing` rows used for historical lookup
 
-That split is why past spend totals remain stable when the upstream catalog changes later.
+That split keeps historical spend totals stable after an upstream catalog changes.
 
-## Upstream Source And Refresh
+## Upstream Source and Refresh
 
-Current pricing input is normalized from `models.dev`.
+Current normalized pricing input comes from `models.dev`.
 
 Operational shape:
 
 - the runtime can refresh pricing metadata from the upstream feed
 - cached snapshots are persisted in `pricing_catalog_cache`
-- the vendored fallback keeps the repo bootstrappable even when the remote source is unavailable
+- the vendored fallback keeps the repo bootstrappable when the remote source is unavailable
 
-The cache is an input to pricing maintenance. The durable pricing source for historical charging is `model_pricing`.
+The durable historical charging source is still `model_pricing`, not the cache row.
 
 ## Historical Pricing Contract
 
 Pricing is effective-dated.
 
-At request time, the gateway resolves a pricing row and copies pricing provenance into `usage_cost_events`, including:
+At request time, the gateway resolves one pricing row and copies provenance into `usage_cost_events`, including:
 
 - `pricing_row_id`
 - `pricing_provider_id`
 - `pricing_model_id`
 - copied rate fields
 - pricing source metadata
-
-This is the mechanism that keeps historical ledger math stable.
 
 ## Supported Pricing Paths
 
@@ -64,50 +67,46 @@ Known coverage constraint:
 
 - Anthropic-on-Vertex pricing is only supported for `location=global`
 
-## Why Requests Become Unpriced
+## Why Requests Become `unpriced`
 
 A request can succeed and still become `unpriced`.
 
-Current important causes include:
+Common causes:
 
 - missing provider pricing source
 - unsupported `pricing_provider_id`
 - unknown pricing model id
 - unsupported Vertex publisher family
 - unsupported Vertex location
-- unsupported billing modifiers such as `service_tier` / `serviceTier`
+- unsupported billing modifiers such as `service_tier`
 - missing exact input or output rate coverage
 
-This is fail-closed accounting behavior. The runtime prefers an explicit `unpriced` row over approximate billing.
+This is fail-closed accounting behavior. Approximate billing is intentionally avoided in this slice.
 
-## `usage_missing` vs `unpriced`
+## `usage_missing` Versus `unpriced`
 
-- `usage_missing`: provider usage could not be normalized
-- `unpriced`: usage exists, but exact pricing could not be resolved safely
+- `usage_missing`
+  - provider usage could not be normalized
+- `unpriced`
+  - usage exists, but exact pricing could not be resolved safely
 
-Both states are visible in reporting, but neither counts toward spend totals or hard-limit windows.
+Both states stay visible in reporting, but neither counts toward spend totals or hard-limit windows.
 
-That means operators can see successful requests with zero charged spend without assuming the request was dropped.
+## Relationship to Request Flow
 
-## Relationship To Routing
-
-Route choice affects accounting, not just provider execution.
-
-Important examples:
+Route choice affects accounting, not only provider execution.
 
 - the chosen provider decides the pricing family
-- the chosen upstream model decides the exact pricing lookup key
-- route/request modifiers can intentionally make a request unpriced
+- the chosen upstream model decides the exact lookup key
+- route or request modifiers can make a request become `unpriced`
 
-For request resolution behavior, see [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md).
+Use [request-lifecycle-and-failure-modes.md](request-lifecycle-and-failure-modes.md) for the full cause-and-effect path.
 
-## Relationship To Budgets
+## Relationship to Budgets
 
 Budget enforcement only uses priced totals.
-
-That means:
 
 - `priced` and `legacy_estimated` rows count
 - `unpriced` and `usage_missing` rows do not count
 
-Budget-window and admin API behavior is owned by [budgets-and-spending.md](budgets-and-spending.md).
+Use [budgets-and-spending.md](budgets-and-spending.md) for budget windows and spend APIs.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,30 +1,39 @@
 # Release Process
 
-`Owns`: maintainer release workflow, local release task behavior, and tag-triggered CI release distribution.
+`Owns`: the maintainer release workflow, the local release task behavior, and the tag-triggered CI release distribution flow.
 `Depends on`: [../CONTRIBUTING.md](../CONTRIBUTING.md)
-`See also`: [deploy-and-operations.md](deploy-and-operations.md), [adr/2026-03-06-release-versioning-and-ghcr-publishing.md](adr/2026-03-06-release-versioning-and-ghcr-publishing.md), [../mise.toml](../mise.toml), [../.github/workflows/release.yml](../.github/workflows/release.yml)
+`See also`: [deploy-and-operations.md](deploy-and-operations.md), [operator-runbooks.md](operator-runbooks.md), [adr/2026-03-06-release-versioning-and-ghcr-publishing.md](adr/2026-03-06-release-versioning-and-ghcr-publishing.md), [../mise.toml](../mise.toml), [../.github/workflows/release.yml](../.github/workflows/release.yml)
 
-This page is the canonical maintainer-facing release runbook.
+This page is the maintainer-facing release runbook.
 
 ## Source of Truth
 
-- local task: [../mise.toml](../mise.toml)
-- release workflow: [../.github/workflows/release.yml](../.github/workflows/release.yml)
-- changelog config: [../cliff.toml](../cliff.toml)
+- local release task:
+  - [../mise.toml](../mise.toml)
+- release workflow:
+  - [../.github/workflows/release.yml](../.github/workflows/release.yml)
+- changelog config:
+  - [../cliff.toml](../cliff.toml)
+
+## Release Preflight
+
+Before `mise run release`, confirm:
+
+- `main` is up to date locally
+- the intended release state is already merged
+- normal CI is green for that commit
+- generated admin contract artifacts are current
+- changelog-worthy commits are in the expected shape
+
+The tag workflow is distribution, not the quality gate.
 
 ## Current Release Flow
 
-1. Update `main` locally and confirm the intended release state.
-2. Run `mise run release`.
-3. Review the generated release commit, tag, changelog, and GitHub release draft state.
-4. Push the release commit and tag.
-5. Let the tag-triggered GitHub Actions workflow build and publish images.
-
-Important current reality:
-
-- `mise run release` creates the version bump, changelog, and GitHub release metadata locally
-- the task does not push for you
-- the maintainer is the gate between local release authoring and public CI distribution
+1. update `main` locally
+2. run `mise run release`
+3. review the generated release commit, tag, changelog, and GitHub release draft state
+4. push the release commit and tag
+5. let the tag-triggered GitHub Actions workflow build and publish images
 
 ## What `mise run release` Does
 
@@ -35,7 +44,7 @@ Current task steps:
 3. `gh release create v$(cog get-version) ...`
 4. `cargo release version $(cog get-version) --execute`
 
-That means the task creates release metadata and Cargo version updates locally before any push happens.
+That means release metadata and version updates are authored locally before any push happens.
 
 ## What GitHub Actions Does
 
@@ -46,22 +55,28 @@ Current workflow responsibilities:
 - build and publish the gateway image
 - build and publish the admin UI image
 - attest image provenance
-- publish/update the GitHub release for the tag
+- publish or update the GitHub release for the tag
 
 ## Current Image Reality
 
 The workflow is not symmetric across both deployables today:
 
-- gateway image: `linux/amd64`
-- admin UI image: `linux/amd64` and `linux/arm64`
+- gateway image:
+  - `linux/amd64`
+- admin UI image:
+  - `linux/amd64`
+  - `linux/arm64`
 
-Current workflow tags:
+## Post-Release Verification
 
-- `vX.Y.Z`
-- `sha-<fullsha>`
-- `latest`
+After the workflow finishes, verify:
 
-Floating `X.Y` tags are not part of the current live workflow.
+- the GitHub release exists for the pushed tag
+- the expected image tags were published
+- the release notes look sane
+- the deploy docs still match the image reality
+
+If the release changed operator-visible behavior, update the canonical docs in the same pass.
 
 ## CI Responsibility Boundary
 
@@ -70,11 +85,5 @@ The release workflow does not explicitly depend on prior CI runs.
 In practice:
 
 - maintainers are responsible for cutting releases from a known-good state
-- normal CI workflows are the preflight signal
-- the tag-triggered workflow is the distribution step, not the quality gate
-
-## When To Update Other Docs
-
-- if workflow mechanics change, update this page first
-- if release philosophy changes, update the ADR and link back here
-- if deploy topology changes, update [deploy-and-operations.md](deploy-and-operations.md), not this page
+- normal CI is the preflight signal
+- tag CI is the distribution step

--- a/docs/request-lifecycle-and-failure-modes.md
+++ b/docs/request-lifecycle-and-failure-modes.md
@@ -1,0 +1,162 @@
+# Request Lifecycle and Failure Modes
+
+`Owns`: the end-to-end request path from authenticated `/v1/*` calls to route choice, provider execution, request logging, pricing, ledger writes, and budget effects.
+`Depends on`: [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md), [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md), [budgets-and-spending.md](budgets-and-spending.md), [observability-and-request-logs.md](observability-and-request-logs.md)
+`See also`: [configuration-reference.md](configuration-reference.md), [identity-and-access.md](identity-and-access.md), [data-relationships.md](data-relationships.md), [adr/2026-03-15-v1-runtime-simplification.md](adr/2026-03-15-v1-runtime-simplification.md)
+
+This page is the cross-cutting view. Neighboring docs own their own policy slices. This page explains how those slices connect during one request.
+
+## Source of Truth
+
+- HTTP handlers: [../crates/gateway/src/http/handlers.rs](../crates/gateway/src/http/handlers.rs)
+- Model access and tag selection: [../crates/gateway-service/src/model_access.rs](../crates/gateway-service/src/model_access.rs)
+- Alias resolution: [../crates/gateway-service/src/model_resolution.rs](../crates/gateway-service/src/model_resolution.rs)
+- Route planning: [../crates/gateway-service/src/route_planner.rs](../crates/gateway-service/src/route_planner.rs)
+- Budget enforcement: [../crates/gateway-service/src/budget_guard.rs](../crates/gateway-service/src/budget_guard.rs)
+- Pricing resolution: [../crates/gateway-service/src/pricing_catalog.rs](../crates/gateway-service/src/pricing_catalog.rs)
+- Request logging: [../crates/gateway-service/src/request_logging.rs](../crates/gateway-service/src/request_logging.rs)
+- Ledger writes: [../crates/gateway-service/src/service.rs](../crates/gateway-service/src/service.rs)
+
+## Request Path
+
+The live request path is single-route in this slice.
+
+1. The gateway authenticates the API key.
+2. The allowed gateway model set is reduced by API-key grants and any user or team allowlists.
+3. The requested model is resolved.
+   - A concrete model key stays concrete.
+   - A `tag:` selector picks one allowed gateway model.
+   - An alias resolves to a canonical execution model.
+4. The route planner builds an ordered route list.
+   - Lower `priority` wins first.
+   - `weight` only matters inside the same priority bucket.
+   - Disabled routes and non-positive weights drop out.
+5. Capability filtering removes routes that cannot satisfy the request.
+6. The budget guard runs before provider execution.
+7. The first eligible route executes.
+8. Request logs are written for the user-visible outcome.
+9. Usage is normalized when possible.
+10. Pricing is resolved exactly or the request is marked `unpriced`.
+11. A ledger row is written when the request has usable usage data.
+12. Post-provider budget math runs before the priced ledger row is committed.
+
+## Worked Example
+
+One common request path looks like this:
+
+- Request:
+  - `POST /v1/chat/completions`
+  - API key belongs to team `growth`
+  - model is `tag:fast`
+- Access:
+  - the API key grant allows `gpt-4o-mini` and `claude-3-5-haiku`
+  - the team allowlist is unrestricted
+- Resolution:
+  - `tag:fast` resolves to gateway model `gpt-4o-mini`
+  - `gpt-4o-mini` is an alias of `openai-gpt-4o-mini`
+- Planning:
+  - `openai-gpt-4o-mini` has two routes in config
+  - route A has priority `50`
+  - route B has priority `100`
+  - route A wins before weight is considered
+- Capability filter:
+  - the request asks for plain chat, no tools, no vision
+  - route A stays eligible
+- Execution:
+  - the provider request goes to the route A provider and upstream model
+- Logging:
+  - `request_logs.model_key` stores `gpt-4o-mini`
+  - `request_logs.resolved_model_key` stores `openai-gpt-4o-mini`
+  - `request_logs.provider_key` stores the route A provider id
+- Accounting:
+  - usage is normalized
+  - pricing resolves exactly
+  - `usage_cost_events.pricing_status` becomes `priced`
+  - the team budget window includes the charge
+
+## Model Visibility Versus Execution
+
+A model can be visible and still fail at runtime.
+
+- `/v1/models` shows grant-visible gateway identities.
+- `/v1/models` does not promise that a route is executable right now.
+- Route viability still depends on:
+  - provider existence
+  - route `enabled`
+  - positive weight
+  - capability match
+  - pricing readiness, if spend accuracy matters for the request path
+
+This is why a model can appear in `/v1/models` and still fail with `invalid_request` or `no_routes_available`.
+
+## Failure Classes
+
+These failures look similar from far away, but they mean different things.
+
+### `invalid_request`
+
+- The model resolved.
+- Capability filtering removed every remaining route.
+- Common causes:
+  - embeddings against a chat-only route
+  - tools against a route with tools disabled
+  - vision against a route that does not advertise vision
+
+### `no_routes_available`
+
+- The model exists.
+- No usable route survived provider and route-viability checks.
+- Common causes:
+  - missing provider id in the live config
+  - all routes disabled
+  - all routes have non-positive weight
+
+### `unpriced`
+
+- The provider request succeeded.
+- Usage exists.
+- Exact pricing could not be resolved.
+- Common causes:
+  - unsupported `pricing_provider_id`
+  - unsupported Vertex publisher or location
+  - unsupported billing modifiers
+  - missing exact rate coverage
+
+`unpriced` requests stay visible in reports but do not count toward budget totals.
+
+### `usage_missing`
+
+- The provider request succeeded.
+- Usage could not be normalized into the gateway accounting model.
+- The request log still records the user-visible outcome.
+- The ledger row stays visible, but it does not count toward spend totals.
+
+## Logging and Ledger Boundaries
+
+Request logs and spend rows are related, but they are not the same object.
+
+- `request_logs` owns the user-visible request outcome.
+- `request_log_payloads` owns sanitized request and response bodies.
+- `usage_cost_events` owns spend enforcement and spend reporting.
+
+That separation matters in two common cases:
+
+- a request can be logged even when it becomes `unpriced`
+- a request can be logged even when a later accounting step hits a rough edge
+
+## Known Rough Edges
+
+- Stream and non-stream chat paths still differ when a post-provider ledger write fails.
+- Request-log payload policy is still bounded and heuristic, not operator-configurable.
+- Provider-attempt and fallback-style metrics are intentionally narrow in this slice.
+
+For the current observability cleanup notes, see [observability-and-request-logs.md](observability-and-request-logs.md).
+
+## What This Page Does Not Own
+
+- config field syntax and validation: [configuration-reference.md](configuration-reference.md)
+- identity and ownership policy: [identity-and-access.md](identity-and-access.md)
+- route-planning contract and endpoint behavior: [model-routing-and-api-behavior.md](model-routing-and-api-behavior.md)
+- exact pricing coverage rules: [pricing-catalog-and-accounting.md](pricing-catalog-and-accounting.md)
+- budget windows and spend APIs: [budgets-and-spending.md](budgets-and-spending.md)
+- request-log storage and payload policy: [observability-and-request-logs.md](observability-and-request-logs.md)

--- a/docs/runtime-bootstrap-and-access.md
+++ b/docs/runtime-bootstrap-and-access.md
@@ -1,0 +1,157 @@
+# Runtime Bootstrap and Access
+
+`Owns`: startup behavior, first-access behavior, bootstrap admin rules, seeded API-key rules, and the difference between local dev, production-shaped local runs, and compose deploys.
+`Depends on`: [configuration-reference.md](configuration-reference.md), [identity-and-access.md](identity-and-access.md)
+`See also`: [../README.md](../README.md), [../deploy/README.md](../deploy/README.md), [deploy-and-operations.md](deploy-and-operations.md), [operator-runbooks.md](operator-runbooks.md)
+
+This page explains what the gateway does when it starts and what access exists right after boot.
+
+## Source of Truth
+
+- CLI entry points: [../crates/gateway/src/main.rs](../crates/gateway/src/main.rs)
+- Startup scripts: [../scripts/start-dev-stack.sh](../scripts/start-dev-stack.sh), [../scripts/start-prod.sh](../scripts/start-prod.sh)
+- Runtime commands: [../mise.toml](../mise.toml)
+- Checked-in configs: [../gateway.yaml](../gateway.yaml), [../gateway.prod.yaml](../gateway.prod.yaml), [../deploy/config/gateway.yaml](../deploy/config/gateway.yaml)
+
+## Startup Actions
+
+The normal startup path is `gateway serve`.
+
+At startup, the gateway can do three separate things:
+
+- run migrations
+- seed config-backed objects such as providers, models, and seed API keys
+- ensure a bootstrap admin exists
+
+Those actions are controlled by:
+
+- `GATEWAY_RUN_MIGRATIONS`
+- `GATEWAY_SEED_CONFIG`
+- `GATEWAY_BOOTSTRAP_ADMIN`
+
+The same behavior is also exposed through explicit commands:
+
+- `gateway migrate`
+- `gateway seed-config`
+- `gateway bootstrap-admin`
+
+## Startup Shapes
+
+### Local development
+
+- config: [../gateway.yaml](../gateway.yaml)
+- database: libsql or SQLite
+- usual entry point: [../scripts/start-dev-stack.sh](../scripts/start-dev-stack.sh)
+- bootstrap admin: enabled
+- forced password change: off
+- seed API keys: driven by config
+
+What exists after boot:
+
+- a gateway on `http://localhost:8080`
+- an admin UI at `http://localhost:8080/admin`
+- a bootstrap admin at `admin@local` with password `admin`
+
+### Production-shaped local run
+
+- config: [../gateway.prod.yaml](../gateway.prod.yaml)
+- database: PostgreSQL
+- usual entry point: [../scripts/start-prod.sh](../scripts/start-prod.sh)
+- bootstrap admin: enabled
+- forced password change: on
+- seed API keys: driven by config
+
+What exists after boot:
+
+- the same admin email and password as the local-dev config
+- a forced password rotation on first sign-in
+- a runtime shape closer to deploy and release behavior
+
+### GHCR compose deploy
+
+- compose entry point: [../deploy/compose.yaml](../deploy/compose.yaml)
+- mounted config: [../deploy/config/gateway.yaml](../deploy/config/gateway.yaml)
+- database: PostgreSQL
+- bootstrap admin: not defined in the checked-in deploy config
+- seeded API key: defined through `GATEWAY_API_KEY`
+
+What exists after boot:
+
+- API access through the seeded gateway API key
+- no checked-in bootstrap admin guarantee
+- admin access only if the mounted runtime config enables bootstrap admin or a prior admin already exists
+
+## Bootstrap Admin
+
+Bootstrap admin creation is for control-plane access.
+
+- It is separate from seeded API keys.
+- It is checked at startup when bootstrap behavior is enabled.
+- It can also be created with `gateway bootstrap-admin`.
+
+Checked-in defaults:
+
+- local config keeps the bootstrap admin on and does not force password rotation
+- production-shaped local config keeps the bootstrap admin on and forces password rotation
+
+For the lifecycle and ownership rules after that first sign-in, see [identity-and-access.md](identity-and-access.md).
+
+## Seeded API Keys
+
+Seeded API keys are for data-plane access.
+
+- They come from the config seed path.
+- They are useful for deploy-style automation and test-style setup.
+- They do not replace admin login.
+
+The compose deploy path leans on this seeded-key behavior more than bootstrap-admin behavior.
+
+## First Access Checklist
+
+The right first-access path depends on the runtime shape.
+
+### Local development
+
+- open `/admin`
+- sign in with `admin@local` / `admin`
+- inspect live admin-backed pages
+
+### Production-shaped local run
+
+- open `/admin`
+- sign in with `admin@local` / `admin`
+- rotate the password when prompted
+- confirm provider secrets and Postgres connectivity
+
+### Compose deploy
+
+- confirm the stack is healthy
+- confirm the seeded API key exists and works for `/v1/*`
+- confirm whether admin bootstrap is enabled in the mounted config before assuming `/admin` is usable
+
+## Startup Paths That Are Easy To Confuse
+
+These behaviors are easy to blur together:
+
+- `seed-config` creates config-backed runtime objects
+- `bootstrap-admin` creates control-plane access
+- `serve` can do both, but only when the related switches are on
+
+That means one environment can have:
+
+- valid API access but no admin login
+- valid admin login but no seeded gateway key
+- both
+- neither, if the startup toggles are disabled and the database is empty
+
+## Current Gaps
+
+- Declarative users, teams, and budgets are not part of the config contract yet. That future direction is tracked in [issue #64](https://github.com/ahstn/oceans-llm/issues/64) and [issue #65](https://github.com/ahstn/oceans-llm/issues/65).
+- Compose deploy does not ship a checked-in bootstrap-admin block by default.
+
+## What This Page Does Not Own
+
+- config field syntax and examples: [configuration-reference.md](configuration-reference.md)
+- deploy topology and runtime caveats: [deploy-and-operations.md](deploy-and-operations.md)
+- step-by-step recovery and upgrade actions: [operator-runbooks.md](operator-runbooks.md)
+- user lifecycle, onboarding, and OIDC policy: [identity-and-access.md](identity-and-access.md)

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,10 @@ prek = "latest"
 description = "Install or update tool versions from mise.toml"
 run = "mise install"
 
+[tasks.docs-check]
+description = "Validate markdown links and required docs graph headers"
+run = "./scripts/docs-check.sh"
+
 [tasks.fmt]
 description = "Format Rust sources"
 run = "cargo fmt --all"

--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+node <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = process.cwd();
+const crossCuttingPages = new Set([
+  "docs/request-lifecycle-and-failure-modes.md",
+  "docs/runtime-bootstrap-and-access.md",
+  "docs/operator-runbooks.md",
+  "docs/oidc-and-sso-status.md",
+  "docs/admin-api-contract-workflow.md",
+]);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(full));
+    } else if (entry.isFile() && full.endsWith(".md")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+const files = [
+  path.join(repoRoot, "README.md"),
+  path.join(repoRoot, "CONTRIBUTING.md"),
+  path.join(repoRoot, "deploy/README.md"),
+  ...walk(path.join(repoRoot, "docs")),
+];
+
+const canonicalDocs = fs
+  .readdirSync(path.join(repoRoot, "docs"), { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+  .map((entry) => path.join(repoRoot, "docs", entry.name));
+
+const errors = [];
+
+function rel(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+for (const filePath of files) {
+  const text = fs.readFileSync(filePath, "utf8");
+  const linkRegex = /\[[^\]]+\]\(([^)]+)\)/g;
+  let match;
+  while ((match = linkRegex.exec(text)) !== null) {
+    const rawTarget = match[1].trim();
+    if (
+      rawTarget.startsWith("http://") ||
+      rawTarget.startsWith("https://") ||
+      rawTarget.startsWith("mailto:") ||
+      rawTarget.startsWith("#")
+    ) {
+      continue;
+    }
+    const target = rawTarget.split("#")[0];
+    if (!target) {
+      continue;
+    }
+    const resolved = path.resolve(path.dirname(filePath), target);
+    if (!fs.existsSync(resolved)) {
+      errors.push(`${rel(filePath)} -> missing link target ${rawTarget}`);
+    }
+  }
+}
+
+for (const filePath of canonicalDocs) {
+  const text = fs.readFileSync(filePath, "utf8");
+  if (!/^`Owns`:/m.test(text)) {
+    errors.push(`${rel(filePath)} -> missing \`Owns\` header`);
+  }
+  if (!/^`Depends on`:/m.test(text)) {
+    errors.push(`${rel(filePath)} -> missing \`Depends on\` header`);
+  }
+  if (!/^`See also`:/m.test(text)) {
+    errors.push(`${rel(filePath)} -> missing \`See also\` header`);
+  }
+  if (crossCuttingPages.has(rel(filePath)) && !/^## What This Page Does Not Own$/m.test(text)) {
+    errors.push(`${rel(filePath)} -> missing "What This Page Does Not Own" section`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("docs-check failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`docs-check passed for ${files.length} markdown files.`);
+NODE


### PR DESCRIPTION
## Description

This PR hardens the repo documentation graph around an IA-first structure without adding docs-site tooling.

- Summary of changes
  - adds new canonical pages for startup and access, request lifecycle, operator runbooks, OIDC status, and the admin API contract workflow
  - rewrites the docs hub, top-level README, deploy README, and contributor guide so operator and maintainer paths stop blending together
  - slims the existing canonical guides so each page owns one policy surface and links outward for cross-cutting context
  - normalizes ADR backlinks with short current-state pointers to the live docs
  - adds `mise run docs-check` for docs-link and header validation

- Why this approach was chosen
  - the repo already had solid topic docs, but the missing layer was cross-cutting operator and maintainer context that previously lived in repo history or ADRs
  - keeping the pass Markdown-first avoids mixing content hardening with docs-site scaffolding

- How it works
  - shared context moved into a small set of new pages
  - existing docs now link to those owners instead of repeating the same explanation
  - `scripts/docs-check.sh` validates internal links and required docs-graph headers through `mise run docs-check`

- Risks, tradeoffs, and alternatives considered
  - this is a broad docs rewrite, so wording drift was the main risk; the new checker reduces broken-link and missing-header drift but does not judge prose quality
  - a separate provider-only doc was intentionally skipped to keep the graph smaller in this pass

- Additional context for reviewers
  - docs-only verification run: `mise run docs-check`
  - `mise run lint` and `mise run test` were not run because this PR does not change Rust or admin UI runtime behavior

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`
