### PR TITLE
fix(admin-ui): restore upstream model column layout

### DIFF
--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -1,5 +1,15 @@
+import type { ReactNode } from 'react'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
-import { HomeIcon } from '@hugeicons/core-free-icons'
+import {
+  AttachmentIcon,
+  CodeIcon,
+  Copy01Icon,
+  HomeIcon,
+  LiveStreaming03Icon,
+  ToolsIcon,
+  VisionIcon,
+} from '@hugeicons/core-free-icons'
+import { toast } from 'sonner'
 
 import { BrandIcon } from '@/components/icons/brand-icon'
 import { AppIcon } from '@/components/icons/app-icon'
@@ -22,11 +32,24 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { requireAdminSession } from '@/routes/-admin-guard'
 import { getModels } from '@/server/admin-data.functions'
+import type { ModelView } from '@/types/api'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_PAGE_SIZE = 30
+
+const CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+})
+
+const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 2,
+})
 
 export const Route = createFileRoute('/models')({
   beforeLoad: ({ location }) => requireAdminSession(location),
@@ -53,16 +76,25 @@ export function ModelsPage() {
     })
   }
 
+  async function handleCopy(modelId: string) {
+    try {
+      await navigator.clipboard.writeText(modelId)
+      toast.success('Model ID copied')
+    } catch {
+      toast.error('Clipboard access failed')
+    }
+  }
+
   return (
-    <div className="flex flex-col gap-4">
-      <Card>
+    <div className="flex min-w-0 flex-col gap-4">
+      <Card className="min-w-0">
         <CardHeader>
           <CardTitle>Models</CardTitle>
           <CardDescription>
             Review routed models, upstream targets, and current health status.
           </CardDescription>
         </CardHeader>
-        <CardContent className="flex flex-col gap-4">
+        <CardContent className="flex min-w-0 flex-col gap-4 overflow-x-hidden">
           <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-[var(--color-text-muted)]">
             <span>
               Showing {modelPage.items.length} of {modelPage.total} models
@@ -72,164 +104,138 @@ export function ModelsPage() {
             </span>
           </div>
 
-          <div className="grid gap-4 lg:grid-cols-2">
-            {modelPage.items.length === 0 ? (
-              <Card className="lg:col-span-2">
-                <CardContent className="pt-5">
-                  <Empty>
-                    <EmptyHeader>
-                      <EmptyMedia variant="icon">
-                        <AppIcon icon={HomeIcon} size={22} stroke={1.5} />
-                      </EmptyMedia>
-                      <EmptyTitle>No models configured</EmptyTitle>
-                      <EmptyDescription>
-                        Add at least one routed model before sending traffic through the gateway.
-                      </EmptyDescription>
-                    </EmptyHeader>
-                    <EmptyContent />
-                  </Empty>
-                </CardContent>
-              </Card>
-            ) : (
-              <>
-                <div className="flex flex-col gap-4 lg:hidden" data-testid="models-mobile-list">
-                  {modelPage.items.map((model) => (
-                    <Card key={model.id}>
-                      <CardHeader className="gap-4">
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="flex min-w-0 items-start gap-3">
-                            <BrandIcon
-                              iconKey={model.model_icon_key}
-                              size={20}
-                              className="mt-0.5"
-                            />
-                            <div className="flex min-w-0 flex-col gap-1">
-                              <div className="flex flex-wrap items-center gap-2">
-                                <CardTitle>{model.id}</CardTitle>
-                                {model.alias_of ? (
-                                  <Badge>{`alias → ${model.alias_of}`}</Badge>
-                                ) : null}
-                              </div>
-                              <CardDescription className="flex flex-wrap items-center gap-2">
-                                <BrandIcon iconKey={model.provider_icon_key} size={14} />
-                                <span>
-                                  {model.provider_label ?? model.provider_key ?? 'Unresolved'}
-                                </span>
-                                {model.provider_key &&
-                                model.provider_label !== model.provider_key ? (
-                                  <span className="font-mono text-xs text-[var(--color-text-soft)]">
-                                    {model.provider_key}
-                                  </span>
-                                ) : null}
-                              </CardDescription>
-                            </div>
-                          </div>
-                          <Badge variant={modelStatusBadgeVariant(model.status)}>
-                            {model.status}
-                          </Badge>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="flex flex-col gap-3 text-sm text-[var(--color-text-muted)]">
-                        <p className="flex items-center gap-2">
-                          <span className="font-semibold text-[var(--color-text)]">Upstream:</span>
-                          <BrandIcon iconKey={model.model_icon_key} size={14} />
-                          <span>{model.upstream_model ?? 'Not currently routed'}</span>
-                        </p>
-                        {model.description ? <p>{model.description}</p> : null}
-                        <div className="flex flex-wrap gap-2 pt-1">
-                          {model.tags.map((tag) => (
-                            <Badge key={tag}>{tag}</Badge>
-                          ))}
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
+          {modelPage.items.length === 0 ? (
+            <Card>
+              <CardContent className="pt-5">
+                <Empty>
+                  <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                      <AppIcon icon={HomeIcon} size={22} stroke={1.5} />
+                    </EmptyMedia>
+                    <EmptyTitle>No models configured</EmptyTitle>
+                    <EmptyDescription>
+                      Add at least one routed model before sending traffic through the gateway.
+                    </EmptyDescription>
+                  </EmptyHeader>
+                  <EmptyContent />
+                </Empty>
+              </CardContent>
+            </Card>
+          ) : (
+            <>
+              <div className="grid gap-4 md:hidden" data-testid="models-mobile-list">
+                {modelPage.items.map((model) => (
+                  <ModelCard key={model.id} model={model} onCopy={handleCopy} />
+                ))}
+              </div>
 
-                <div className="hidden lg:col-span-2 lg:block">
-                  <Table className="min-w-[72rem] table-fixed" data-testid="models-desktop-table">
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="bg-card sticky left-0 z-20 w-[23rem] min-w-[23rem] px-4">
-                          Model ID
-                        </TableHead>
-                        <TableHead className="w-[14rem] px-4">Provider</TableHead>
-                        <TableHead className="w-[18rem] px-4">Upstream Model</TableHead>
-                        <TableHead className="w-[17rem] px-4">Description</TableHead>
-                        <TableHead className="w-[16rem] px-4">Tags</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {modelPage.items.map((model) => (
-                        <TableRow key={model.id}>
-                          <TableCell
-                            className="bg-card sticky left-0 z-10 px-4"
-                            data-testid={`models-desktop-cell-${model.id}`}
-                          >
-                            <div className="flex min-w-0 flex-col gap-2 py-1">
-                              <div className="flex min-w-0 items-center gap-3">
-                                <BrandIcon iconKey={model.model_icon_key} size={18} />
+              <div className="hidden min-w-0 md:block" data-testid="models-desktop-table">
+                <Table className="min-w-[82rem] table-fixed">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="bg-card sticky left-0 z-20 w-[16rem] min-w-[16rem] px-4">
+                        Model ID
+                      </TableHead>
+                      <TableHead className="w-[16rem] px-4">Upstream Model</TableHead>
+                      <TableHead className="w-[16rem] px-4">Provider</TableHead>
+                      <TableHead className="w-[12rem] px-4">Cost / 1M Tokens</TableHead>
+                      <TableHead className="w-[12rem] px-4">Context Window</TableHead>
+                      <TableHead className="w-[18rem] px-4">Capabilities</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {modelPage.items.map((model) => (
+                      <TableRow key={model.id} className="align-top">
+                        <TableCell
+                          className="bg-card sticky left-0 z-10 px-4 shadow-[8px_0_12px_-12px_rgba(0,0,0,0.8)]"
+                          data-testid={`models-desktop-cell-${model.id}`}
+                        >
+                          <div className="flex min-w-0 flex-col gap-2 py-1">
+                            <div className="flex min-w-0 items-start gap-3">
+                              <BrandIcon
+                                iconKey={model.model_icon_key}
+                                size={18}
+                                className="mt-0.5 shrink-0"
+                              />
+                              <div className="flex min-w-0 flex-col gap-2">
                                 <div className="flex min-w-0 items-center gap-2">
                                   <span className="truncate font-semibold text-[var(--color-text)]">
                                     {model.id}
                                   </span>
-                                  <Badge variant={modelStatusBadgeVariant(model.status)}>
-                                    {model.status}
-                                  </Badge>
+                                  <ModelStatusIndicator status={model.status} />
+                                  <Button
+                                    type="button"
+                                    size="icon-xs"
+                                    variant="ghost"
+                                    className="shrink-0"
+                                    aria-label={`Copy model ID ${model.id}`}
+                                    onClick={() => handleCopy(model.id)}
+                                  >
+                                    <AppIcon icon={Copy01Icon} size={14} stroke={1.5} />
+                                  </Button>
                                 </div>
+                                {model.alias_of ? (
+                                  <div>
+                                    <Badge variant="secondary">{`alias → ${model.alias_of}`}</Badge>
+                                  </div>
+                                ) : null}
                               </div>
-                              {model.alias_of ? (
-                                <div>
-                                  <Badge variant="secondary">{`alias → ${model.alias_of}`}</Badge>
-                                </div>
-                              ) : null}
                             </div>
-                          </TableCell>
-                          <TableCell className="px-4">
-                            <div className="flex min-w-0 flex-col gap-1 py-1">
-                              <div className="flex min-w-0 items-center gap-2">
-                                <BrandIcon iconKey={model.provider_icon_key} size={14} />
-                                <span className="truncate text-[var(--color-text)]">
-                                  {model.provider_label ?? model.provider_key ?? 'Unresolved'}
-                                </span>
-                              </div>
-                              {model.provider_key && model.provider_label !== model.provider_key ? (
-                                <span className="truncate font-mono text-xs text-[var(--color-text-soft)]">
-                                  {model.provider_key}
-                                </span>
-                              ) : null}
-                            </div>
-                          </TableCell>
-                          <TableCell className="px-4">
-                            <div className="flex min-w-0 items-center gap-2 py-1">
+                          </div>
+                        </TableCell>
+                        <TableCell className="px-4">
+                          <div className="flex min-w-0 flex-col gap-2 py-1">
+                            <div className="flex min-w-0 items-center gap-2">
                               <BrandIcon iconKey={model.model_icon_key} size={14} />
-                              <span className="truncate text-[var(--color-text-muted)]">
+                              <span className="truncate text-[var(--color-text)]">
                                 {model.upstream_model ?? 'Not currently routed'}
                               </span>
                             </div>
-                          </TableCell>
-                          <TableCell className="px-4">
-                            <p className="line-clamp-2 whitespace-normal py-1 text-[var(--color-text-muted)]">
-                              {model.description ?? 'No description provided.'}
-                            </p>
-                          </TableCell>
-                          <TableCell className="px-4">
-                            <div className="flex flex-wrap gap-2 py-1">
-                              {model.tags.length > 0 ? (
-                                model.tags.map((tag) => <Badge key={tag}>{tag}</Badge>)
-                              ) : (
-                                <span className="text-[var(--color-text-soft)]">No tags</span>
-                              )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="px-4">
+                          <div className="flex min-w-0 flex-col gap-2 py-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <BrandIcon iconKey={model.provider_icon_key} size={14} />
+                              <span className="truncate text-[var(--color-text)]">
+                                {providerTypeLabel(model)}
+                              </span>
                             </div>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              </>
-            )}
-          </div>
+                            {model.provider_key && model.provider_label !== model.provider_key ? (
+                              <span className="truncate font-mono text-xs text-[var(--color-text-soft)]">
+                                {model.provider_key}
+                              </span>
+                            ) : null}
+                          </div>
+                        </TableCell>
+                        <TableCell className="px-4 whitespace-normal">
+                          <StackedMetric
+                            topLabel="Input"
+                            topValue={formatCost(model.input_cost_per_million_tokens_usd_10000)}
+                            bottomLabel="Output"
+                            bottomValue={formatCost(model.output_cost_per_million_tokens_usd_10000)}
+                          />
+                        </TableCell>
+                        <TableCell className="px-4 whitespace-normal">
+                          <StackedMetric
+                            topLabel="Input"
+                            topValue={formatWindow(
+                              model.input_window_tokens ?? model.context_window_tokens,
+                            )}
+                            bottomLabel="Output"
+                            bottomValue={formatWindow(model.output_window_tokens)}
+                          />
+                        </TableCell>
+                        <TableCell className="px-4 whitespace-normal">
+                          <CapabilityBadges model={model} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
 
           <div className="flex items-center justify-end gap-2">
             <Button
@@ -255,8 +261,227 @@ export function ModelsPage() {
   )
 }
 
-function modelStatusBadgeVariant(status: string): 'success' | 'warning' {
-  return status === 'healthy' ? 'success' : 'warning'
+function ModelCard({ model, onCopy }: { model: ModelView; onCopy: (modelId: string) => void }) {
+  return (
+    <Card>
+      <CardHeader className="gap-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <BrandIcon iconKey={model.model_icon_key} size={20} className="mt-0.5" />
+            <div className="flex min-w-0 flex-col gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <CardTitle>{model.id}</CardTitle>
+                <ModelStatusIndicator status={model.status} />
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  aria-label={`Copy model ID ${model.id}`}
+                  onClick={() => onCopy(model.id)}
+                >
+                  <AppIcon icon={Copy01Icon} size={14} stroke={1.5} />
+                </Button>
+                {model.alias_of ? <Badge>{`alias → ${model.alias_of}`}</Badge> : null}
+              </div>
+              <CardDescription className="flex flex-wrap items-center gap-2">
+                <BrandIcon iconKey={model.provider_icon_key} size={14} />
+                <span>{providerTypeLabel(model)}</span>
+              </CardDescription>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 text-sm">
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+          <MetricDetail label="Resolved" value={model.resolved_model_key} />
+          <MetricDetail label="Provider ID" value={model.provider_key ?? '—'} mono />
+          <MetricDetail label="Upstream" value={model.upstream_model ?? 'Not currently routed'} />
+          <MetricDetail
+            label="Cost / 1M"
+            value={
+              <StackedMetric
+                topLabel="Input"
+                topValue={formatCost(model.input_cost_per_million_tokens_usd_10000)}
+                bottomLabel="Output"
+                bottomValue={formatCost(model.output_cost_per_million_tokens_usd_10000)}
+              />
+            }
+          />
+          <MetricDetail
+            label="Context Window"
+            value={
+              <StackedMetric
+                topLabel="Input"
+                topValue={formatWindow(model.input_window_tokens ?? model.context_window_tokens)}
+                bottomLabel="Output"
+                bottomValue={formatWindow(model.output_window_tokens)}
+              />
+            }
+          />
+          <MetricDetail label="Capabilities" value={<CapabilityBadges model={model} />} />
+        </dl>
+        <ModelNotes model={model} />
+      </CardContent>
+    </Card>
+  )
+}
+
+function MetricDetail({
+  label,
+  mono = false,
+  value,
+}: {
+  label: string
+  mono?: boolean
+  value: ReactNode
+}) {
+  return (
+    <div>
+      <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+        {label}
+      </dt>
+      <dd
+        className={
+          mono
+            ? 'font-mono text-xs text-[var(--color-text-muted)]'
+            : 'text-[var(--color-text-muted)]'
+        }
+      >
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function ModelStatusIndicator({ status }: { status: string }) {
+  const tone =
+    status === 'healthy' ? 'bg-emerald-500 shadow-emerald-500/30' : 'bg-amber-400 shadow-amber-400/30'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={status}
+          className={`inline-flex size-2.5 shrink-0 rounded-full shadow-[0_0_0_3px] ${tone}`}
+        />
+      </TooltipTrigger>
+      <TooltipContent sideOffset={6}>{status}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function ModelNotes({ model }: { model: ModelView }) {
+  if (!model.description && model.tags.length === 0) {
+    return <span className="text-[var(--color-text-soft)]">—</span>
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2 py-1">
+      {model.description ? (
+        <p className="line-clamp-2 whitespace-normal text-[var(--color-text-muted)]">
+          {model.description}
+        </p>
+      ) : null}
+      {model.tags.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {model.tags.map((tag) => (
+            <Badge key={tag} variant="outline">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function StackedMetric({
+  topLabel,
+  topValue,
+  bottomLabel,
+  bottomValue,
+}: {
+  topLabel: string
+  topValue: string
+  bottomLabel: string
+  bottomValue: string
+}) {
+  return (
+    <div className="flex min-w-[10rem] flex-col gap-1 py-1">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+          {topLabel}
+        </span>
+        <span className="text-[var(--color-text-muted)]">{topValue}</span>
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+          {bottomLabel}
+        </span>
+        <span className="text-[var(--color-text-muted)]">{bottomValue}</span>
+      </div>
+    </div>
+  )
+}
+
+function CapabilityBadges({ model }: { model: ModelView }) {
+  const capabilities = [
+    model.supports_streaming ? { label: 'Streaming', icon: LiveStreaming03Icon } : null,
+    model.supports_vision ? { label: 'Vision', icon: VisionIcon } : null,
+    model.supports_tool_calling ? { label: 'Tool Calling', icon: ToolsIcon } : null,
+    model.supports_structured_output ? { label: 'Structured Output', icon: CodeIcon } : null,
+    model.supports_attachments ? { label: 'Attachments', icon: AttachmentIcon } : null,
+  ].filter(
+    (
+      value,
+    ): value is {
+      label: string
+      icon: typeof LiveStreaming03Icon
+    } => value !== null,
+  )
+
+  if (capabilities.length === 0) {
+    return <span className="text-[var(--color-text-soft)]">—</span>
+  }
+
+  return (
+    <div className="flex min-w-0 flex-wrap gap-2 py-1">
+      {capabilities.map((capability) => (
+        <Badge key={capability.label} variant="outline" className="gap-1.5">
+          <AppIcon icon={capability.icon} size={12} stroke={1.5} />
+          {capability.label}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+function providerTypeLabel(model: ModelView) {
+  return model.provider_label ?? model.provider_key ?? 'Unresolved'
+}
+
+function formatCost(value: number | null | undefined) {
+  if (value == null) {
+    return '—'
+  }
+
+  return CURRENCY_FORMATTER.format(value / 10_000)
+}
+
+function formatWindow(value: number | null | undefined) {
+  if (value == null) {
+    return '—'
+  }
+
+  if (value >= 1_000_000) {
+    return `${COMPACT_NUMBER_FORMATTER.format(value / 1_000_000)}M`
+  }
+
+  if (value >= 1_000) {
+    return `${COMPACT_NUMBER_FORMATTER.format(value / 1_000)}k`
+  }
+
+  return String(value)
 }
 
 function normalizeModelsSearch(search: Record<string, unknown>) {

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { ModelPageView } from '@/types/api'
 
 const navigateMock = vi.fn()
@@ -15,10 +16,12 @@ vi.mock('@tanstack/react-router', () => ({
   useRouter: () => ({
     navigate: navigateMock,
   }),
+  redirect: vi.fn(),
 }))
 
 vi.mock('@/server/admin-data.functions', () => ({
   getModels: vi.fn(),
+  getAuthSession: vi.fn(),
 }))
 
 const modelPage: ModelPageView = {
@@ -33,6 +36,16 @@ const modelPage: ModelPageView = {
       provider_icon_key: 'openrouter',
       upstream_model: 'google/gemini-2.0-flash',
       model_icon_key: 'gemini',
+      input_cost_per_million_tokens_usd_10000: 3_000,
+      output_cost_per_million_tokens_usd_10000: 25_000,
+      context_window_tokens: 1_048_576,
+      input_window_tokens: null,
+      output_window_tokens: 65_536,
+      supports_streaming: true,
+      supports_vision: true,
+      supports_tool_calling: true,
+      supports_structured_output: true,
+      supports_attachments: true,
       tags: ['fast', 'cheap'],
       status: 'healthy',
     },
@@ -46,6 +59,16 @@ const modelPage: ModelPageView = {
       provider_icon_key: 'vertexai',
       upstream_model: 'google/gemini-2.0-flash',
       model_icon_key: 'gemini',
+      input_cost_per_million_tokens_usd_10000: 3_000,
+      output_cost_per_million_tokens_usd_10000: 25_000,
+      context_window_tokens: 1_048_576,
+      input_window_tokens: null,
+      output_window_tokens: 65_536,
+      supports_streaming: true,
+      supports_vision: true,
+      supports_tool_calling: false,
+      supports_structured_output: true,
+      supports_attachments: true,
       tags: ['fast', 'fallback'],
       status: 'degraded',
     },
@@ -68,7 +91,11 @@ describe('ModelsPage', () => {
 
     const { ModelsPage } = await import('@/routes/models')
 
-    render(<ModelsPage />)
+    render(
+      <TooltipProvider>
+        <ModelsPage />
+      </TooltipProvider>,
+    )
 
     expect(screen.getByTestId('models-mobile-list')).toBeInTheDocument()
     expect(screen.getByTestId('models-desktop-table')).toBeInTheDocument()
@@ -77,21 +104,66 @@ describe('ModelsPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('removes the resolved column and keeps status inside the model identity cell', async () => {
+  it('renders the desktop table with the expected column order and stacked routing cells', async () => {
     routeMock.useLoaderData.mockReturnValue({ data: modelPage })
 
     const { ModelsPage } = await import('@/routes/models')
 
-    render(<ModelsPage />)
+    render(
+      <TooltipProvider>
+        <ModelsPage />
+      </TooltipProvider>,
+    )
 
     const table = screen.getAllByTestId('models-desktop-table')[0]
+    const headers = within(table)
+      .getAllByRole('columnheader')
+      .map((header) => header.textContent?.trim())
 
     expect(within(table).queryByText('Resolved')).not.toBeInTheDocument()
-    expect(within(table).getByText('Model ID')).toBeInTheDocument()
+    expect(headers).toEqual([
+      'Model ID',
+      'Upstream Model',
+      'Provider',
+      'Cost / 1M Tokens',
+      'Context Window',
+      'Capabilities',
+    ])
 
     const identityCell = screen.getAllByTestId('models-desktop-cell-backup-fast')[0]
     expect(within(identityCell).getByText('backup-fast')).toBeInTheDocument()
-    expect(within(identityCell).getByText('degraded')).toBeInTheDocument()
+    expect(within(identityCell).getByLabelText('degraded')).toBeInTheDocument()
     expect(within(identityCell).getByText('alias → fast')).toBeInTheDocument()
+
+    const backupRow = within(table).getByText('backup-fast').closest('tr')
+    expect(backupRow).not.toBeNull()
+    const backupCells = within(backupRow as HTMLElement).getAllByRole('cell')
+
+    expect(within(backupCells[1] as HTMLElement).getByText('google/gemini-2.0-flash')).toBeInTheDocument()
+    expect(within(backupCells[2] as HTMLElement).getByText('Google Vertex AI')).toBeInTheDocument()
+    expect(within(backupCells[2] as HTMLElement).getByText('vertex-gemini')).toBeInTheDocument()
+    expect(within(backupCells[3] as HTMLElement).getByText('Input')).toBeInTheDocument()
+    expect(within(backupCells[3] as HTMLElement).getByText('Output')).toBeInTheDocument()
+    expect(within(backupCells[4] as HTMLElement).getByText('Input')).toBeInTheDocument()
+    expect(within(backupCells[4] as HTMLElement).getByText('Output')).toBeInTheDocument()
+    expect(within(backupCells[5] as HTMLElement).getByText('Streaming')).toBeInTheDocument()
+    expect(within(backupCells[5] as HTMLElement).getByText('Vision')).toBeInTheDocument()
+  })
+
+  it('does not render the notes column in the desktop table', async () => {
+    routeMock.useLoaderData.mockReturnValue({ data: modelPage })
+
+    const { ModelsPage } = await import('@/routes/models')
+
+    render(
+      <TooltipProvider>
+        <ModelsPage />
+      </TooltipProvider>,
+    )
+
+    const table = screen.getAllByTestId('models-desktop-table')[0]
+
+    expect(within(table).queryByText('Notes')).not.toBeInTheDocument()
+    expect(within(table).queryByText('Gemini fallback on Vertex')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Description

Restore the dedicated `Upstream Model` column in the admin Models desktop table while preserving the richer pricing, context window, and capability presentation added on top of the table-scroll redesign.

PR title format follows Conventional Commits: `fix(admin-ui): restore upstream model column layout`.

- Summary of changes
  - restore `Upstream Model` as its own desktop column
  - keep `Provider` limited to stacked provider label and provider key
  - keep `Cost / 1M Tokens`, `Context Window`, and `Capabilities` as separate structured columns
  - remove the desktop `Notes` column
  - add regression tests for header order and stacked desktop cell content
- Why this approach was chosen
  - it matches the intended information hierarchy more cleanly than the denser combined routing column while preserving the richer contract from `main`
- How it works
  - the sticky internal model column remains unchanged
  - the desktop table now renders six columns in the agreed order
  - the route test asserts the exact desktop header set and verifies representative row content by column
- Risks, tradeoffs, and alternatives considered
  - the table is slightly wider again, but the table-only horizontal scroll pattern still contains that width inside the card region
  - I did not include the blank/failed Playwright screenshot in this PR because the fresh stack’s admin UI upstream did not render reliably in headless capture
- Additional context for reviewers
  - validated with `bun run --cwd crates/admin-ui/web test src/test/routes/models-route.test.tsx`
  - validated with `mise run lint`

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`
