### PR TITLE
feat(gateway): add OpenAI Responses API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rust-first LLM gateway workspace with an embedded TanStack Start admin control p
 - `crates/gateway`
   - Rust HTTP runtime for `/healthz`, `/readyz`, `/v1/*`, and `/api/v1/admin/*`
 - `crates/gateway-core`
-  - shared domain types, traits, OpenAI-compatible DTOs, and errors
+  - shared domain types, traits, OpenAI-compatible Chat/Responses/Embeddings DTOs, and errors
 - `crates/gateway-store`
   - libsql or SQLite and PostgreSQL stores, migrations, and seed behavior
 - `crates/gateway-service`

--- a/crates/gateway-core/src/domain.rs
+++ b/crates/gateway-core/src/domain.rs
@@ -1048,6 +1048,8 @@ pub struct ProviderCapabilities {
     #[serde(default = "default_true")]
     pub chat_completions: bool,
     #[serde(default = "default_true")]
+    pub responses: bool,
+    #[serde(default = "default_true")]
     pub stream: bool,
     #[serde(default = "default_true")]
     pub embeddings: bool,
@@ -1087,6 +1089,7 @@ impl ProviderCapabilities {
     ) -> Self {
         Self {
             chat_completions,
+            responses: false,
             stream,
             embeddings,
             tools,
@@ -1103,25 +1106,44 @@ impl ProviderCapabilities {
 
     #[must_use]
     pub const fn openai_compat_baseline() -> Self {
-        Self::with_dimensions(true, true, true, true, true, true, true)
+        Self {
+            chat_completions: true,
+            responses: true,
+            stream: true,
+            embeddings: true,
+            tools: true,
+            vision: true,
+            json_schema: true,
+            developer_role: true,
+        }
     }
 
     #[must_use]
     pub const fn all_enabled() -> Self {
-        Self::with_dimensions(true, true, true, true, true, true, true)
+        Self {
+            chat_completions: true,
+            responses: true,
+            stream: true,
+            embeddings: true,
+            tools: true,
+            vision: true,
+            json_schema: true,
+            developer_role: true,
+        }
     }
 
     #[must_use]
     pub const fn intersect(self, other: Self) -> Self {
-        Self::with_dimensions(
-            self.chat_completions && other.chat_completions,
-            self.stream && other.stream,
-            self.embeddings && other.embeddings,
-            self.tools && other.tools,
-            self.vision && other.vision,
-            self.json_schema && other.json_schema,
-            self.developer_role && other.developer_role,
-        )
+        Self {
+            chat_completions: self.chat_completions && other.chat_completions,
+            responses: self.responses && other.responses,
+            stream: self.stream && other.stream,
+            embeddings: self.embeddings && other.embeddings,
+            tools: self.tools && other.tools,
+            vision: self.vision && other.vision,
+            json_schema: self.json_schema && other.json_schema,
+            developer_role: self.developer_role && other.developer_role,
+        }
     }
 }
 

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -32,14 +32,17 @@ pub use error::{AuthError, GatewayError, ProviderError, RouteError, StoreError};
 pub use protocol::core::{
     ChatMessage as CoreChatMessage, ChatRequest as CoreChatRequest,
     EmbeddingsRequest as CoreEmbeddingsRequest, RequestRequirements as CoreRequestRequirements,
+    ResponsesRequest as CoreResponsesRequest,
 };
 pub use protocol::openai::{
     ChatCompletionsRequest, EmbeddingsRequest, ModelsListResponse, OpenAiErrorBody,
-    OpenAiErrorEnvelope,
+    OpenAiErrorEnvelope, ResponseOutputItem, ResponseUsage, ResponsesRequest, ResponsesResponse,
+    ResponsesStreamEvent,
 };
 pub use protocol::translate::{
-    core_chat_request_to_openai, core_embeddings_request_to_openai, openai_chat_request_to_core,
-    openai_embeddings_request_to_core,
+    core_chat_request_to_openai, core_embeddings_request_to_openai,
+    core_responses_request_to_openai, openai_chat_request_to_core,
+    openai_embeddings_request_to_core, openai_responses_request_to_core,
 };
 pub use streaming::{ParsedSseEvent, SseEventParser, Utf8ChunkDecoder};
 pub use traits::{

--- a/crates/gateway-core/src/protocol/core.rs
+++ b/crates/gateway-core/src/protocol/core.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RequestRequirements {
     pub chat_completions: bool,
+    pub responses: bool,
     pub stream: bool,
     pub embeddings: bool,
     pub tools: bool,
@@ -20,6 +21,9 @@ impl RequestRequirements {
         let mut names = Vec::new();
         if self.chat_completions {
             names.push("chat_completions");
+        }
+        if self.responses {
+            names.push("responses");
         }
         if self.stream {
             names.push("stream");
@@ -59,6 +63,7 @@ impl ChatRequest {
     pub fn requirements(&self) -> RequestRequirements {
         RequestRequirements {
             chat_completions: true,
+            responses: false,
             stream: self.stream,
             embeddings: false,
             tools: self
@@ -105,12 +110,55 @@ impl EmbeddingsRequest {
         let _ = self;
         RequestRequirements {
             chat_completions: false,
+            responses: false,
             stream: false,
             embeddings: true,
             tools: false,
             vision: false,
             json_schema: false,
             developer_role: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponsesRequest {
+    pub model: String,
+    pub input: Value,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<Value>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl ResponsesRequest {
+    #[must_use]
+    pub fn requirements(&self) -> RequestRequirements {
+        RequestRequirements {
+            chat_completions: false,
+            responses: true,
+            stream: self.stream,
+            embeddings: false,
+            tools: self
+                .tools
+                .as_ref()
+                .is_some_and(value_is_present_for_capability),
+            vision: response_input_has_vision(&self.input),
+            json_schema: self
+                .text
+                .as_ref()
+                .is_some_and(responses_text_requires_json_schema),
+            developer_role: response_input_has_developer_role(&self.input),
         }
     }
 }
@@ -122,6 +170,58 @@ fn value_is_present_for_capability(value: &Value) -> bool {
         Value::Object(items) => !items.is_empty(),
         _ => true,
     }
+}
+
+fn responses_text_requires_json_schema(value: &Value) -> bool {
+    let Some(format) = value.as_object().and_then(|object| object.get("format")) else {
+        return false;
+    };
+    response_format_requires_json_schema(format)
+}
+
+fn response_input_has_vision(value: &Value) -> bool {
+    match value {
+        Value::Array(items) => items.iter().any(response_input_item_has_vision),
+        Value::Object(_) => response_input_item_has_vision(value),
+        _ => false,
+    }
+}
+
+fn response_input_item_has_vision(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+
+    matches!(
+        object.get("type").and_then(Value::as_str),
+        Some("input_image" | "input_file")
+    ) || object
+        .get("content")
+        .is_some_and(response_input_content_has_vision)
+}
+
+fn response_input_content_has_vision(value: &Value) -> bool {
+    match value {
+        Value::Array(parts) => parts.iter().any(response_input_item_has_vision),
+        Value::Object(_) => response_input_item_has_vision(value),
+        _ => false,
+    }
+}
+
+fn response_input_has_developer_role(value: &Value) -> bool {
+    match value {
+        Value::Array(items) => items.iter().any(response_input_item_has_developer_role),
+        Value::Object(_) => response_input_item_has_developer_role(value),
+        _ => false,
+    }
+}
+
+fn response_input_item_has_developer_role(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|object| object.get("role"))
+        .and_then(Value::as_str)
+        .is_some_and(|role| role.eq_ignore_ascii_case("developer"))
 }
 
 fn response_format_requires_json_schema(value: &Value) -> bool {
@@ -202,6 +302,7 @@ mod tests {
         assert!(requirements.json_schema);
         assert!(requirements.developer_role);
         assert!(!requirements.embeddings);
+        assert!(!requirements.responses);
     }
 
     #[test]
@@ -215,6 +316,38 @@ mod tests {
         let requirements = request.requirements();
         assert!(requirements.embeddings);
         assert!(!requirements.chat_completions);
+        assert!(!requirements.responses);
         assert!(!requirements.stream);
+    }
+
+    #[test]
+    fn responses_request_requirements_reflect_request_shape() {
+        let request = super::ResponsesRequest {
+            model: "reasoning".to_string(),
+            input: json!([
+                {"type":"message","role":"developer","content":"be concise"},
+                {"type":"message","role":"user","content":[
+                    {"type":"input_text","text":"Describe this"},
+                    {"type":"input_image","image_url":"https://example.test/cat.png"}
+                ]}
+            ]),
+            stream: true,
+            instructions: None,
+            tools: Some(json!([{"type":"function","name":"lookup"}])),
+            tool_choice: None,
+            reasoning: Some(json!({"effort":"medium"})),
+            text: Some(json!({"format":{"type":"json_schema","name":"answer","schema":{}}})),
+            extra: BTreeMap::new(),
+        };
+
+        let requirements = request.requirements();
+        assert!(requirements.responses);
+        assert!(requirements.stream);
+        assert!(requirements.tools);
+        assert!(requirements.vision);
+        assert!(requirements.json_schema);
+        assert!(requirements.developer_role);
+        assert!(!requirements.chat_completions);
+        assert!(!requirements.embeddings);
     }
 }

--- a/crates/gateway-core/src/protocol/openai.rs
+++ b/crates/gateway-core/src/protocol/openai.rs
@@ -76,6 +76,65 @@ pub struct EmbeddingsRequest {
     pub extra: BTreeMap<String, Value>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponsesRequest {
+    pub model: String,
+    pub input: Value,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<Value>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponsesResponse {
+    pub id: String,
+    pub object: String,
+    pub model: String,
+    #[serde(default)]
+    pub output: Vec<ResponseOutputItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<ResponseUsage>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponseOutputItem {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub item_type: String,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponseUsage {
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub total_tokens: Option<i64>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponsesStreamEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::GatewayError;

--- a/crates/gateway-core/src/protocol/translate.rs
+++ b/crates/gateway-core/src/protocol/translate.rs
@@ -60,6 +60,40 @@ pub fn core_embeddings_request_to_openai(
     }
 }
 
+#[must_use]
+pub fn openai_responses_request_to_core(
+    request: &openai::ResponsesRequest,
+) -> core::ResponsesRequest {
+    core::ResponsesRequest {
+        model: request.model.clone(),
+        input: request.input.clone(),
+        stream: request.stream,
+        instructions: request.instructions.clone(),
+        tools: request.tools.clone(),
+        tool_choice: request.tool_choice.clone(),
+        reasoning: request.reasoning.clone(),
+        text: request.text.clone(),
+        extra: request.extra.clone(),
+    }
+}
+
+#[must_use]
+pub fn core_responses_request_to_openai(
+    request: &core::ResponsesRequest,
+) -> openai::ResponsesRequest {
+    openai::ResponsesRequest {
+        model: request.model.clone(),
+        input: request.input.clone(),
+        stream: request.stream,
+        instructions: request.instructions.clone(),
+        tools: request.tools.clone(),
+        tool_choice: request.tool_choice.clone(),
+        reasoning: request.reasoning.clone(),
+        text: request.text.clone(),
+        extra: request.extra.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -67,10 +101,11 @@ mod tests {
     use serde_json::{Value, json};
 
     use crate::protocol::{
-        openai::{ChatCompletionsRequest, ChatMessage, EmbeddingsRequest},
+        openai::{ChatCompletionsRequest, ChatMessage, EmbeddingsRequest, ResponsesRequest},
         translate::{
             core_chat_request_to_openai, core_embeddings_request_to_openai,
-            openai_chat_request_to_core, openai_embeddings_request_to_core,
+            core_responses_request_to_openai, openai_chat_request_to_core,
+            openai_embeddings_request_to_core, openai_responses_request_to_core,
         },
     };
 
@@ -135,5 +170,35 @@ mod tests {
         assert_eq!(translated_back.model, openai_request.model);
         assert_eq!(translated_back.input, openai_request.input);
         assert_eq!(translated_back.extra, openai_request.extra);
+    }
+
+    #[test]
+    fn responses_request_round_trips_between_openai_and_core() {
+        let mut request_extra = BTreeMap::new();
+        request_extra.insert("metadata".to_string(), json!({"tenant":"acme"}));
+
+        let openai_request = ResponsesRequest {
+            model: "reasoning".to_string(),
+            input: json!([
+                {"type":"message","role":"user","content":"hello"},
+                {"type":"function_call_output","call_id":"call_1","output":"ok"}
+            ]),
+            stream: true,
+            instructions: Some(json!("Answer with citations.")),
+            tools: Some(json!([{"type":"function","name":"lookup"}])),
+            tool_choice: Some(json!("auto")),
+            reasoning: Some(json!({"effort":"medium"})),
+            text: Some(json!({"format":{"type":"text"}})),
+            extra: request_extra,
+        };
+
+        let core_request = openai_responses_request_to_core(&openai_request);
+        assert_eq!(core_request.model, "reasoning");
+        assert_eq!(core_request.input, openai_request.input);
+        assert_eq!(core_request.tools, openai_request.tools);
+        assert_eq!(core_request.reasoning, openai_request.reasoning);
+
+        let translated_back = core_responses_request_to_openai(&core_request);
+        assert_eq!(translated_back, openai_request);
     }
 }

--- a/crates/gateway-core/src/traits.rs
+++ b/crates/gateway-core/src/traits.rs
@@ -19,7 +19,7 @@ use crate::{
         UsageLedgerRecord, UserBudgetRecord, UserRecord,
     },
     error::{ProviderError, RouteError, StoreError},
-    protocol::core::{ChatRequest, EmbeddingsRequest},
+    protocol::core::{ChatRequest, EmbeddingsRequest, ResponsesRequest},
 };
 
 #[async_trait]
@@ -427,6 +427,18 @@ pub trait ProviderClient: Send + Sync {
         request: &EmbeddingsRequest,
         context: &ProviderRequestContext,
     ) -> Result<Value, ProviderError>;
+
+    async fn responses(
+        &self,
+        request: &ResponsesRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<Value, ProviderError>;
+
+    async fn responses_stream(
+        &self,
+        request: &ResponsesRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<ProviderStream, ProviderError>;
 }
 
 #[derive(Default, Clone)]

--- a/crates/gateway-providers/src/openai_compat.rs
+++ b/crates/gateway-providers/src/openai_compat.rs
@@ -5,10 +5,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::StreamExt;
 use gateway_core::{
-    CoreChatRequest, CoreEmbeddingsRequest, OpenAiCompatDeveloperRole, OpenAiCompatMaxTokensField,
-    OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility, ProviderCapabilities,
-    ProviderClient, ProviderError, ProviderRequestContext, ProviderStream, SseEventParser,
-    core_chat_request_to_openai, core_embeddings_request_to_openai,
+    CoreChatRequest, CoreEmbeddingsRequest, CoreResponsesRequest, OpenAiCompatDeveloperRole,
+    OpenAiCompatMaxTokensField, OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility,
+    ProviderCapabilities, ProviderClient, ProviderError, ProviderRequestContext, ProviderStream,
+    SseEventParser, core_chat_request_to_openai, core_embeddings_request_to_openai,
+    core_responses_request_to_openai,
 };
 use serde_json::{Map, Value, json};
 
@@ -110,6 +111,46 @@ impl OpenAiCompatProvider {
         self.build_request("embeddings", body, context, false, false)
     }
 
+    pub fn build_responses_request(
+        &self,
+        request: &CoreResponsesRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<reqwest::Request, ProviderError> {
+        let wire_request = core_responses_request_to_openai(request);
+        let mut body = serde_json::to_value(wire_request)
+            .map_err(|error| ProviderError::Transport(error.to_string()))?;
+
+        if let Some(object) = body.as_object_mut() {
+            object.insert(
+                "model".to_string(),
+                Value::String(context.upstream_model.clone()),
+            );
+        }
+
+        self.build_request("responses", body, context, false, false)
+    }
+
+    pub fn build_responses_stream_request(
+        &self,
+        request: &CoreResponsesRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<reqwest::Request, ProviderError> {
+        let mut stream_request = request.clone();
+        stream_request.stream = true;
+        let wire_request = core_responses_request_to_openai(&stream_request);
+        let mut body = serde_json::to_value(wire_request)
+            .map_err(|error| ProviderError::Transport(error.to_string()))?;
+
+        if let Some(object) = body.as_object_mut() {
+            object.insert(
+                "model".to_string(),
+                Value::String(context.upstream_model.clone()),
+            );
+        }
+
+        self.build_request("responses", body, context, true, false)
+    }
+
     fn build_request(
         &self,
         endpoint_suffix: &str,
@@ -130,11 +171,12 @@ impl OpenAiCompatProvider {
             && enforce_stream
         {
             object.insert("stream".to_string(), Value::Bool(true));
-            if context
-                .compatibility
-                .openai_compat
-                .as_ref()
-                .is_some_and(|profile| profile.supports_stream_usage)
+            if apply_compatibility_profile
+                && context
+                    .compatibility
+                    .openai_compat
+                    .as_ref()
+                    .is_some_and(|profile| profile.supports_stream_usage)
             {
                 ensure_stream_usage_requested(object);
             }
@@ -326,6 +368,28 @@ impl ProviderClient for OpenAiCompatProvider {
         let request = self.build_embeddings_request(request, context)?;
         self.execute_json_request(request).await
     }
+
+    async fn responses(
+        &self,
+        request: &CoreResponsesRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<Value, ProviderError> {
+        let request = self.build_responses_request(request, context)?;
+        self.execute_json_request(request).await
+    }
+
+    async fn responses_stream(
+        &self,
+        request: &CoreResponsesRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<ProviderStream, ProviderError> {
+        let request = self.build_responses_stream_request(request, context)?;
+        let response = self.execute_stream_request(request).await?;
+
+        Ok(normalize_openai_compat_responses_stream(
+            response.bytes_stream(),
+        ))
+    }
 }
 
 fn normalize_openai_compat_stream<S>(upstream: S) -> ProviderStream
@@ -410,6 +474,78 @@ fn normalize_openai_compat_sse_data(data: &str) -> String {
     serde_json::to_string(&value).unwrap_or_else(|_| data.to_string())
 }
 
+fn normalize_openai_compat_responses_stream<S>(upstream: S) -> ProviderStream
+where
+    S: futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+{
+    Box::pin(stream! {
+        let mut parser = SseEventParser::default();
+        let mut saw_payload_event = false;
+        let mut stream_failed = false;
+        futures_util::pin_mut!(upstream);
+
+        while let Some(chunk) = upstream.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    yield Ok(openai_sse_error_chunk(
+                        "upstream_openai_compat_responses_stream_error",
+                        &error.to_string(),
+                    ));
+                    stream_failed = true;
+                    break;
+                }
+            };
+
+            let events = match parser.push_bytes(&chunk) {
+                Ok(events) => events,
+                Err(error) => {
+                    yield Ok(openai_sse_error_chunk(
+                        "openai_compat_responses_sse_parse_error",
+                        &error.to_string(),
+                    ));
+                    stream_failed = true;
+                    break;
+                }
+            };
+
+            for event in events {
+                let data = event.data.trim();
+                if data == "[DONE]" {
+                    continue;
+                }
+
+                if data.is_empty() && event.event.is_none() {
+                    continue;
+                }
+
+                saw_payload_event = true;
+                yield Ok(render_sse_event_chunk(event.event.as_deref(), &event.data));
+            }
+        }
+
+        if !stream_failed && let Err(error) = parser.finish() {
+            yield Ok(openai_sse_error_chunk(
+                "openai_compat_responses_sse_finalization_error",
+                &error.to_string(),
+            ));
+            stream_failed = true;
+        }
+
+        if !stream_failed && !saw_payload_event {
+            yield Ok(openai_sse_error_chunk(
+                "openai_compat_responses_empty_stream",
+                "upstream responses stream ended without SSE payload events",
+            ));
+            stream_failed = true;
+        }
+
+        if !stream_failed {
+            yield Ok(done_sse_chunk());
+        }
+    })
+}
+
 fn normalize_openai_compat_chunk_value(value: &mut Value) {
     let Some(object) = value.as_object_mut() else {
         return;
@@ -482,9 +618,9 @@ mod tests {
     use bytes::Bytes;
     use futures_util::{StreamExt, stream};
     use gateway_core::{
-        CoreChatMessage, CoreChatRequest, OpenAiCompatDeveloperRole, OpenAiCompatMaxTokensField,
-        OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility, ProviderClient, ProviderError,
-        ProviderRequestContext, RouteCompatibility,
+        CoreChatMessage, CoreChatRequest, CoreResponsesRequest, OpenAiCompatDeveloperRole,
+        OpenAiCompatMaxTokensField, OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility,
+        ProviderClient, ProviderError, ProviderRequestContext, RouteCompatibility,
     };
     use serde_json::{Map, Value, json};
     use tokio::net::TcpListener;
@@ -523,6 +659,54 @@ mod tests {
             .and_then(|body| body.as_bytes())
             .expect("bytes body");
         serde_json::from_slice(body).expect("json body")
+    }
+
+    fn provider_with_base_url(base_url: String) -> OpenAiCompatProvider {
+        OpenAiCompatProvider::new(OpenAiCompatConfig {
+            provider_key: "openai-prod".to_string(),
+            base_url,
+            bearer_token: None,
+            default_headers: BTreeMap::new(),
+            request_timeout_ms: 10_000,
+        })
+        .expect("provider")
+    }
+
+    fn default_context() -> ProviderRequestContext {
+        ProviderRequestContext {
+            request_id: "req-123".to_string(),
+            model_key: "fast".to_string(),
+            provider_key: "openai-prod".to_string(),
+            upstream_model: "gpt-4o-mini".to_string(),
+            extra_headers: Map::new(),
+            extra_body: Map::new(),
+            request_headers: BTreeMap::new(),
+            compatibility: Default::default(),
+        }
+    }
+
+    async fn render_provider_stream(mut stream: gateway_core::ProviderStream) -> String {
+        let mut rendered = String::new();
+        while let Some(chunk) = stream.next().await {
+            rendered.push_str(std::str::from_utf8(chunk.expect("chunk").as_ref()).expect("utf8"));
+        }
+        rendered
+    }
+
+    fn responses_request(stream: bool) -> CoreResponsesRequest {
+        CoreResponsesRequest {
+            model: "reasoning".to_string(),
+            input: json!([
+                {"type":"message","role":"user","content":"hello"}
+            ]),
+            stream,
+            instructions: Some(json!("Answer briefly.")),
+            tools: Some(json!([{"type":"function","name":"lookup"}])),
+            tool_choice: Some(json!("auto")),
+            reasoning: Some(json!({"effort":"medium"})),
+            text: Some(json!({"format":{"type":"text"}})),
+            extra: BTreeMap::new(),
+        }
     }
 
     #[test]
@@ -818,6 +1002,60 @@ mod tests {
             .expect("bytes body");
         let body_json: Value = serde_json::from_slice(body).expect("json body");
         assert_eq!(body_json["stream"], Value::Bool(true));
+    }
+
+    #[test]
+    fn builds_responses_request_with_expected_path_and_body() {
+        let provider = provider();
+        let request = responses_request(false);
+        let context = ProviderRequestContext {
+            request_id: "req-123".to_string(),
+            model_key: "reasoning".to_string(),
+            provider_key: "openai-prod".to_string(),
+            upstream_model: "gpt-5-mini".to_string(),
+            extra_headers: Map::new(),
+            extra_body: json!({"parallel_tool_calls": false, "store": true})
+                .as_object()
+                .cloned()
+                .expect("object"),
+            request_headers: BTreeMap::new(),
+            compatibility: RouteCompatibility {
+                openai_compat: Some(OpenAiCompatRouteCompatibility {
+                    supports_store: false,
+                    ..Default::default()
+                }),
+            },
+        };
+
+        let built = provider
+            .build_responses_request(&request, &context)
+            .expect("build request");
+        let body_json = request_body_json(&built);
+
+        assert_eq!(built.url().as_str(), "https://api.openai.com/v1/responses");
+        assert_eq!(body_json["model"], "gpt-5-mini");
+        assert_eq!(body_json["input"], request.input);
+        assert_eq!(body_json["tools"], request.tools.expect("tools"));
+        assert_eq!(body_json["parallel_tool_calls"], Value::Bool(false));
+        assert_eq!(body_json["store"], Value::Bool(true));
+    }
+
+    #[test]
+    fn build_responses_stream_request_enforces_stream_without_chat_stream_options() {
+        let provider = provider();
+        let request = responses_request(false);
+        let context = context_with_profile(OpenAiCompatRouteCompatibility {
+            supports_stream_usage: true,
+            ..Default::default()
+        });
+
+        let built = provider
+            .build_responses_stream_request(&request, &context)
+            .expect("build request");
+        let body_json = request_body_json(&built);
+
+        assert_eq!(body_json["stream"], Value::Bool(true));
+        assert!(body_json.get("stream_options").is_none());
     }
 
     #[tokio::test]
@@ -1503,6 +1741,120 @@ mod tests {
         }
 
         assert!(rendered.contains("\"code\":\"openai_compat_empty_stream\""));
+        assert!(!rendered.contains("data: [DONE]"));
+    }
+
+    #[tokio::test]
+    async fn responses_stream_preserves_response_events_and_appends_done() {
+        let app = Router::new().route(
+            "/v1/responses",
+            post(|| async move {
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/event-stream")
+                    .body(Body::from(
+                        "event: response.output_item.added\n\
+                         data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_1\",\"type\":\"message\"}}\n\n\
+                         event: response.output_text.delta\n\
+                         data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"delta\":\"hi\"}\n\n\
+                         event: response.output_item.added\n\
+                         data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\"}}\n\n\
+                         event: response.reasoning_text.delta\n\
+                         data: {\"type\":\"response.reasoning_text.delta\",\"item_id\":\"rs_1\",\"delta\":\"because\"}\n\n\
+                         event: response.function_call_arguments.delta\n\
+                         data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{}\"}\n\n\
+                         event: response.completed\n\
+                         data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":4,\"total_tokens\":7}}}\n\n",
+                    ))
+                    .expect("response")
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve app");
+        });
+
+        let provider = provider_with_base_url(format!("http://{addr}/v1"));
+        let stream = provider
+            .responses_stream(&responses_request(true), &default_context())
+            .await
+            .expect("stream");
+
+        let rendered = render_provider_stream(stream).await;
+        assert!(rendered.contains("event: response.output_text.delta"));
+        assert!(rendered.contains("event: response.reasoning_text.delta"));
+        assert!(rendered.contains("event: response.function_call_arguments.delta"));
+        assert!(rendered.contains("\"input_tokens\":3"));
+        assert!(rendered.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn responses_stream_emits_error_chunk_on_incomplete_final_event() {
+        let app = Router::new().route(
+            "/v1/responses",
+            post(|| async move {
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/event-stream")
+                    .body(Body::from(
+                        "event: response.output_text.delta\ndata: {\"type\"",
+                    ))
+                    .expect("response")
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve app");
+        });
+
+        let provider = provider_with_base_url(format!("http://{addr}/v1"));
+        let stream = provider
+            .responses_stream(&responses_request(true), &default_context())
+            .await
+            .expect("stream");
+
+        let rendered = render_provider_stream(stream).await;
+        assert!(rendered.contains("\"code\":\"openai_compat_responses_sse_finalization_error\""));
+        assert!(!rendered.contains("data: [DONE]"));
+    }
+
+    #[tokio::test]
+    async fn responses_stream_rejects_done_only_transcript_as_empty_stream() {
+        let app = Router::new().route(
+            "/v1/responses",
+            post(|| async move {
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/event-stream")
+                    .body(Body::from("data: [DONE]\n\n"))
+                    .expect("response")
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve app");
+        });
+
+        let provider = provider_with_base_url(format!("http://{addr}/v1"));
+        let stream = provider
+            .responses_stream(&responses_request(true), &default_context())
+            .await
+            .expect("stream");
+
+        let rendered = render_provider_stream(stream).await;
+        assert!(rendered.contains("\"code\":\"openai_compat_responses_empty_stream\""));
         assert!(!rendered.contains("data: [DONE]"));
     }
 }

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -5,8 +5,9 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures_util::StreamExt;
 use gateway_core::{
-    CoreChatRequest, CoreEmbeddingsRequest, ProviderCapabilities, ProviderClient, ProviderError,
-    ProviderRequestContext, ProviderStream, SseEventParser, Utf8ChunkDecoder,
+    CoreChatRequest, CoreEmbeddingsRequest, CoreResponsesRequest, ProviderCapabilities,
+    ProviderClient, ProviderError, ProviderRequestContext, ProviderStream, SseEventParser,
+    Utf8ChunkDecoder,
 };
 use serde_json::{Map, Value, json};
 use time::OffsetDateTime;
@@ -264,6 +265,26 @@ impl ProviderClient for VertexProvider {
     ) -> Result<Value, ProviderError> {
         Err(ProviderError::InvalidRequest(
             "vertex embeddings are not supported in this v1 runtime".to_string(),
+        ))
+    }
+
+    async fn responses(
+        &self,
+        _request: &CoreResponsesRequest,
+        _context: &ProviderRequestContext,
+    ) -> Result<Value, ProviderError> {
+        Err(ProviderError::InvalidRequest(
+            "vertex responses are not supported in this v1 runtime".to_string(),
+        ))
+    }
+
+    async fn responses_stream(
+        &self,
+        _request: &CoreResponsesRequest,
+        _context: &ProviderRequestContext,
+    ) -> Result<ProviderStream, ProviderError> {
+        Err(ProviderError::InvalidRequest(
+            "vertex responses streaming is not supported in this v1 runtime".to_string(),
         ))
     }
 }

--- a/crates/gateway-service/src/request_logging.rs
+++ b/crates/gateway-service/src/request_logging.rs
@@ -4,7 +4,7 @@ use gateway_core::{
     ApiKeyOwnerKind, AuthError, AuthenticatedApiKey, ChatCompletionsRequest, GatewayError,
     IdentityRepository, OpenAiErrorEnvelope, RequestLogDetail, RequestLogPage,
     RequestLogPayloadRecord, RequestLogQuery, RequestLogRecord, RequestLogRepository, RequestTags,
-    SseEventParser,
+    ResponsesRequest, SseEventParser,
 };
 
 use crate::{REQUEST_LOG_MODEL_ICON_KEY, REQUEST_LOG_PROVIDER_ICON_KEY, RequestLogIconMetadata};
@@ -23,6 +23,7 @@ pub struct ChatRequestLogContext {
     pub request_id: String,
     pub requested_model_key: String,
     pub resolved_model_key: String,
+    pub operation: &'static str,
     pub request_tags: RequestTags,
     request_json: Value,
     request_payload_truncated: bool,
@@ -67,7 +68,7 @@ pub struct UsageSummary {
 }
 
 #[derive(Debug, Clone)]
-struct ChatCompletionLogSummary {
+struct RequestLogSummary {
     provider_key: String,
     icon_metadata: RequestLogIconMetadata,
     stream: bool,
@@ -77,7 +78,7 @@ struct ChatCompletionLogSummary {
     usage: UsageSummary,
 }
 
-impl ChatCompletionLogSummary {
+impl RequestLogSummary {
     fn success(
         provider_key: String,
         icon_metadata: RequestLogIconMetadata,
@@ -116,6 +117,16 @@ impl ChatCompletionLogSummary {
     }
 }
 
+struct OperationRequestLogInput<'a, T> {
+    operation: &'static str,
+    request_id: &'a str,
+    requested_model_key: &'a str,
+    resolved_model_key: &'a str,
+    request: &'a T,
+    request_headers: &'a BTreeMap<String, String>,
+    request_tags: RequestTags,
+}
+
 impl UsageSummary {
     #[must_use]
     pub fn has_usage(self) -> bool {
@@ -152,7 +163,7 @@ impl StreamResponseCollector {
             let parsed = serde_json::from_str::<Value>(payload).ok();
             if let Some(usage) = parsed
                 .as_ref()
-                .and_then(|value| value.get("usage"))
+                .and_then(usage_value_from_stream_event)
                 .filter(|usage| !usage.is_null())
             {
                 self.usage = Some(usage.clone());
@@ -228,6 +239,14 @@ fn stream_failure_from_value(value: &Value) -> Option<StreamFailureSummary> {
     })
 }
 
+fn usage_value_from_stream_event(value: &Value) -> Option<&Value> {
+    value.get("usage").or_else(|| {
+        value
+            .get("response")
+            .and_then(|response| response.get("usage"))
+    })
+}
+
 trait PayloadResultExt {
     fn map_truncated(self, additional_truncated: bool) -> (Value, bool);
 }
@@ -262,12 +281,52 @@ where
         request_headers: &BTreeMap<String, String>,
         request_tags: RequestTags,
     ) -> ChatRequestLogContext {
-        let sanitized_headers = request_headers
+        self.begin_operation_request(OperationRequestLogInput {
+            operation: "chat_completions",
+            request_id,
+            requested_model_key,
+            resolved_model_key,
+            request,
+            request_headers,
+            request_tags,
+        })
+    }
+
+    #[must_use]
+    pub fn begin_responses_request(
+        &self,
+        request_id: &str,
+        requested_model_key: &str,
+        resolved_model_key: &str,
+        request: &ResponsesRequest,
+        request_headers: &BTreeMap<String, String>,
+        request_tags: RequestTags,
+    ) -> ChatRequestLogContext {
+        self.begin_operation_request(OperationRequestLogInput {
+            operation: "responses",
+            request_id,
+            requested_model_key,
+            resolved_model_key,
+            request,
+            request_headers,
+            request_tags,
+        })
+    }
+
+    fn begin_operation_request<T>(
+        &self,
+        input: OperationRequestLogInput<'_, T>,
+    ) -> ChatRequestLogContext
+    where
+        T: serde::Serialize,
+    {
+        let sanitized_headers = input
+            .request_headers
             .iter()
             .map(|(key, value)| (key.clone(), Value::String(redact_header_value(key, value))))
             .collect::<Map<_, _>>();
         let request_body =
-            redact_json_value(&serde_json::to_value(request).unwrap_or_else(|_| json!({})));
+            redact_json_value(&serde_json::to_value(input.request).unwrap_or_else(|_| json!({})));
         let (request_json, request_payload_truncated) = truncate_payload(json!({
             "headers": sanitized_headers,
             "body": request_body,
@@ -275,10 +334,11 @@ where
 
         ChatRequestLogContext {
             request_log_id: Uuid::new_v4(),
-            request_id: request_id.to_string(),
-            requested_model_key: requested_model_key.to_string(),
-            resolved_model_key: resolved_model_key.to_string(),
-            request_tags,
+            request_id: input.request_id.to_string(),
+            requested_model_key: input.requested_model_key.to_string(),
+            resolved_model_key: input.resolved_model_key.to_string(),
+            operation: input.operation,
+            request_tags: input.request_tags,
             request_json,
             request_payload_truncated,
         }
@@ -323,7 +383,7 @@ where
         self.persist_chat_log(
             api_key,
             context,
-            ChatCompletionLogSummary::success(
+            RequestLogSummary::success(
                 provider_key.to_string(),
                 icon_metadata,
                 false,
@@ -355,7 +415,7 @@ where
         self.persist_chat_log(
             api_key,
             context,
-            ChatCompletionLogSummary::failure(
+            RequestLogSummary::failure(
                 provider_key.to_string(),
                 icon_metadata,
                 false,
@@ -387,7 +447,7 @@ where
         let usage = usage_summary_from_value(collector.usage());
         let (response_json, response_payload_truncated) = collector.into_payload(failure.as_ref());
         let summary = match failure {
-            Some(failure) => ChatCompletionLogSummary::failure(
+            Some(failure) => RequestLogSummary::failure(
                 provider_key,
                 icon_metadata.clone(),
                 true,
@@ -395,13 +455,9 @@ where
                 failure.status_code,
                 failure.error_code,
             ),
-            None => ChatCompletionLogSummary::success(
-                provider_key,
-                icon_metadata,
-                true,
-                latency_ms,
-                usage,
-            ),
+            None => {
+                RequestLogSummary::success(provider_key, icon_metadata, true, latency_ms, usage)
+            }
         };
         self.persist_chat_log(
             api_key,
@@ -434,7 +490,7 @@ where
         &self,
         api_key: &AuthenticatedApiKey,
         context: &ChatRequestLogContext,
-        summary: ChatCompletionLogSummary,
+        summary: RequestLogSummary,
         response_json: Value,
         response_payload_truncated: bool,
     ) -> Result<LoggedRequest, GatewayError> {
@@ -445,7 +501,8 @@ where
             });
         }
 
-        let metadata = request_log_metadata(summary.stream, &summary.icon_metadata);
+        let metadata =
+            request_log_metadata(context.operation, summary.stream, &summary.icon_metadata);
         let log = RequestLogRecord {
             request_log_id: context.request_log_id,
             request_id: context.request_id.clone(),
@@ -489,8 +546,14 @@ pub fn usage_summary_from_value(value: Option<&Value>) -> UsageSummary {
         return UsageSummary::default();
     };
 
-    let prompt_tokens = usage.get("prompt_tokens").and_then(Value::as_i64);
-    let completion_tokens = usage.get("completion_tokens").and_then(Value::as_i64);
+    let prompt_tokens = usage
+        .get("prompt_tokens")
+        .or_else(|| usage.get("input_tokens"))
+        .and_then(Value::as_i64);
+    let completion_tokens = usage
+        .get("completion_tokens")
+        .or_else(|| usage.get("output_tokens"))
+        .and_then(Value::as_i64);
     let total_tokens = match usage.get("total_tokens").and_then(Value::as_i64) {
         some @ Some(_) => some,
         None => match (prompt_tokens, completion_tokens) {
@@ -507,13 +570,14 @@ pub fn usage_summary_from_value(value: Option<&Value>) -> UsageSummary {
 }
 
 fn request_log_metadata(
+    operation: &'static str,
     stream: bool,
     icon_metadata: &RequestLogIconMetadata,
 ) -> Map<String, Value> {
     let mut metadata = Map::new();
     metadata.insert(
         "operation".to_string(),
-        Value::String("chat_completions".to_string()),
+        Value::String(operation.to_string()),
     );
     metadata.insert("stream".to_string(), Value::Bool(stream));
     metadata.insert(

--- a/crates/gateway-service/src/service.rs
+++ b/crates/gateway-service/src/service.rs
@@ -5,8 +5,9 @@ use gateway_core::{
     ChatCompletionsRequest, GatewayError, GatewayModel, IdentityRepository, ModelRepository,
     ModelRoute, Money4, PricingCatalogRepository, PricingResolution, PricingUnpricedReason,
     ProviderRepository, RequestLogDetail, RequestLogPage, RequestLogQuery, RequestLogRecord,
-    RequestLogRepository, RequestTags, ResolvedModelPricing, RouteError, RoutePlanner, StoreHealth,
-    TeamBudgetRecord, UsageLedgerRecord, UsagePricingStatus, UserBudgetRecord,
+    RequestLogRepository, RequestTags, ResolvedModelPricing, ResponsesRequest, RouteError,
+    RoutePlanner, StoreHealth, TeamBudgetRecord, UsageLedgerRecord, UsagePricingStatus,
+    UserBudgetRecord,
 };
 use serde_json::{Value, json};
 use time::OffsetDateTime;
@@ -183,6 +184,26 @@ where
         request_tags: RequestTags,
     ) -> ChatRequestLogContext {
         self.request_logging.begin_chat_request(
+            request_id,
+            requested_model_key,
+            resolved_model_key,
+            request,
+            request_headers,
+            request_tags,
+        )
+    }
+
+    #[must_use]
+    pub fn begin_responses_request_log(
+        &self,
+        request_id: &str,
+        requested_model_key: &str,
+        resolved_model_key: &str,
+        request: &ResponsesRequest,
+        request_headers: &std::collections::BTreeMap<String, String>,
+        request_tags: RequestTags,
+    ) -> ChatRequestLogContext {
+        self.request_logging.begin_responses_request(
             request_id,
             requested_model_key,
             resolved_model_key,
@@ -458,8 +479,14 @@ fn usage_summary_from_value(value: Option<&Value>) -> Result<UsageSummary, Gatew
         return Ok(UsageSummary::default());
     };
 
-    let prompt_tokens = usage.get("prompt_tokens").and_then(Value::as_i64);
-    let completion_tokens = usage.get("completion_tokens").and_then(Value::as_i64);
+    let prompt_tokens = usage
+        .get("prompt_tokens")
+        .or_else(|| usage.get("input_tokens"))
+        .and_then(Value::as_i64);
+    let completion_tokens = usage
+        .get("completion_tokens")
+        .or_else(|| usage.get("output_tokens"))
+        .and_then(Value::as_i64);
     let total_tokens = match usage.get("total_tokens").and_then(Value::as_i64) {
         some @ Some(_) => some,
         None => match (prompt_tokens, completion_tokens) {

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -948,6 +948,8 @@ pub struct RouteCapabilitiesConfig {
     #[serde(default = "default_enabled")]
     pub chat_completions: bool,
     #[serde(default = "default_enabled")]
+    pub responses: bool,
+    #[serde(default = "default_enabled")]
     pub stream: bool,
     #[serde(default = "default_enabled")]
     pub embeddings: bool,
@@ -963,15 +965,16 @@ pub struct RouteCapabilitiesConfig {
 
 impl RouteCapabilitiesConfig {
     fn into_capabilities(self) -> ProviderCapabilities {
-        ProviderCapabilities::with_dimensions(
-            self.chat_completions,
-            self.stream,
-            self.embeddings,
-            self.tools,
-            self.vision,
-            self.json_schema,
-            self.developer_role,
-        )
+        ProviderCapabilities {
+            chat_completions: self.chat_completions,
+            responses: self.responses,
+            stream: self.stream,
+            embeddings: self.embeddings,
+            tools: self.tools,
+            vision: self.vision,
+            json_schema: self.json_schema,
+            developer_role: self.developer_role,
+        }
     }
 }
 
@@ -979,6 +982,7 @@ impl Default for RouteCapabilitiesConfig {
     fn default() -> Self {
         Self {
             chat_completions: true,
+            responses: true,
             stream: true,
             embeddings: true,
             tools: true,

--- a/crates/gateway/src/http/handlers.rs
+++ b/crates/gateway/src/http/handlers.rs
@@ -14,8 +14,9 @@ use futures_util::{StreamExt, stream};
 use gateway_core::{
     AuthenticatedApiKey, ChatCompletionsRequest, CoreRequestRequirements, EmbeddingsRequest,
     GatewayError, ModelsListResponse, ProviderCapabilities, ProviderClient, ProviderError,
-    ProviderRequestContext, RequestLogRecord, RequestTags, openai_chat_request_to_core,
-    openai_embeddings_request_to_core, protocol::openai::ModelCard,
+    ProviderRequestContext, RequestLogRecord, RequestTags, ResponsesRequest,
+    openai_chat_request_to_core, openai_embeddings_request_to_core,
+    openai_responses_request_to_core, protocol::openai::ModelCard,
 };
 use gateway_service::{
     RequestLogIconMetadata, ResolvedProviderConnection, resolve_model_icon_key,
@@ -103,7 +104,13 @@ pub async fn v1_chat_completions(
         request_tags,
     );
     let request_span = Span::current();
-    record_request_span_fields(&request_span, &auth, &resolved, core_request.stream);
+    record_request_span_fields(
+        &request_span,
+        &auth,
+        &resolved,
+        core_request.stream,
+        "/v1/chat/completions",
+    );
     let (eligible_route_count, selected) =
         select_first_eligible_route(&state.providers, &resolved.routes, requirements);
 
@@ -331,6 +338,269 @@ pub async fn v1_chat_completions(
     Ok(response)
 }
 
+pub async fn v1_responses(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<ResponsesRequest>,
+) -> Result<Response, AppError> {
+    let request_started_at = Instant::now();
+    let auth = state
+        .service
+        .authenticate(extract_authorization_header(&headers))
+        .await?;
+    let core_request = openai_responses_request_to_core(&request);
+    let requirements = core_request.requirements();
+    let resolved = state
+        .service
+        .resolve_request(&auth, &core_request.model)
+        .await?;
+
+    let request_id = extract_request_id(&headers);
+    let request_headers = extract_request_headers(&headers);
+    let request_tags = extract_request_tags(&headers)?;
+    let request_log_context = state.service.begin_responses_request_log(
+        &request_id,
+        &resolved.selection.requested_model.model_key,
+        &resolved.selection.execution_model.model_key,
+        &request,
+        &request_headers,
+        request_tags,
+    );
+    let request_span = Span::current();
+    record_request_span_fields(
+        &request_span,
+        &auth,
+        &resolved,
+        core_request.stream,
+        "/v1/responses",
+    );
+    let (eligible_route_count, selected) =
+        select_first_eligible_route(&state.providers, &resolved.routes, requirements);
+
+    tracing::info!(
+        request_model = %core_request.model,
+        resolved_model = %resolved.selection.execution_model.model_key,
+        route_count = resolved.routes.len(),
+        eligible_route_count,
+        stream = core_request.stream,
+        required_capabilities = ?requirements.required_capability_names(),
+        "responses request resolved"
+    );
+
+    let (route, provider) = match selected {
+        Some(selection) => selection,
+        None => {
+            let error = no_compatible_route_error(requirements);
+            state.metrics.record_chat_request(&ChatRequestMetric {
+                labels: ChatMetricLabels {
+                    requested_model: &resolved.selection.requested_model.model_key,
+                    resolved_model: &resolved.selection.execution_model.model_key,
+                    provider_key: "unavailable",
+                    stream: core_request.stream,
+                },
+                status_code: i64::from(error.http_status_code()),
+                outcome: error.error_type(),
+                latency_seconds: latency_seconds_since(request_started_at),
+            });
+            return Err(AppError(error));
+        }
+    };
+    let icon_metadata = request_log_icon_metadata(
+        &route,
+        resolved.provider_connections.get(&route.provider_key),
+        &resolved.selection.execution_model.model_key,
+        &resolved.selection.requested_model.model_key,
+    );
+    let labels = ChatMetricLabels {
+        requested_model: &resolved.selection.requested_model.model_key,
+        resolved_model: &resolved.selection.execution_model.model_key,
+        provider_key: &route.provider_key,
+        stream: core_request.stream,
+    };
+    record_provider_execution_span_fields(&request_span, &route.provider_key);
+
+    if let Err(error) = state
+        .service
+        .enforce_pre_provider_budget(&auth, &request_id, OffsetDateTime::now_utc())
+        .await
+    {
+        state.metrics.record_chat_request(&ChatRequestMetric {
+            labels: labels.clone(),
+            status_code: i64::from(error.http_status_code()),
+            outcome: error.error_type(),
+            latency_seconds: latency_seconds_since(request_started_at),
+        });
+        return Err(AppError(error));
+    }
+
+    let context = build_provider_context(
+        &request_id,
+        &resolved.selection.requested_model.model_key,
+        &route,
+        request_headers,
+    );
+
+    if core_request.stream {
+        let provider_execution_span = tracing::info_span!(
+            "provider_execution",
+            request_id = %request_id,
+            requested_model = %resolved.selection.requested_model.model_key,
+            resolved_model = %resolved.selection.execution_model.model_key,
+            provider = %route.provider_key,
+            stream = true,
+            ownership_kind = %auth.owner_kind.as_str(),
+        );
+        let stream = match provider
+            .responses_stream(&core_request, &context)
+            .instrument(provider_execution_span)
+            .await
+        {
+            Ok(stream) => stream,
+            Err(error) => {
+                let gateway_error = map_operation_provider_error(error, requirements);
+                tracing::warn!(
+                    request_id = %request_id,
+                    provider_key = %route.provider_key,
+                    termination_reason = "provider_responses_stream_start_error",
+                    error_code = %gateway_error.error_code(),
+                    "responses stream start failed"
+                );
+                best_effort_log_stream_result(
+                    &state.service,
+                    &auth,
+                    &request_log_context,
+                    gateway_service::StreamLogResultInput {
+                        provider_key: route.provider_key.clone(),
+                        icon_metadata: icon_metadata.clone(),
+                        latency_ms: latency_ms_since(request_started_at),
+                        collector: state.service.new_stream_response_collector(),
+                        failure: Some(gateway_service::StreamFailureSummary {
+                            status_code: gateway_error.http_status_code().into(),
+                            error_code: gateway_error.error_code().to_string(),
+                        }),
+                    },
+                )
+                .await;
+                state.metrics.record_chat_request(&ChatRequestMetric {
+                    labels,
+                    status_code: i64::from(gateway_error.http_status_code()),
+                    outcome: gateway_error.error_type(),
+                    latency_seconds: latency_seconds_since(request_started_at),
+                });
+                return Err(AppError(gateway_error));
+            }
+        };
+        let body_stream = wrap_stream_with_request_logging(LoggingBodyStreamState {
+            upstream: stream,
+            service: state.service.clone(),
+            metrics: state.metrics.clone(),
+            auth: auth.clone(),
+            request_log_context: request_log_context.clone(),
+            requested_model_key: resolved.selection.requested_model.model_key.clone(),
+            resolved_model_key: resolved.selection.execution_model.model_key.clone(),
+            execution_model: resolved.selection.execution_model.clone(),
+            route: route.clone(),
+            provider_key: route.provider_key.clone(),
+            icon_metadata: icon_metadata.clone(),
+            started_at: request_started_at,
+            finished: false,
+            collector: state.service.new_stream_response_collector(),
+        });
+
+        let mut response = Response::builder()
+            .status(axum::http::StatusCode::OK)
+            .header(CONTENT_TYPE, "text/event-stream; charset=utf-8")
+            .header(CACHE_CONTROL, "no-cache")
+            .body(Body::from_stream(body_stream))
+            .map_err(|error| {
+                AppError(GatewayError::Internal(format!(
+                    "failed to build responses streaming response: {error}"
+                )))
+            })?;
+
+        if let Ok(request_id_header) = HeaderValue::from_str(&request_id) {
+            response
+                .headers_mut()
+                .insert("x-request-id", request_id_header);
+        }
+
+        return Ok(response);
+    }
+
+    let provider_execution_span = tracing::info_span!(
+        "provider_execution",
+        request_id = %request_id,
+        requested_model = %resolved.selection.requested_model.model_key,
+        resolved_model = %resolved.selection.execution_model.model_key,
+        provider = %route.provider_key,
+        stream = false,
+        ownership_kind = %auth.owner_kind.as_str(),
+    );
+    let value = provider
+        .responses(&core_request, &context)
+        .instrument(provider_execution_span)
+        .await
+        .map_err(|error| map_operation_provider_error(error, requirements));
+    let value = match value {
+        Ok(value) => normalize_response_model(value, &resolved.selection.requested_model.model_key),
+        Err(error) => {
+            best_effort_log_non_stream_failure(
+                &state.service,
+                &auth,
+                &request_log_context,
+                &route.provider_key,
+                icon_metadata.clone(),
+                latency_ms_since(request_started_at),
+                &error,
+            )
+            .await;
+            state.metrics.record_chat_request(&ChatRequestMetric {
+                labels,
+                status_code: i64::from(error.http_status_code()),
+                outcome: error.error_type(),
+                latency_seconds: latency_seconds_since(request_started_at),
+            });
+            return Err(AppError(error));
+        }
+    };
+    finalize_successful_usage_accounting(
+        &state,
+        UsageAccountingContext {
+            auth: &auth,
+            model: &resolved.selection.execution_model,
+            route: &route,
+            request_id: &request_id,
+            labels: labels.clone(),
+            operation: "responses",
+        },
+        usage_value_from_response(&value),
+    )
+    .await;
+    best_effort_log_non_stream_success(
+        &state.service,
+        &auth,
+        &request_log_context,
+        &route.provider_key,
+        icon_metadata,
+        latency_ms_since(request_started_at),
+        &value,
+    )
+    .await;
+    state.metrics.record_chat_request(&ChatRequestMetric {
+        labels,
+        status_code: 200,
+        outcome: "success",
+        latency_seconds: latency_seconds_since(request_started_at),
+    });
+    let mut response = Json(value).into_response();
+    if let Ok(request_id_header) = HeaderValue::from_str(&request_id) {
+        response
+            .headers_mut()
+            .insert("x-request-id", request_id_header);
+    }
+    Ok(response)
+}
+
 pub async fn v1_embeddings(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -501,6 +771,7 @@ fn supports_requirements(
     requirements: CoreRequestRequirements,
 ) -> bool {
     (!requirements.chat_completions || capabilities.chat_completions)
+        && (!requirements.responses || capabilities.responses)
         && (!requirements.stream || capabilities.stream)
         && (!requirements.embeddings || capabilities.embeddings)
         && (!requirements.tools || capabilities.tools)
@@ -718,7 +989,7 @@ fn wrap_stream_with_request_logging(
                             route: &state.route,
                             request_id: &state.request_log_context.request_id,
                             labels,
-                            operation: "chat_completions",
+                            operation: state.request_log_context.operation,
                         },
                         state.collector.usage().cloned(),
                     )
@@ -951,8 +1222,14 @@ fn usage_summary_from_value(value: Option<&Value>) -> UsageSummary {
         return UsageSummary::default();
     };
 
-    let prompt_tokens = usage.get("prompt_tokens").and_then(Value::as_i64);
-    let completion_tokens = usage.get("completion_tokens").and_then(Value::as_i64);
+    let prompt_tokens = usage
+        .get("prompt_tokens")
+        .or_else(|| usage.get("input_tokens"))
+        .and_then(Value::as_i64);
+    let completion_tokens = usage
+        .get("completion_tokens")
+        .or_else(|| usage.get("output_tokens"))
+        .and_then(Value::as_i64);
     let total_tokens = match usage.get("total_tokens").and_then(Value::as_i64) {
         some @ Some(_) => some,
         None => match (prompt_tokens, completion_tokens) {
@@ -981,8 +1258,9 @@ fn record_request_span_fields(
     auth: &AuthenticatedApiKey,
     resolved: &gateway_service::ResolvedGatewayRequest,
     stream: bool,
+    route_path: &str,
 ) {
-    span.record("http.route", field::display("/v1/chat/completions"));
+    span.record("http.route", field::display(route_path));
     span.record(
         "requested_model",
         field::display(&resolved.selection.requested_model.model_key),

--- a/crates/gateway/src/http/mod.rs
+++ b/crates/gateway/src/http/mod.rs
@@ -129,6 +129,7 @@ pub fn build_router(state: AppState, admin_ui: AdminUiConfig) -> Router {
         .route("/api/v1/auth/oidc/callback", get(oidc_callback))
         .route("/v1/models", get(v1_models))
         .route("/v1/chat/completions", post(v1_chat_completions))
+        .route("/v1/responses", post(v1_responses))
         .route("/v1/embeddings", post(v1_embeddings))
         .with_state(state)
         .layer(

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1205,10 +1205,11 @@ mod tests {
     use gateway_core::{
         ApiKeyRepository, AuthMode, BudgetAlertChannel, BudgetAlertDeliveryRecord,
         BudgetAlertDeliveryStatus, BudgetAlertRepository, BudgetCadence, BudgetRepository,
-        CoreChatRequest, CoreEmbeddingsRequest, GlobalRole, IdentityRepository, MembershipRole,
-        ModelRepository, Money4, ProviderCapabilities, ProviderClient, ProviderError,
-        ProviderRequestContext, ProviderStream, SeedApiKey, SeedModel, SeedModelRoute,
-        SeedProvider, UsageLedgerRecord, UsagePricingStatus, parse_gateway_api_key,
+        CoreChatRequest, CoreEmbeddingsRequest, CoreResponsesRequest, GlobalRole,
+        IdentityRepository, MembershipRole, ModelRepository, Money4, ProviderCapabilities,
+        ProviderClient, ProviderError, ProviderRequestContext, ProviderStream, SeedApiKey,
+        SeedModel, SeedModelRoute, SeedProvider, UsageLedgerRecord, UsagePricingStatus,
+        parse_gateway_api_key,
     };
     use gateway_providers::{OpenAiCompatConfig, OpenAiCompatProvider};
     use gateway_service::{GatewayService, WeightedRoutePlanner, hash_gateway_key_secret};
@@ -1317,6 +1318,32 @@ mod tests {
                 "mock embeddings unsupported for this provider".to_string(),
             ))
         }
+
+        async fn responses(
+            &self,
+            _request: &CoreResponsesRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<Value, ProviderError> {
+            self.chat_calls.fetch_add(1, Ordering::SeqCst);
+            match self.chat_result.clone() {
+                MockChatResult::Value(value) => Ok(value),
+                MockChatResult::Error(error) => Err(error.into_provider_error()),
+            }
+        }
+
+        async fn responses_stream(
+            &self,
+            _request: &CoreResponsesRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<ProviderStream, ProviderError> {
+            let stream = futures_util::stream::iter(
+                self.stream_chunks
+                    .clone()
+                    .into_iter()
+                    .map(|chunk| Ok(Bytes::from(chunk))),
+            );
+            Ok(Box::pin(stream))
+        }
     }
 
     fn make_chat_provider(
@@ -1392,6 +1419,26 @@ mod tests {
                 MockEmbeddingsResult::Value(value) => Ok(value),
                 MockEmbeddingsResult::Error(error) => Err(error.into_provider_error()),
             }
+        }
+
+        async fn responses(
+            &self,
+            _request: &CoreResponsesRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<Value, ProviderError> {
+            Err(ProviderError::InvalidRequest(
+                "mock responses unsupported for this provider".to_string(),
+            ))
+        }
+
+        async fn responses_stream(
+            &self,
+            _request: &CoreResponsesRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<ProviderStream, ProviderError> {
+            Err(ProviderError::InvalidRequest(
+                "mock responses stream unsupported for this provider".to_string(),
+            ))
         }
     }
 
@@ -3423,6 +3470,162 @@ mod tests {
         assert_eq!(ledgers[0].request_id, request_id);
         assert_eq!(ledgers[0].pricing_status, "usage_missing");
         assert_eq!(ledgers[0].computed_cost_10000, 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn responses_executes_resolved_provider_and_records_usage() {
+        let (calls, provider) = make_chat_provider(
+            "openai-prod",
+            MockChatResult::Value(json!({
+                "id": "resp_123",
+                "object": "response",
+                "model": "gpt-5",
+                "output": [{"id":"msg_1","type":"message","content":[{"type":"output_text","text":"pong"}]}],
+                "usage": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+            })),
+            vec![],
+            ProviderCapabilities::openai_compat_baseline(),
+        );
+        let mut registry = gateway_core::ProviderRegistry::new();
+        registry.register(Arc::new(provider));
+
+        let (app, raw_key, db_path) = build_default_test_app(registry).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/responses")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {raw_key}"))
+                    .body(Body::from(
+                        json!({
+                            "model": "fast",
+                            "input": [{"type":"message","role":"user","content":"ping"}]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        let request_id = response
+            .headers()
+            .get("x-request-id")
+            .expect("x-request-id header")
+            .to_str()
+            .expect("request id value")
+            .to_string();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let payload: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(payload["model"], "fast");
+        assert_eq!(payload["object"], "response");
+
+        let logs = load_request_logs(&db_path).await;
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].provider_key, "openai-prod");
+        assert_eq!(logs[0].status_code, Some(200));
+        assert_eq!(logs[0].prompt_tokens, Some(11));
+        assert_eq!(logs[0].completion_tokens, Some(7));
+        assert_eq!(logs[0].total_tokens, Some(18));
+        assert_eq!(logs[0].metadata["stream"], Value::Bool(false));
+        assert_eq!(logs[0].metadata["operation"], "responses");
+
+        let ledgers = load_usage_ledger(&db_path).await;
+        assert_eq!(ledgers.len(), 1);
+        assert_eq!(ledgers[0].request_id, request_id);
+        assert_eq!(ledgers[0].provider_key, "openai-prod");
+        assert_eq!(ledgers[0].prompt_tokens, Some(11));
+        assert_eq!(ledgers[0].completion_tokens, Some(7));
+        assert_eq!(ledgers[0].total_tokens, Some(18));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn responses_rejects_when_no_route_supports_responses() {
+        let (calls, provider) = make_chat_provider(
+            "openai-prod",
+            MockChatResult::Value(json!({"object":"response","output":[]})),
+            vec![],
+            ProviderCapabilities::openai_compat_baseline(),
+        );
+        let mut registry = gateway_core::ProviderRegistry::new();
+        registry.register(Arc::new(provider));
+
+        let seed_providers = vec![SeedProvider {
+            provider_key: "openai-prod".to_string(),
+            provider_type: "openai_compat".to_string(),
+            config: serde_json::json!({"base_url": "https://api.openai.com/v1"}),
+            secrets: None,
+        }];
+        let models = vec![SeedModel {
+            model_key: "fast".to_string(),
+            alias_target_model_key: None,
+            description: Some("Fast tier".to_string()),
+            tags: vec!["fast".to_string()],
+            rank: 10,
+            routes: vec![SeedModelRoute {
+                provider_key: "openai-prod".to_string(),
+                upstream_model: "gpt-5".to_string(),
+                priority: 10,
+                weight: 1.0,
+                enabled: true,
+                extra_headers: Map::<String, Value>::new(),
+                extra_body: Map::<String, Value>::new(),
+                capabilities: ProviderCapabilities {
+                    chat_completions: true,
+                    responses: false,
+                    stream: true,
+                    embeddings: true,
+                    tools: true,
+                    vision: true,
+                    json_schema: true,
+                    developer_role: true,
+                },
+                compatibility: Default::default(),
+            }],
+        }];
+
+        let (app, raw_key, _) = build_test_app(seed_providers, models, registry).await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/responses")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {raw_key}"))
+                    .body(Body::from(
+                        json!({
+                            "model": "fast",
+                            "input": "ping"
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let payload: Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            payload["error"]["message"]
+                .as_str()
+                .expect("message")
+                .contains("responses")
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/2026-03-13-capability-aware-route-gating.md
+++ b/docs/adr/2026-03-13-capability-aware-route-gating.md
@@ -32,6 +32,7 @@ We introduced richer per-route capability metadata and pre-execution capability 
 `ProviderCapabilities` now models:
 
 - `chat_completions`
+- `responses`
 - `stream`
 - `embeddings`
 - `tools`

--- a/docs/adr/2026-03-13-protocol-neutral-core-request-boundary.md
+++ b/docs/adr/2026-03-13-protocol-neutral-core-request-boundary.md
@@ -28,13 +28,14 @@ We introduced a protocol-neutral core request model and moved the provider trait
 
 - `ChatRequest`
 - `ChatMessage`
+- `ResponsesRequest`
 - `EmbeddingsRequest`
 
 These are the canonical execution model used by provider adapters.
 
 ### 2. Keep OpenAI wire DTOs as the external API layer
 
-`gateway-core::protocol::openai` remains the wire contract for HTTP handlers. This preserves `/v1/chat/completions` and `/v1/embeddings` compatibility while internal execution can evolve independently.
+`gateway-core::protocol::openai` remains the wire contract for HTTP handlers. This preserves `/v1/chat/completions`, `/v1/responses`, and `/v1/embeddings` compatibility while internal execution can evolve independently.
 
 ### 3. Add explicit translators between wire and core models
 

--- a/docs/adr/2026-04-23-openai-responses-api-family-boundary.md
+++ b/docs/adr/2026-04-23-openai-responses-api-family-boundary.md
@@ -1,0 +1,26 @@
+# OpenAI Responses API Family Boundary
+
+## Status
+
+Accepted
+
+## Context
+
+The gateway already exposed OpenAI-shaped Chat Completions and Embeddings. The OpenAI Responses API has different request input shapes, output items, usage fields, reasoning items, tool events, and stream event names. Treating Responses as Chat Completions with transformed fields would lose semantics and create a compatibility shim that would be hard to unwind.
+
+## Decision
+
+`POST /v1/responses` is a first-class public API family.
+
+Implementation rules:
+
+- `gateway-core` owns a distinct Responses wire DTO and core request type.
+- provider execution uses `ProviderClient::responses` and `ProviderClient::responses_stream`.
+- route gating requires the `responses` capability.
+- the OpenAI-compatible provider posts to upstream `/v1/responses`.
+- Responses streams preserve `response.*` event names and payloads instead of normalizing into Chat Completions chunks.
+- usage is normalized from `input_tokens`, `output_tokens`, and `total_tokens`.
+
+## Consequences
+
+The gateway now has a durable place to add Responses-specific behavior without overloading Chat Completions compatibility profiles. The first slice still returns upstream response objects as JSON and preserves stream event payloads; richer semantic normalization for hosted tools, multimodal content, and cache/reasoning counters remains follow-up work.

--- a/docs/adr/2026-04-23-route-level-provider-api-compatibility-profiles.md
+++ b/docs/adr/2026-04-23-route-level-provider-api-compatibility-profiles.md
@@ -53,7 +53,7 @@ Trade-offs:
 
 ## Follow-Up
 
-- Add OpenAI Responses API support with a first-class request, response, and stream model.
+- Continue expanding OpenAI Responses API coverage on its first-class request, response, and stream boundary.
 - Add native Anthropic Messages API-family mapping.
 - Add direct Google Generative AI provider support beyond Vertex.
 - Add cross-provider tool-call streaming fixtures and normalization.

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -320,6 +320,8 @@ Capability flags default permissively. A route can constrain provider capability
 
 Compatibility metadata is separate from capabilities. Capabilities decide whether a route may execute; compatibility describes explicit request and stream-shape transforms for the selected provider route.
 
+Capability flags include API-family gates such as `chat_completions`, `responses`, and `embeddings`, plus feature gates such as `stream`, `tools`, `vision`, `json_schema`, and `developer_role`.
+
 OpenAI-compatible route profile:
 
 ```yaml
@@ -346,6 +348,8 @@ OpenAI-compatible profile defaults:
 | `developer_role` | `developer` | `developer`, `system` |
 | `reasoning_effort` | `passthrough` | `passthrough`, `omit`, `reasoning_object` |
 | `supports_stream_usage` | `false` | `true`, `false` |
+
+The current `openai_compat` profile fields are Chat Completions transforms. `/v1/responses` is a separate supported API family and is not adapted by reusing Chat Completions compatibility shims.
 
 Do not use `extra_body` for compatibility transforms. `extra_body` remains for additive provider-specific overrides, and the typed compatibility profile remains authoritative when a declared transform conflicts with an additive override.
 

--- a/docs/configuration/model-routing-and-api-behavior.md
+++ b/docs/configuration/model-routing-and-api-behavior.md
@@ -23,6 +23,7 @@ The live public endpoints are:
 
 - `GET /v1/models`
 - `POST /v1/chat/completions`
+- `POST /v1/responses`
 - `POST /v1/embeddings`
 
 All are authenticated.
@@ -92,6 +93,7 @@ Routes are filtered before provider execution based on request requirements and 
 Current capability dimensions:
 
 - `chat_completions`
+- `responses`
 - `stream`
 - `embeddings`
 - `tools`
@@ -110,7 +112,7 @@ Capabilities and compatibility have different jobs:
 - `capabilities` gates whether the route can execute a request at all
 - `compatibility` rewrites the outbound provider request shape after a route is selected
 
-OpenAI-compatible route profiles currently cover deterministic transforms such as `store` removal, token field renaming, `developer` role rewriting, `reasoning_effort` handling, and stream usage requests.
+OpenAI-compatible route profiles currently cover deterministic Chat Completions transforms such as `store` removal, token field renaming, `developer` role rewriting, `reasoning_effort` handling, and stream usage requests. Responses uses a separate typed request/provider path; Chat Completions transforms must not be used as Responses shims.
 
 See [provider-api-compatibility.md](../reference/provider-api-compatibility.md) for the compatibility matrix and field-level contract.
 
@@ -159,6 +161,17 @@ Current behavior highlights:
 - budget checks run before provider execution
 - successful requests write usage when usage can be normalized
 - request logs store both requested and resolved model identity
+
+## `/v1/responses`
+
+`POST /v1/responses` follows the same authentication, model resolution, route planning, budget guard, logging, and ledger flow as Chat Completions.
+
+Important differences:
+
+- route capability filtering requires `responses`
+- provider execution calls the provider's Responses methods, not Chat Completions methods
+- streaming preserves Responses `response.*` event names and payloads instead of rewriting them into Chat Completions chunks
+- usage is normalized from `input_tokens`, `output_tokens`, and `total_tokens`
 
 ## `/v1/embeddings`
 

--- a/docs/configuration/pricing-catalog-and-accounting.md
+++ b/docs/configuration/pricing-catalog-and-accounting.md
@@ -100,7 +100,9 @@ Routes can opt into that request shape with `compatibility.openai_compat.support
 - provider-specific usage counters may not fit the gateway accounting model
 - successful requests can still become `usage_missing` or `unpriced`
 
-The accounting model remains limited to `prompt_tokens`, `completion_tokens`, and `total_tokens` in this slice.
+This compatibility option is Chat Completions-specific. Responses streams use the Responses event model and read usage from completed response events with `response.usage`.
+
+The accounting model remains limited to prompt/input tokens, completion/output tokens, and total tokens in this slice.
 
 ## Relationship to Request Flow
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ This site is the operator and maintainer map for the gateway.
   - [Operator Runbooks](operations/operator-runbooks.md)
 - Cross-cutting request path across routing, logging, pricing, and spend:
   - [Request Lifecycle and Failure Modes](reference/request-lifecycle-and-failure-modes.md)
-- Provider API family support, OpenAI-compatible route quirks, and deferred compatibility work:
+- Provider API family support, OpenAI-compatible route quirks, and compatibility follow-up work:
   - [Provider API Compatibility](reference/provider-api-compatibility.md)
 - Admin UI capability map and live versus preview-backed surface split:
   - [Admin Control Plane](access/admin-control-plane.md)

--- a/docs/operations/budgets-and-spending.md
+++ b/docs/operations/budgets-and-spending.md
@@ -36,6 +36,7 @@ Only `priced` and `legacy_estimated` rows count toward spend totals and budget w
 Pre-provider hard-limit checks run on the live request path for:
 
 - `POST /v1/chat/completions`
+- `POST /v1/responses`
 - `POST /v1/embeddings`
 
 Budgets are enforced by owner scope:

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -33,7 +33,7 @@ The intended deploy path is collector-friendly OTLP export rather than an in-pro
 
 The runtime emits bounded request-level signals for:
 
-- chat request totals
+- API request totals
 - request latency
 - request outcomes
 - token totals
@@ -90,6 +90,8 @@ The summary row stores:
 - truncation flags
 - metadata such as `operation` and `stream`
 
+`operation` is the public API family. Current values include `chat_completions`, `responses`, and `embeddings`.
+
 Streaming requests persist a bounded transcript payload rather than raw transport bytes.
 
 The stream payload contract is incremental rather than chunk-local:
@@ -98,10 +100,11 @@ The stream payload contract is incremental rather than chunk-local:
 - SSE `data:` frames are reassembled across chunk boundaries
 - both `data:` and `data: ` forms are accepted
 - the latest coherent `usage` object is retained for request-log and ledger work
+- Responses streams also retain usage from `response.usage` on completed response events
 
 Request-log payloads are user-visible artifacts. They do not persist the transformed outbound provider request body produced by route compatibility profiles.
 
-Provider stream transcripts can include normalized compatibility output, such as promoted usage or canonical reasoning deltas, because that normalized stream is what the gateway returns to callers.
+Provider stream transcripts can include normalized compatibility output, such as promoted usage or canonical reasoning deltas, because that normalized stream is what the gateway returns to callers. Responses streams preserve `response.*` event names and payloads rather than being rewritten into Chat Completions chunks.
 
 ## Redaction and Truncation Boundaries
 

--- a/docs/reference/data-relationships.md
+++ b/docs/reference/data-relationships.md
@@ -50,6 +50,8 @@ This document is schema-oriented. It describes the persistent relationships that
 - `capabilities_json` controls whether the route may execute a request
 - `compatibility_json` controls declared provider API compatibility transforms after route selection
 
+`capabilities_json` includes API-family gates such as `chat_completions`, `responses`, and `embeddings`.
+
 Compatibility metadata is not a provider config fallback and is not an `extra_body` convention.
 
 ### Identity and Access Tables

--- a/docs/reference/e2e-contract-tests.md
+++ b/docs/reference/e2e-contract-tests.md
@@ -53,6 +53,7 @@ The current suite already covers:
 - browser auth and forced password-rotation flow
 - public `/v1/models`
 - public `/v1/chat/completions`
+- public `/v1/responses`
 - admin UI API-key create, live use, and revoke
 - live spend report API behavior
 - team hard-limit enforcement for team-owned keys

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -1,6 +1,6 @@
 # Provider API Compatibility
 
-`See also`: [Configuration Reference](../configuration/configuration-reference.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Request Lifecycle and Failure Modes](request-lifecycle-and-failure-modes.md), [Pricing Catalog and Accounting](../configuration/pricing-catalog-and-accounting.md), [Observability and Request Logs](../operations/observability-and-request-logs.md), [ADR: Route-Level Provider API Compatibility Profiles](../adr/2026-04-23-route-level-provider-api-compatibility-profiles.md)
+`See also`: [Configuration Reference](../configuration/configuration-reference.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Request Lifecycle and Failure Modes](request-lifecycle-and-failure-modes.md), [Pricing Catalog and Accounting](../configuration/pricing-catalog-and-accounting.md), [Observability and Request Logs](../operations/observability-and-request-logs.md), [ADR: Route-Level Provider API Compatibility Profiles](../adr/2026-04-23-route-level-provider-api-compatibility-profiles.md), [OpenAI Responses API Family Boundary](../adr/2026-04-23-openai-responses-api-family-boundary.md)
 
 This page describes the live compatibility contract between the gateway's public OpenAI-shaped API and provider-specific upstream APIs.
 
@@ -10,17 +10,18 @@ The gateway currently exposes:
 
 - `GET /v1/models`
 - `POST /v1/chat/completions`
+- `POST /v1/responses`
 - `POST /v1/embeddings`
 
-The first compatibility slice does not add `/v1/responses`, `/v1/messages`, or direct Google Generative AI endpoints.
+The Responses API is a first-class API family. It is not translated through Chat Completions.
 
 ## API-Family Matrix
 
 | API family | Current gateway status | Adapter path | Compatibility policy |
 | --- | --- | --- | --- |
 | OpenAI Chat Completions | Supported for `openai_compat` providers | `crates/gateway-providers/src/openai_compat.rs` | Route-level `openai_compat` profile can declare request-shape quirks and streaming usage support. |
+| OpenAI Responses API | Supported for `openai_compat` providers | `crates/gateway-providers/src/openai_compat.rs` | Uses a distinct typed request/core/provider boundary and preserves Responses event-stream semantics. |
 | OpenAI Embeddings | Supported for `openai_compat` providers | `crates/gateway-providers/src/openai_compat.rs` | Uses the same route/provider resolution path; no compatibility transforms are applied in this slice. |
-| OpenAI Responses API | Not implemented | Follow-up issue | Requires a distinct request/response/event model instead of forcing Responses semantics through Chat Completions. |
 | Anthropic Messages | Not implemented as a native public API | Follow-up issue | Vertex Anthropic transport exists, but native Messages semantics need explicit mapping and tests. |
 | Google Generative AI | Not implemented as a direct API-key provider path | Follow-up issue | Vertex Google transport exists; direct Google native API needs separate auth, request, and stream mapping. |
 | Cross-provider multimodal files/images | Partial, provider-dependent | Follow-up issue | Needs explicit request body and accounting semantics across OpenAI-compatible, Vertex Google, Anthropic, and Google native APIs. |
@@ -54,6 +55,8 @@ models:
 
 ## OpenAI-Compatible Profile Fields
 
+These profile transforms apply to Chat Completions request-shape quirks unless explicitly stated. Responses requests use the same route/provider selection path, but they are not patched with Chat Completions compatibility shims such as `stream_options.include_usage`.
+
 `openai_compat.supports_store`
 
 - default: `true`
@@ -82,7 +85,7 @@ models:
 
 ## Stream Normalization
 
-The OpenAI-compatible stream adapter keeps the SSE transcript OpenAI-shaped while normalizing common provider variants:
+The Chat Completions stream adapter keeps the SSE transcript OpenAI-shaped while normalizing common provider variants:
 
 - appends one final `data: [DONE]` when the upstream omits it after valid payload events
 - promotes `choices[*].usage` to top-level `usage` when top-level usage is absent
@@ -91,6 +94,8 @@ The OpenAI-compatible stream adapter keeps the SSE transcript OpenAI-shaped whil
 - emits structured SSE error chunks for malformed or incomplete streams instead of pretending the stream completed normally
 
 This is intentionally narrower than full tool-call streaming normalization. Tool-call streaming needs a richer gateway event model and is tracked separately.
+
+The Responses stream adapter is separate. It parses SSE frames for transport safety, preserves `event: response.*` names and JSON payloads, surfaces malformed or incomplete streams as structured SSE error chunks, and appends one final `data: [DONE]` only after a successful upstream stream that omitted it.
 
 ## Accounting Boundary
 
@@ -101,6 +106,8 @@ Current durable accounting only relies on:
 - `prompt_tokens`
 - `completion_tokens`
 - `total_tokens`
+
+Responses usage is normalized from `usage.input_tokens`, `usage.output_tokens`, and `usage.total_tokens` into the gateway's prompt/completion/total accounting columns. Streaming Responses usage is read from completed response events with `response.usage`.
 
 Provider-specific cache, reasoning, image, audio, and modality counters remain follow-up work. Until those semantics are explicit, successful requests may still become `usage_missing` or `unpriced`.
 
@@ -116,7 +123,6 @@ The route-profile design follows the same broad lesson visible in mature adapter
 
 These items are intentionally outside this first slice:
 
-- OpenAI Responses API request, response, and stream events
 - native Anthropic Messages public/API-family mapping
 - direct Google Generative AI provider/API-key path
 - cross-provider tool-call streaming normalization fixtures

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -29,7 +29,7 @@ The live request path is single-route in this slice.
    - Lower `priority` wins first.
    - `weight` only matters inside the same priority bucket.
    - Disabled routes and non-positive weights drop out.
-5. Capability filtering removes routes that cannot satisfy the request.
+5. Capability filtering removes routes that cannot satisfy the API family and feature requirements. For example, `/v1/responses` requires `responses`, while `/v1/chat/completions` requires `chat_completions`.
 6. The budget guard runs before provider execution.
    - hard-limit rejection returns `429 budget_exceeded`
    - no provider call occurs on this path
@@ -49,7 +49,7 @@ Compatibility transforms affect the provider request body and stream options. Th
 One common request path looks like this:
 
 - Request:
-  - `POST /v1/chat/completions`
+  - `POST /v1/responses`
   - API key belongs to team `growth`
   - model is `tag:fast`
 - Access:
@@ -64,10 +64,10 @@ One common request path looks like this:
   - route B has priority `100`
   - route A wins before weight is considered
 - Capability filter:
-  - the request asks for plain chat, no tools, no vision
+  - the request asks for the Responses API family, no tools, no vision
   - route A stays eligible
 - Execution:
-  - the provider request goes to the route A provider and upstream model
+  - the provider request goes to the route A provider and upstream model through the Responses adapter
 - Logging:
   - `request_logs.model_key` stores `gpt-4o-mini`
   - `request_logs.resolved_model_key` stores `openai-gpt-4o-mini`
@@ -103,6 +103,7 @@ These failures look similar from far away, but they mean different things.
 - Capability filtering removed every remaining route.
 - Common causes:
   - embeddings against a chat-only route
+  - Responses requests against a route with `responses: false`
   - tools against a route with tools disabled
   - vision against a route that does not advertise vision
 
@@ -155,11 +156,11 @@ That separation matters in two common cases:
 - a request can be logged even when it becomes `unpriced`
 - a request can be logged even when a later accounting step hits a rough edge
 
-For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure.
+For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure. Chat Completions streams usually expose usage at top level. Responses streams expose usage on completed response events as `response.usage`.
 
 ## Known Rough Edges
 
-- Stream and non-stream chat paths still differ when a post-provider ledger write fails.
+- Stream and non-stream paths still differ when a post-provider ledger write fails.
 - Request-log payload policy is still bounded and heuristic, not operator-configurable.
 
 For the current observability cleanup notes, see [observability-and-request-logs.md](../operations/observability-and-request-logs.md).


### PR DESCRIPTION
## Description

Closes #88.

Adds a first-class OpenAI Responses API family boundary instead of routing Responses through Chat Completions compatibility shims.

- Summary of changes: adds `/v1/responses` request DTOs, core/openai translation, route capability gating, provider trait methods, OpenAI-compatible provider request/stream handling, request logging and usage accounting support, and documentation/ADR coverage.
- Why this approach was chosen: Responses is modeled as its own API family so route selection, provider behavior, accounting, and docs remain explicit and testable.
- How it works: requests translate into `CoreResponsesRequest`, route selection requires the `responses` capability, OpenAI-compatible routes call `/responses` directly, stream events are preserved with gateway termination, and usage is read from Responses-style `input_tokens`/`output_tokens` fields.
- Risks, tradeoffs, and alternatives considered: this intentionally does not add non-OpenAI native provider mappings or tool-call streaming normalization beyond the current event boundary; those remain separate compatibility work.
- Additional context for reviewers: the docs and ADRs were updated around provider compatibility, request lifecycle, routing capabilities, accounting, and observability semantics.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation run:

- [x] `mise run docs-check`
- [x] `cargo test -p gateway-core -p gateway-providers -p gateway-service -p gateway`