### PR TITLE
docs(observability): codify issue-54 runtime contract

### DIFF
--- a/docs/adr/2026-03-31-chat-observability-hardening-and-stream-parse-contract.md
+++ b/docs/adr/2026-03-31-chat-observability-hardening-and-stream-parse-contract.md
@@ -1,0 +1,187 @@
+# ADR: Chat Observability Hardening and Incremental Stream-Parse Contract
+
+- Date: 2026-03-31
+- Status: Accepted
+- Related Issues:
+  - [#54](https://github.com/ahstn/oceans-llm/issues/54)
+  - [#49](https://github.com/ahstn/oceans-llm/issues/49)
+- Builds On:
+  - [2026-03-15-otlp-observability-and-request-log-payloads.md](2026-03-15-otlp-observability-and-request-log-payloads.md)
+  - [2026-03-15-v1-runtime-simplification.md](2026-03-15-v1-runtime-simplification.md)
+  - [2026-03-17-post-success-accounting-and-strict-request-log-lookups.md](2026-03-17-post-success-accounting-and-strict-request-log-lookups.md)
+
+## Current state
+
+- [../operations/observability-and-request-logs.md](../operations/observability-and-request-logs.md)
+- [../reference/request-lifecycle-and-failure-modes.md](../reference/request-lifecycle-and-failure-modes.md)
+- [../operations/budgets-and-spending.md](../operations/budgets-and-spending.md)
+
+## Context
+
+Issue [#54](https://github.com/ahstn/oceans-llm/issues/54) exposed two correctness problems in the chat runtime that mattered for operators, maintainers, and future architectural discipline:
+
+1. pre-provider budget rejection and provider execution were not described or measured as separate things,
+2. streamed request-log capture treated raw transport chunks as if they were already valid UTF-8 and complete SSE frames.
+
+Those problems were dangerous because they made the gateway look more reliable than it really was. A budget-rejected request could appear to have attempted provider execution, and a streamed response could appear successfully logged while silently dropping payload detail or retaining stale usage. Both outcomes undermine trust in observability, and observability is only valuable if operators can rely on it when the system is behaving badly.
+
+The earlier runtime work had already moved the codebase away from compatibility-era fallback behavior:
+
+- [2026-03-15-v1 runtime simplification](2026-03-15-v1-runtime-simplification.md) removed fallback-style request metadata and tightened the streaming contract.
+- [2026-03-15 OTLP observability and payload-backed request logs](2026-03-15-otlp-observability-and-request-log-payloads.md) established request logs and payloads as explicit runtime contracts instead of incidental handler side effects.
+- [2026-03-17 fail-open post-success accounting](2026-03-17-post-success-accounting-and-strict-request-log-lookups.md) clarified that user-visible success and downstream accounting integrity are different concerns.
+
+Issue [#54](https://github.com/ahstn/oceans-llm/issues/54) sat directly on top of those decisions. If left unresolved, it would have reintroduced the same class of problem in a subtler form: strict-looking runtime contracts implemented on top of chunk-local parsing and ambiguous metrics semantics.
+
+## Decision
+
+We make two architectural decisions for chat observability:
+
+### 1. Budget rejection is a request outcome, not a provider attempt
+
+Hard-limit enforcement that rejects a request before provider execution must be represented as a request-level outcome only.
+
+This means:
+
+- the budget guard runs before provider execution in [../../crates/gateway/src/http/handlers.rs](../../crates/gateway/src/http/handlers.rs),
+- a `budget_exceeded` rejection returns `429` and stops before any provider call,
+- observability records that path as a bounded request outcome such as `budget_error`,
+- we do not keep or reintroduce compatibility shims that imply a provider attempt happened when it did not.
+
+Why:
+
+- “provider attempted” and “request rejected before provider” are different operational facts,
+- conflating them damages metric integrity and makes dashboards harder to trust,
+- strict sequencing in the handler is simpler than compensating later with special-case corrections.
+
+### 2. Stream payload capture is incremental and protocol-aware, not chunk-local
+
+Streamed chat request logging must parse the upstream stream as an SSE protocol stream, not as independent transport chunks.
+
+This means:
+
+- UTF-8 is reassembled across chunk boundaries,
+- SSE frames are reassembled across chunk boundaries,
+- both `data:` and `data: ` forms are accepted,
+- incomplete UTF-8 or incomplete final SSE frames are treated as parse failure,
+- the latest coherent `usage` snapshot wins instead of the first snapshot winning forever.
+
+The core implementation lives in:
+
+- shared SSE parsing: [../../crates/gateway-core/src/streaming.rs](../../crates/gateway-core/src/streaming.rs)
+- request-log stream collection: [../../crates/gateway-service/src/request_logging.rs](../../crates/gateway-service/src/request_logging.rs)
+- chat handler integration: [../../crates/gateway/src/http/handlers.rs](../../crates/gateway/src/http/handlers.rs)
+
+Why:
+
+- transport chunk boundaries are not protocol boundaries,
+- relying on chunk alignment is a hidden fallback that only “works” when upstream behavior happens to be convenient,
+- keeping the latest usage snapshot matches how providers often emit interim then final totals,
+- moving the parser into shared core code prevents divergent stream-parsing rules between providers, handlers, and request logging.
+
+## How It Was Implemented
+
+### Handler sequencing
+
+The chat handler in [../../crates/gateway/src/http/handlers.rs](../../crates/gateway/src/http/handlers.rs):
+
+- resolves routing first,
+- constructs bounded request labels,
+- enforces pre-provider budget policy before the provider is called,
+- records a request outcome immediately on budget rejection.
+
+This is the important architectural boundary: once the provider execution path begins, the request has crossed into a different phase of the lifecycle. Before that point, the runtime should not emit signals that imply provider work occurred.
+
+### Shared SSE parsing in gateway-core
+
+The parser in [../../crates/gateway-core/src/streaming.rs](../../crates/gateway-core/src/streaming.rs) now owns:
+
+- split UTF-8 reassembly,
+- split SSE frame reassembly,
+- delimiter handling across `\n\n`, `\r\n\r\n`, and `\r\r`,
+- acceptance of both `data:` and `data: ` line forms,
+- explicit finalization errors for incomplete UTF-8 or incomplete terminal events.
+
+This intentionally removes any need for handler-local or provider-local fallback parsing.
+
+### Request-log collector semantics
+
+The stream collector in [../../crates/gateway-service/src/request_logging.rs](../../crates/gateway-service/src/request_logging.rs):
+
+- consumes parsed SSE events instead of raw chunks,
+- stores the latest observed `usage` object,
+- records stream failure metadata when an error payload or parse failure appears,
+- produces a bounded, sanitized transcript payload for request-log storage.
+
+This keeps the request-log contract aligned with the actual stream protocol rather than with the transport layer.
+
+### Contract tests
+
+The behavior is covered in:
+
+- gateway integration tests in [../../crates/gateway/src/main.rs](../../crates/gateway/src/main.rs)
+- request-logging unit tests in [../../crates/gateway-service/src/request_logging.rs](../../crates/gateway-service/src/request_logging.rs)
+- shared streaming parser unit tests in [../../crates/gateway-core/src/streaming.rs](../../crates/gateway-core/src/streaming.rs)
+
+These tests cover:
+
+- budget rejection before provider execution,
+- request outcome recording for budget rejection,
+- split UTF-8 codepoints,
+- split SSE frames,
+- `data:` without a space,
+- latest-usage retention,
+- incomplete terminal frame handling.
+
+## Documentation Consequences
+
+The runtime behavior was already strict in code, but the docs needed to say that clearly.
+
+The canonical pages now describe:
+
+- budget rejection as a pre-provider `429 budget_exceeded` path,
+- observability request outcomes for budget rejection,
+- incremental stream parsing and latest-usage retention,
+- removal of fallback-era expectations from this code path.
+
+Canonical docs:
+
+- [../operations/observability-and-request-logs.md](../operations/observability-and-request-logs.md)
+- [../reference/request-lifecycle-and-failure-modes.md](../reference/request-lifecycle-and-failure-modes.md)
+- [../operations/budgets-and-spending.md](../operations/budgets-and-spending.md)
+
+We want future readers to learn the real contract from the docs, not from spelunking tests or reconstructing intent from issue threads.
+
+## Consequences
+
+Positive:
+
+- request outcomes and provider execution are no longer semantically conflated,
+- streamed request logs are more trustworthy under realistic network chunking,
+- the parser contract is shared instead of being reimplemented in multiple layers,
+- the docs now match the strict runtime behavior instead of hinting at legacy or fuzzy semantics.
+
+Tradeoffs:
+
+- malformed or incomplete upstream streams fail more explicitly,
+- the stream collector is more stateful than a naive chunk-by-chunk implementation,
+- operators must treat stream parse failures as real upstream/runtime integrity incidents rather than as ignorable logging noise.
+
+## What We Explicitly Rejected
+
+- Reintroducing provider-attempt or fallback-era compatibility metadata for pre-provider budget rejection.
+- Preserving chunk-local parsing with best-effort heuristics.
+- Keeping separate handler-local parsing rules alongside the shared parser.
+- Treating the first observed usage object as canonical when a later coherent total is available.
+
+Those would all preserve older, weaker patterns that make future maintenance harder.
+
+## Follow-up Work
+
+- Track and resolve the remaining post-provider stream versus non-stream rough edge in [#49](https://github.com/ahstn/oceans-llm/issues/49).
+- Consider whether additional dashboards or alerting should key directly off stream parse failures and budget-error outcomes.
+- Keep future observability changes routed through the shared parser and request-log lifecycle instead of adding new transport-local shortcuts.
+
+## Attribution
+
+This ADR was prepared through collaborative human + AI implementation and documentation work.

--- a/docs/operations/budgets-and-spending.md
+++ b/docs/operations/budgets-and-spending.md
@@ -47,6 +47,8 @@ Hard-limit behavior:
 
 - if projected spend in the active window would exceed the configured amount and `hard_limit = true`, the request fails with `budget_exceeded`
 - the HTTP status is `429`
+- the provider is not executed on this path
+- observability records the request as a budget rejection outcome instead of a provider execution
 
 ## Two-Phase Enforcement
 

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -35,12 +35,19 @@ The runtime emits bounded request-level signals for:
 
 - chat request totals
 - request latency
+- request outcomes
 - token totals
 - operational cost totals
 - usage-record totals by pricing status
 - caller request tags for filtering and attribution
 
 Request correlation is anchored on `x-request-id`.
+
+Request outcomes are emitted once per request with bounded labels. Important examples in this slice are:
+
+- `budget_error` for pre-provider hard-limit rejection
+- `invalid_request` for capability mismatch
+- `upstream_error` for upstream execution or stream failure
 
 ## Request Tagging Contract
 
@@ -85,6 +92,13 @@ The summary row stores:
 
 Streaming requests persist a bounded transcript payload rather than raw transport bytes.
 
+The stream payload contract is incremental rather than chunk-local:
+
+- UTF-8 is reassembled across transport chunk boundaries
+- SSE `data:` frames are reassembled across chunk boundaries
+- both `data:` and `data: ` forms are accepted
+- the latest coherent `usage` object is retained for request-log and ledger work
+
 ## Redaction and Truncation Boundaries
 
 Current redaction is key-driven and header-driven.
@@ -113,13 +127,12 @@ Recent cleanup changed the contract in a few important ways.
 - fallback-era request metadata is gone
 - missing request-log detail rows return strict `404 not_found`
 - stream payload parsing is more boundary-safe than the earlier chunk-by-chunk behavior
+- budget-rejected chat requests record a `budget_error` request outcome without executing the provider
 
 Operators and maintainers should stop expecting:
 
 - fallback metadata columns to appear in new request rows
 - nullable detail lookups for missing rows
-
-The remaining stream and ledger mismatch still lives in a smaller rough edge, not in the old fallback-era contract.
 
 ## Admin Observability APIs
 

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -31,6 +31,8 @@ The live request path is single-route in this slice.
    - Disabled routes and non-positive weights drop out.
 5. Capability filtering removes routes that cannot satisfy the request.
 6. The budget guard runs before provider execution.
+   - hard-limit rejection returns `429 budget_exceeded`
+   - no provider call occurs on this path
 7. The first eligible route executes.
 8. Request logs are written for the user-visible outcome.
 9. Usage is normalized when possible.
@@ -109,6 +111,13 @@ These failures look similar from far away, but they mean different things.
   - all routes disabled
   - all routes have non-positive weight
 
+### `budget_exceeded`
+
+- A pre-provider hard-limit check blocked the request.
+- The HTTP response is `429`.
+- No provider call occurs on this path.
+- Observability records this as a request outcome rather than as provider execution.
+
 ### `unpriced`
 
 - The provider request succeeded.
@@ -142,11 +151,12 @@ That separation matters in two common cases:
 - a request can be logged even when it becomes `unpriced`
 - a request can be logged even when a later accounting step hits a rough edge
 
+For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure.
+
 ## Known Rough Edges
 
 - Stream and non-stream chat paths still differ when a post-provider ledger write fails.
 - Request-log payload policy is still bounded and heuristic, not operator-configurable.
-- Provider-attempt and fallback-style metrics are intentionally narrow in this slice.
 
 For the current observability cleanup notes, see [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
 


### PR DESCRIPTION
## Description

Document the current chat observability contract around issue #54 and add an ADR that explains the architectural meaning of the stricter runtime behavior.

PR title format must follow Conventional Commits, for example `feat(gateway): add release workflow`.

Use this section for review hints, explanations, discussion points, and follow-up TODOs.

- Summary of changes
  - add an ADR for strict chat observability semantics and incremental stream parsing
  - update the canonical observability, request lifecycle, and budgets docs to match the current runtime contract
  - make the pre-provider `budget_exceeded` path explicit as a `429` request outcome that does not execute the provider
  - make the streamed request-log parsing contract explicit: incremental UTF-8/SSE parsing, `data:` and `data: ` acceptance, latest coherent usage snapshot wins
- Why this approach was chosen
  - issue #54 is already implemented in the runtime on `main`; the missing work in this session was making the contract durable and unambiguous for operators and future maintainers
  - this keeps the codebase strict instead of preserving fallback-era assumptions in docs and issue state
- How it works
  - the ADR links the decision back to `crates/gateway/src/http/handlers.rs`, `crates/gateway-core/src/streaming.rs`, `crates/gateway-service/src/request_logging.rs`, and the regression tests that cover the behavior
  - the docs now describe the actual runtime sequencing and stream-parse rules instead of implying older, looser semantics
- Risks, tradeoffs, and alternatives considered
  - the main risk was documenting behavior imprecisely; this PR reduces that risk rather than changing runtime behavior
  - I did not add compatibility wording or fallback explanations because those would preserve stale patterns we explicitly do not want to carry forward
- Additional context for reviewers
  - docs-only PR
  - related issue: #54
  - related follow-up rough edge still open separately: #49

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Docs verification run in this session:

- `mise run docs-verify`
