### PR TITLE
feat(admin): add current-session logout

### DIFF
--- a/crates/admin-ui/web/e2e/admin-auth.e2e.ts
+++ b/crates/admin-ui/web/e2e/admin-auth.e2e.ts
@@ -31,11 +31,7 @@ test('bootstrap admin must rotate the password before accessing the control plan
   ])
 
   await expect(page.getByText('Oceans Gateway')).toBeVisible()
-  await expect(
-    page.getByText(
-      'API keys, identity, spend, and observability are gateway-backed. Model inventory is still preview-only in this environment.',
-    ),
-  ).toBeVisible()
+  await expect(page.getByText(adminEmail).first()).toBeVisible()
 
   const sessionPayload = await page.evaluate(async () => {
     const response = await fetch('/api/v1/auth/session')
@@ -44,4 +40,19 @@ test('bootstrap admin must rotate the password before accessing the control plan
 
   expect(sessionPayload.data.must_change_password).toBe(false)
   expect(sessionPayload.data.user.email).toBe(adminEmail)
+
+  await page.getByRole('button', { name: new RegExp(adminEmail) }).click()
+  await Promise.all([
+    page.waitForURL(/\/admin\/login$/),
+    page.getByRole('menuitem', { name: 'Sign out' }).click(),
+  ])
+
+  const signedOutPayload = await page.evaluate(async () => {
+    const response = await fetch('/api/v1/auth/session')
+    return response.json()
+  })
+  expect(signedOutPayload.data).toBeNull()
+
+  await page.goto('/admin/api-keys')
+  await expect(page).toHaveURL(/\/admin\/login\?redirect=%2Fapi-keys$/)
 })

--- a/crates/admin-ui/web/src/components/app-sidebar.tsx
+++ b/crates/admin-ui/web/src/components/app-sidebar.tsx
@@ -10,6 +10,14 @@ import {
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -27,9 +35,11 @@ import type { AuthSessionView } from '@/types/api'
 interface AppSidebarProps {
   currentPath: string
   session: AuthSessionView
+  signOutPending: boolean
+  onSignOut: () => void
 }
 
-export function AppSidebar({ currentPath, session }: AppSidebarProps) {
+export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: AppSidebarProps) {
   const activeSection = getActiveNavSection(currentPath)
 
   return (
@@ -112,33 +122,56 @@ export function AppSidebar({ currentPath, session }: AppSidebarProps) {
       </SidebarContent>
 
       <SidebarFooter className="border-sidebar-border/70 gap-3 border-t p-3">
-        <div className="border-sidebar-border/70 bg-sidebar-accent/35 text-sidebar-foreground/75 rounded-xl border p-3 text-xs group-data-[collapsible=icon]:hidden">
-          <p className="text-sidebar-foreground font-medium">Local preview mode</p>
-          <p className="mt-1 leading-relaxed">
-            Gateway-backed admin flows are live here. Model inventory remains preview-only.
-          </p>
-        </div>
-
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton asChild size="lg" className="h-auto rounded-xl px-3 py-3">
-              <Link to="/change-password">
-                <Avatar className="size-8 rounded-lg">
-                  <AvatarFallback className="bg-sidebar-primary/15 text-sidebar-primary rounded-lg">
-                    {getInitials(session.user.name)}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium">{session.user.name}</span>
-                  <span className="text-sidebar-foreground/70 truncate text-xs">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton size="lg" className="h-auto rounded-xl px-3 py-3">
+                  <Avatar className="size-8 rounded-lg">
+                    <AvatarFallback className="bg-sidebar-primary/15 text-sidebar-primary rounded-lg">
+                      {getInitials(session.user.name)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
+                    <span className="truncate font-medium">{session.user.name}</span>
+                    <span className="text-sidebar-foreground/70 truncate text-xs">
+                      {session.user.email}
+                    </span>
+                  </div>
+                  <AppIcon
+                    icon={ArrowRight01Icon}
+                    size={16}
+                    stroke={1.5}
+                    className="ml-auto rotate-[-90deg] group-data-[collapsible=icon]:hidden"
+                  />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="top" align="start" className="w-64">
+                <DropdownMenuLabel className="grid gap-1">
+                  <span className="truncate text-sm font-medium">{session.user.name}</span>
+                  <span className="text-muted-foreground truncate text-xs font-normal">
                     {session.user.email}
                   </span>
-                </div>
-                <span className="border-sidebar-border/70 text-sidebar-foreground/70 hidden rounded-full border px-2 py-0.5 text-[10px] font-medium tracking-[0.14em] uppercase group-data-[collapsible=icon]:hidden xl:inline-flex">
-                  {session.user.global_role}
-                </span>
-              </Link>
-            </SidebarMenuButton>
+                  <span className="text-muted-foreground text-xs font-normal">
+                    {formatRole(session.user.global_role)}
+                  </span>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link to="/change-password">Change password</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  variant="destructive"
+                  disabled={signOutPending}
+                  onSelect={(event) => {
+                    event.preventDefault()
+                    onSignOut()
+                  }}
+                >
+                  {signOutPending ? 'Signing out...' : 'Sign out'}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>
@@ -155,4 +188,12 @@ function getInitials(name: string) {
     .slice(0, 2)
     .map((part) => part[0]?.toUpperCase() ?? '')
     .join('')
+}
+
+function formatRole(role: string) {
+  return role
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ')
 }

--- a/crates/admin-ui/web/src/components/layout/app-shell.test.tsx
+++ b/crates/admin-ui/web/src/components/layout/app-shell.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppShell } from '@/components/layout/app-shell'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -10,7 +10,28 @@ vi.mock('@tanstack/react-router', async () => ({
   useRouterState: () => '/admin/api-keys',
 }))
 
+const logoutAdminSession = vi.fn()
+
+vi.mock('@/server/admin-data.functions', () => ({
+  logoutAdminSession: () => logoutAdminSession(),
+}))
+
 describe('AppShell', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    logoutAdminSession.mockReset()
+    logoutAdminSession.mockResolvedValue({ data: { status: 'ok' } })
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, replace: vi.fn() },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
   it('renders all required menu sections and items', () => {
     render(
       <TooltipProvider>
@@ -37,10 +58,42 @@ describe('AppShell', () => {
       'Observability',
       'Identity',
       'Admin User',
+      'admin@example.com',
     ]
 
     for (const label of labels) {
       expect(screen.getAllByText(label).length).toBeGreaterThan(0)
     }
+  })
+
+  it('signs out from the account menu', async () => {
+    render(
+      <TooltipProvider>
+        <AppShell
+          session={{
+            must_change_password: false,
+            user: {
+              id: 'user_1',
+              name: 'Admin User',
+              email: 'admin@example.com',
+              global_role: 'platform_admin',
+            },
+          }}
+        >
+          content
+        </AppShell>
+      </TooltipProvider>,
+    )
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: /Admin User/i }))
+    expect(await screen.findByText('Change password')).toBeVisible()
+    expect(screen.getByText('Platform Admin')).toBeVisible()
+
+    fireEvent.click(screen.getByText('Sign out'))
+
+    await waitFor(() => {
+      expect(logoutAdminSession).toHaveBeenCalledTimes(1)
+      expect(window.location.replace).toHaveBeenCalledWith('/admin/login')
+    })
   })
 })

--- a/crates/admin-ui/web/src/components/layout/app-shell.tsx
+++ b/crates/admin-ui/web/src/components/layout/app-shell.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from 'react'
+import { useTransition, type ReactNode } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
+import { toast } from 'sonner'
 
 import { AppSidebar } from '@/components/app-sidebar'
 import {
@@ -17,6 +18,7 @@ import {
 } from '@/components/ui/breadcrumb'
 import { Separator } from '@/components/ui/separator'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
+import { logoutAdminSession } from '@/server/admin-data.functions'
 import type { AuthSessionView } from '@/types/api'
 
 interface AppShellProps {
@@ -26,13 +28,30 @@ interface AppShellProps {
 
 export function AppShell({ children, session }: AppShellProps) {
   const pathname = useRouterState({ select: (state) => state.location.pathname })
+  const [isSigningOut, startSignOut] = useTransition()
   const currentPath = normalizeAdminPath(pathname)
   const activeSection = getActiveNavSection(currentPath)
   const activeItem = getActiveNavItem(currentPath)
 
+  function handleSignOut() {
+    startSignOut(async () => {
+      try {
+        await logoutAdminSession()
+        window.location.replace('/admin/login')
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Unable to sign out')
+      }
+    })
+  }
+
   return (
     <SidebarProvider>
-      <AppSidebar currentPath={currentPath} session={session} />
+      <AppSidebar
+        currentPath={currentPath}
+        session={session}
+        signOutPending={isSigningOut}
+        onSignOut={handleSignOut}
+      />
 
       <SidebarInset>
         <header className="border-border/70 bg-background/80 sticky top-0 z-20 flex h-16 shrink-0 items-center gap-3 border-b px-4 backdrop-blur-xl sm:px-6">

--- a/crates/admin-ui/web/src/components/ui/card.tsx
+++ b/crates/admin-ui/web/src/components/ui/card.tsx
@@ -33,9 +33,9 @@ function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+function CardTitle({ className, ...props }: React.ComponentProps<'h3'>) {
   return (
-    <div
+    <h3
       data-slot="card-title"
       className={cn(
         'font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm',

--- a/crates/admin-ui/web/src/generated/admin-api.ts
+++ b/crates/admin-ui/web/src/generated/admin-api.ts
@@ -420,6 +420,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["logout_current_session"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/auth/oidc/callback": {
         parameters: {
             query?: never;
@@ -1942,6 +1958,25 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Envelope_AuthSessionView"];
+                };
+            };
+        };
+    };
+    logout_current_session: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Envelope_IdentityActionStatus"];
                 };
             };
         };

--- a/crates/admin-ui/web/src/routes/-admin-guard.ts
+++ b/crates/admin-ui/web/src/routes/-admin-guard.ts
@@ -2,6 +2,7 @@ import { createIsomorphicFn } from '@tanstack/react-start'
 import { redirect } from '@tanstack/react-router'
 
 import { getAuthSession } from '@/server/admin-data.functions'
+import { buildRedirectTarget, isPlatformAdminSession } from '@/routes/-auth-routing'
 
 const loadAuthSession = createIsomorphicFn()
   .server(async () => {
@@ -10,40 +11,23 @@ const loadAuthSession = createIsomorphicFn()
   })
   .client(() => getAuthSession())
 
-function normalizeAdminPath(pathname: string) {
-  return pathname.replace(/^\/admin(?=\/|$)/, '') || '/'
-}
-
-function buildRedirectTarget(pathname: string, search: Record<string, unknown>) {
-  const currentPath = normalizeAdminPath(pathname)
-  const query = new URLSearchParams()
-
-  for (const [key, value] of Object.entries(search)) {
-    if (typeof value === 'string') {
-      query.set(key, value)
-    }
-  }
-
-  const searchString = query.toString()
-  return searchString ? `${currentPath}?${searchString}` : currentPath
-}
-
 export async function requireAdminSession(location: {
   pathname: string
   search: Record<string, unknown>
 }) {
   const { data: session } = await loadAuthSession()
+  const adminSession = isPlatformAdminSession(session) ? session : null
 
-  if (!session) {
+  if (!adminSession) {
     throw redirect({
       to: '/login',
       search: { redirect: buildRedirectTarget(location.pathname, location.search) },
     })
   }
 
-  if (session.must_change_password) {
+  if (adminSession.must_change_password) {
     throw redirect({ to: '/change-password' })
   }
 
-  return { session }
+  return { session: adminSession }
 }

--- a/crates/admin-ui/web/src/routes/-auth-routing.ts
+++ b/crates/admin-ui/web/src/routes/-auth-routing.ts
@@ -1,0 +1,48 @@
+import type { AuthSessionView } from '@/types/api'
+
+export const DEFAULT_SIGNED_IN_PATH = '/api-keys'
+
+export function normalizeAdminPath(pathname: string) {
+  return pathname.replace(/^\/admin(?=\/|$)/, '') || '/'
+}
+
+export function isPublicAdminRoute(currentPath: string) {
+  return (
+    currentPath.startsWith('/invite/') ||
+    currentPath.startsWith('/account-ready') ||
+    currentPath === '/login' ||
+    currentPath === '/change-password'
+  )
+}
+
+export function buildRedirectTarget(pathname: string, search: Record<string, unknown>) {
+  const currentPath = normalizeAdminPath(pathname)
+  const query = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(search)) {
+    if (typeof value === 'string') {
+      query.set(key, value)
+    }
+  }
+
+  const searchString = query.toString()
+  return searchString ? `${currentPath}?${searchString}` : currentPath
+}
+
+export function isPlatformAdminSession(session: AuthSessionView | null | undefined) {
+  return session?.user.global_role === 'platform_admin'
+}
+
+export function signedInAdminHref(redirect?: string) {
+  return `/admin${redirect ?? DEFAULT_SIGNED_IN_PATH}`
+}
+
+export function postLoginAdminHref(session: AuthSessionView, redirect?: string) {
+  if (session.must_change_password) {
+    return redirect
+      ? `/admin/change-password?redirect=${encodeURIComponent(redirect)}`
+      : '/admin/change-password'
+  }
+
+  return signedInAdminHref(redirect)
+}

--- a/crates/admin-ui/web/src/routes/__root.tsx
+++ b/crates/admin-ui/web/src/routes/__root.tsx
@@ -18,6 +18,13 @@ import { AppShell } from '@/components/layout/app-shell'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { getAuthSession } from '@/server/admin-data.functions'
 import globalsCss from '@/styles/globals.css?url'
+import {
+  DEFAULT_SIGNED_IN_PATH,
+  buildRedirectTarget,
+  isPlatformAdminSession,
+  isPublicAdminRoute,
+  normalizeAdminPath,
+} from '@/routes/-auth-routing'
 
 const loadAuthSession = createIsomorphicFn()
   .server(async () => {
@@ -31,36 +38,37 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     const currentPath = normalizeAdminPath(location.pathname)
     const isPublicRoute = isPublicAdminRoute(currentPath)
     const { data: session } = await loadAuthSession()
+    const adminSession = isPlatformAdminSession(session) ? session : null
 
     if (isPublicRoute) {
-      if (currentPath === '/login' && session) {
+      if (currentPath === '/login' && adminSession) {
         throw redirect({
-          to: session.must_change_password ? '/change-password' : '/api-keys',
+          to: adminSession.must_change_password ? '/change-password' : DEFAULT_SIGNED_IN_PATH,
         })
       }
 
-      if (currentPath === '/change-password' && !session) {
+      if (currentPath === '/change-password' && !adminSession) {
         throw redirect({
           to: '/login',
           search: { redirect: '/change-password' },
         })
       }
 
-      return { session }
+      return { session: adminSession }
     }
 
-    if (!session) {
+    if (!adminSession) {
       throw redirect({
         to: '/login',
         search: { redirect: buildRedirectTarget(location.pathname, location.search) },
       })
     }
 
-    if (session.must_change_password && currentPath !== '/change-password') {
+    if (adminSession.must_change_password && currentPath !== '/change-password') {
       throw redirect({ to: '/change-password' })
     }
 
-    return { session }
+    return { session: adminSession }
   },
   head: () => ({
     meta: [
@@ -102,33 +110,6 @@ function RootComponent() {
       ) : null}
     </RootDocument>
   )
-}
-
-function normalizeAdminPath(pathname: string) {
-  return pathname.replace(/^\/admin(?=\/|$)/, '') || '/'
-}
-
-function isPublicAdminRoute(currentPath: string) {
-  return (
-    currentPath.startsWith('/invite/') ||
-    currentPath.startsWith('/account-ready') ||
-    currentPath === '/login' ||
-    currentPath === '/change-password'
-  )
-}
-
-function buildRedirectTarget(pathname: string, search: Record<string, unknown>) {
-  const currentPath = normalizeAdminPath(pathname)
-  const query = new URLSearchParams()
-
-  for (const [key, value] of Object.entries(search)) {
-    if (typeof value === 'string') {
-      query.set(key, value)
-    }
-  }
-
-  const searchString = query.toString()
-  return searchString ? `${currentPath}?${searchString}` : currentPath
 }
 
 function RootDocument({ children }: { children: ReactNode }) {

--- a/crates/admin-ui/web/src/routes/change-password.tsx
+++ b/crates/admin-ui/web/src/routes/change-password.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { changeCurrentPassword } from '@/server/admin-data.functions'
+import { signedInAdminHref } from '@/routes/-auth-routing'
 
 export const Route = createFileRoute('/change-password')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -40,7 +41,7 @@ function ChangePasswordPage() {
           },
         })
         toast.success('Password updated')
-        window.location.assign(`/admin${search.redirect ?? '/api-keys'}`)
+        window.location.assign(signedInAdminHref(search.redirect))
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Unable to change password')
       }

--- a/crates/admin-ui/web/src/routes/login.tsx
+++ b/crates/admin-ui/web/src/routes/login.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { loginAdminWithPassword } from '@/server/admin-data.functions'
+import { postLoginAdminHref } from '@/routes/-auth-routing'
 
 export const Route = createFileRoute('/login')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -29,13 +30,7 @@ function LoginPage() {
       try {
         const response = await loginAdminWithPassword({ data: { email, password } })
         toast.success('Signed in')
-        const target = response.data.must_change_password
-          ? search.redirect
-            ? `/admin/change-password?redirect=${encodeURIComponent(search.redirect)}`
-            : '/admin/change-password'
-          : `/admin${search.redirect ?? '/api-keys'}`
-
-        window.location.assign(target)
+        window.location.assign(postLoginAdminHref(response.data, search.redirect))
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Unable to sign in')
       }

--- a/crates/admin-ui/web/src/server/admin-data.functions.ts
+++ b/crates/admin-ui/web/src/server/admin-data.functions.ts
@@ -24,6 +24,7 @@ import {
   listTeams,
   listUsers,
   loginWithPassword,
+  logoutCurrentSession,
   removeTeamMember,
   revokeApiKey,
   resendPasswordInvite,
@@ -189,6 +190,10 @@ export const changeCurrentPassword = createServerFn({ method: 'POST' }).handler(
     return changePassword(data)
   },
 )
+
+export const logoutAdminSession = createServerFn({ method: 'POST' }).handler(async () => {
+  return logoutCurrentSession()
+})
 
 export const createIdentityTeam = createServerFn({ method: 'POST' }).handler(
   async ({ data }: { data: Parameters<typeof createTeam>[0] }) => {

--- a/crates/admin-ui/web/src/server/admin-data.server.test.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.test.ts
@@ -13,6 +13,7 @@ import {
   listSpendBudgets,
   listTeams,
   listUsers,
+  logoutCurrentSession,
   reactivateUser,
   removeTeamMember,
   revokeApiKey,
@@ -506,6 +507,13 @@ describe('server-side admin data wrappers', () => {
       }
     })
     POST.mockImplementation(async (path: string) => {
+      if (path === '/api/v1/auth/logout') {
+        return {
+          data: { data: { status: 'ok' }, meta: { generated_at: '2026-03-10T11:32:00Z' } },
+          response: { status: 200 },
+        }
+      }
+
       if (path === '/api/v1/admin/identity/users/{user_id}/reset-onboarding') {
         return {
           data: {
@@ -668,5 +676,11 @@ describe('server-side admin data wrappers', () => {
       params: { path: { user_id: 'user_1' } },
       body: { global_role: 'platform_admin' },
     })
+  })
+
+  it('wires logout to the documented gateway path', async () => {
+    await expect(logoutCurrentSession()).resolves.toMatchObject({ data: { status: 'ok' } })
+
+    expect(POST).toHaveBeenCalledWith('/api/v1/auth/logout')
   })
 })

--- a/crates/admin-ui/web/src/server/admin-data.server.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.ts
@@ -19,6 +19,7 @@ import type {
   InvitationStateView,
   LeaderboardRange,
   LeaderboardView,
+  LogoutResult,
   ModelPageView,
   PasswordInviteResult,
   PasswordLoginInput,
@@ -306,6 +307,11 @@ export async function changePassword(
 ): Promise<ApiEnvelope<AuthSessionView>> {
   const client = createGatewayApiClient()
   return unwrapGatewayResponse(await client.POST('/api/v1/auth/password/change', { body: input }))
+}
+
+export async function logoutCurrentSession(): Promise<ApiEnvelope<LogoutResult>> {
+  const client = createGatewayApiClient()
+  return unwrapGatewayResponse(await client.POST('/api/v1/auth/logout'))
 }
 
 export async function listUsers(): Promise<ApiEnvelope<IdentityUsersPayload>> {

--- a/crates/admin-ui/web/src/types/live-api.ts
+++ b/crates/admin-ui/web/src/types/live-api.ts
@@ -79,3 +79,4 @@ export type AuthSessionUserView = components['schemas']['AuthSessionUserView']
 export type AuthSessionView = components['schemas']['AuthSessionView']
 export type PasswordLoginInput = components['schemas']['PasswordLoginRequest']
 export type ChangePasswordInput = components['schemas']['ChangePasswordRequest']
+export type LogoutResult = IdentityActionResult

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -1494,13 +1494,45 @@ mod tests {
             )
             .await
             .expect("create session");
+        let other_session = store
+            .create_user_session(
+                Uuid::new_v4(),
+                member.user_id,
+                "other-token-hash",
+                now + Duration::days(1),
+                now,
+            )
+            .await
+            .expect("create second session");
+        store
+            .revoke_user_session(session.session_id, now)
+            .await
+            .expect("revoke one session");
+        assert!(
+            store
+                .get_user_session(session.session_id)
+                .await
+                .expect("load revoked session")
+                .expect("session exists")
+                .revoked_at
+                .is_some()
+        );
+        assert!(
+            store
+                .get_user_session(other_session.session_id)
+                .await
+                .expect("load other session")
+                .expect("other session exists")
+                .revoked_at
+                .is_none()
+        );
         store
             .revoke_user_sessions(member.user_id, now)
             .await
             .expect("revoke sessions");
         assert!(
             store
-                .get_user_session(session.session_id)
+                .get_user_session(other_session.session_id)
                 .await
                 .expect("load session")
                 .expect("session exists")

--- a/crates/gateway-store/src/libsql_store/identity.rs
+++ b/crates/gateway-store/src/libsql_store/identity.rs
@@ -1034,6 +1034,26 @@ impl LibsqlStore {
         Ok(())
     }
 
+    pub async fn revoke_user_session(
+        &self,
+        session_id: Uuid,
+        revoked_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        self.connection
+            .execute(
+                r#"
+                UPDATE user_sessions
+                SET revoked_at = ?1
+                WHERE session_id = ?2
+                  AND revoked_at IS NULL
+                "#,
+                libsql::params![revoked_at.unix_timestamp(), session_id.to_string()],
+            )
+            .await
+            .map_err(to_write_error)?;
+        Ok(())
+    }
+
     pub async fn get_user_oidc_auth(
         &self,
         oidc_provider_id: &str,

--- a/crates/gateway-store/src/libsql_store/mod.rs
+++ b/crates/gateway-store/src/libsql_store/mod.rs
@@ -356,6 +356,14 @@ impl GatewayStore for LibsqlStore {
         Self::revoke_user_sessions(self, user_id, revoked_at).await
     }
 
+    async fn revoke_user_session(
+        &self,
+        session_id: Uuid,
+        revoked_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        Self::revoke_user_session(self, session_id, revoked_at).await
+    }
+
     async fn get_user_oidc_auth(
         &self,
         oidc_provider_id: &str,

--- a/crates/gateway-store/src/postgres_store/identity.rs
+++ b/crates/gateway-store/src/postgres_store/identity.rs
@@ -946,6 +946,27 @@ impl PostgresStore {
         Ok(())
     }
 
+    pub async fn revoke_user_session(
+        &self,
+        session_id: Uuid,
+        revoked_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        sqlx::query(
+            r#"
+            UPDATE user_sessions
+            SET revoked_at = $1
+            WHERE session_id = $2
+              AND revoked_at IS NULL
+            "#,
+        )
+        .bind(revoked_at.unix_timestamp())
+        .bind(session_id.to_string())
+        .execute(&self.pool)
+        .await
+        .map_err(to_write_error)?;
+        Ok(())
+    }
+
     pub async fn get_user_oidc_auth(
         &self,
         oidc_provider_id: &str,

--- a/crates/gateway-store/src/postgres_store/mod.rs
+++ b/crates/gateway-store/src/postgres_store/mod.rs
@@ -351,6 +351,14 @@ impl GatewayStore for PostgresStore {
         Self::revoke_user_sessions(self, user_id, revoked_at).await
     }
 
+    async fn revoke_user_session(
+        &self,
+        session_id: Uuid,
+        revoked_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        Self::revoke_user_session(self, session_id, revoked_at).await
+    }
+
     async fn get_user_oidc_auth(
         &self,
         oidc_provider_id: &str,

--- a/crates/gateway-store/src/store.rs
+++ b/crates/gateway-store/src/store.rs
@@ -198,6 +198,11 @@ pub trait GatewayStore:
         user_id: Uuid,
         revoked_at: OffsetDateTime,
     ) -> Result<(), StoreError>;
+    async fn revoke_user_session(
+        &self,
+        session_id: Uuid,
+        revoked_at: OffsetDateTime,
+    ) -> Result<(), StoreError>;
     async fn get_user_oidc_auth(
         &self,
         oidc_provider_id: &str,
@@ -1060,6 +1065,14 @@ impl GatewayStore for AnyStore {
         revoked_at: OffsetDateTime,
     ) -> Result<(), StoreError> {
         dispatch_store!(self, revoke_user_sessions(user_id, revoked_at))
+    }
+
+    async fn revoke_user_session(
+        &self,
+        session_id: Uuid,
+        revoked_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        dispatch_store!(self, revoke_user_session(session_id, revoked_at))
     }
 
     async fn get_user_oidc_auth(

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -1383,6 +1383,31 @@
         }
       }
     },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": [
+          "crate::http::identity"
+        ],
+        "operationId": "logout_current_session",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_IdentityActionStatus"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          }
+        ]
+      }
+    },
     "/api/v1/auth/oidc/callback": {
       "get": {
         "tags": [

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -667,6 +667,7 @@ pub struct RequestLogPayloadView {
         crate::http::identity::transfer_identity_team_member,
         crate::http::identity::get_auth_session,
         crate::http::identity::login_with_password,
+        crate::http::identity::logout_current_session,
         crate::http::identity::change_password,
         crate::http::identity::create_identity_user,
         crate::http::identity::update_identity_user,
@@ -763,6 +764,7 @@ mod tests {
         assert!(paths.contains_key("/api/v1/admin/observability/leaderboard"));
         assert!(paths.contains_key("/api/v1/admin/observability/request-logs/{request_log_id}"));
         assert!(paths.contains_key("/api/v1/auth/session"));
+        assert!(paths.contains_key("/api/v1/auth/logout"));
 
         assert!(
             components

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -8,7 +8,8 @@ use axum::{
 };
 use gateway_core::{
     AuthError, AuthMode, GatewayError, GlobalRole, IdentityRepository, IdentityUserRecord,
-    MembershipRole, OidcProviderRecord, PasswordInvitationRecord, UserRecord, UserStatus,
+    MembershipRole, OidcProviderRecord, PasswordInvitationRecord, UserRecord, UserSessionRecord,
+    UserStatus,
 };
 use gateway_store::{AnyStore, GatewayStore};
 use sha2::{Digest, Sha256};
@@ -44,6 +45,7 @@ use crate::http::{
 const SESSION_COOKIE_NAME: &str = "ogw_session";
 const INVITE_TTL_DAYS: i64 = 7;
 const SESSION_TTL_DAYS: i64 = 30;
+const SESSION_TTL_SECONDS: i64 = SESSION_TTL_DAYS * 24 * 60 * 60;
 
 #[utoipa::path(
     get,
@@ -304,44 +306,74 @@ pub async fn get_auth_session(
 )]
 pub async fn login_with_password(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(request): Json<PasswordLoginRequest>,
 ) -> Result<Response, AppError> {
+    let invalid_credentials = || AppError(GatewayError::Auth(AuthError::InvalidCredentials));
     let email_normalized = normalize_email(&request.email)?;
     let user = state
         .store
         .get_user_by_email_normalized(&email_normalized)
         .await?
-        .ok_or(AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
+        .ok_or_else(invalid_credentials)?;
+    if user.auth_mode != AuthMode::Password {
+        return Err(invalid_credentials());
+    }
     let password_auth = state
         .store
         .get_user_password_auth(user.user_id)
         .await?
-        .ok_or(AppError(GatewayError::Auth(AuthError::InvalidCredentials)))?;
+        .ok_or_else(invalid_credentials)?;
 
-    if user.auth_mode != AuthMode::Password {
-        return Err(AppError(GatewayError::Auth(AuthError::InvalidCredentials)));
-    }
-    if user.global_role != GlobalRole::PlatformAdmin {
-        return Err(AppError(GatewayError::Auth(
-            AuthError::InsufficientPrivileges,
-        )));
-    }
-    if user.status != UserStatus::Active {
-        return Err(AppError(GatewayError::InvalidRequest(
-            "only active admins can sign in".to_string(),
-        )));
-    }
     let password_ok =
         gateway_service::verify_gateway_key_secret(&request.password, &password_auth.password_hash)
             .map_err(|error| AppError(GatewayError::Internal(error.to_string())))?;
     if !password_ok {
-        return Err(AppError(GatewayError::Auth(AuthError::InvalidCredentials)));
+        return Err(invalid_credentials());
+    }
+    if user.global_role != GlobalRole::PlatformAdmin {
+        return Err(invalid_credentials());
+    }
+    if user.status != UserStatus::Active {
+        return Err(invalid_credentials());
     }
 
     let now = OffsetDateTime::now_utc();
-    let session_cookie = issue_session_cookie(&state, user.user_id, now).await?;
+    let session_cookie =
+        issue_session_cookie(&state, user.user_id, now, session_cookie_secure(&headers)).await?;
     let mut response = Json(envelope(build_auth_session_view(user))).into_response();
     response.headers_mut().append(SET_COOKIE, session_cookie);
+    Ok(response)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/logout",
+    responses((status = 200, body = Envelope<IdentityActionStatus>)),
+    security(("session_cookie" = []))
+)]
+pub async fn logout_current_session(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, AppError> {
+    if let Some(current_session) = resolve_session_cookie(&state, &headers).await? {
+        let now = OffsetDateTime::now_utc();
+        if current_session.session.revoked_at.is_none()
+            && current_session.session.expires_at > now
+            && current_session.session.token_hash == token_hash(&current_session.raw_token)
+        {
+            state
+                .store
+                .revoke_user_session(current_session.session.session_id, now)
+                .await?;
+        }
+    }
+
+    let mut response = Json(envelope(IdentityActionStatus { status: "ok" })).into_response();
+    response.headers_mut().append(
+        SET_COOKIE,
+        expire_session_cookie(session_cookie_secure(&headers))?,
+    );
     Ok(response)
 }
 
@@ -927,6 +959,7 @@ pub async fn oidc_start(
 )]
 pub async fn oidc_callback(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Query(query): Query<OidcCallbackQuery>,
 ) -> Result<Response, AppError> {
     let provider = load_enabled_oidc_provider(&state.store, &query.provider_key).await?;
@@ -992,7 +1025,8 @@ pub async fn oidc_callback(
         user
     };
 
-    let session_cookie = issue_session_cookie(&state, user.user_id, now).await?;
+    let session_cookie =
+        issue_session_cookie(&state, user.user_id, now, session_cookie_secure(&headers)).await?;
     let redirect_to = query.redirect_to.unwrap_or_else(|| {
         let query = form_urlencoded::Serializer::new(String::new())
             .append_pair("mode", "oidc")
@@ -1015,28 +1049,32 @@ fn request_origin(headers: &HeaderMap) -> String {
     format!("{proto}://{host}")
 }
 
+fn session_cookie_secure(headers: &HeaderMap) -> bool {
+    header_value(headers, "x-forwarded-proto").as_deref() == Some("https")
+        || header_value(headers, "x-forwarded-origin")
+            .is_some_and(|origin| origin.starts_with("https://"))
+}
+
 pub(crate) async fn resolve_session_user(
     state: &AppState,
     headers: &HeaderMap,
 ) -> Result<Option<UserRecord>, AppError> {
-    let Some(raw_token) = cookie_value(headers, SESSION_COOKIE_NAME) else {
-        return Ok(None);
-    };
-    let Some(token_id) = parse_signed_token_id(&raw_token) else {
-        return Ok(None);
-    };
-    let Some(session) = state.store.get_user_session(token_id).await? else {
+    let Some(current_session) = resolve_session_cookie(state, headers).await? else {
         return Ok(None);
     };
     let now = OffsetDateTime::now_utc();
-    if session.revoked_at.is_some()
-        || session.expires_at <= now
-        || session.token_hash != token_hash(&raw_token)
+    if current_session.session.revoked_at.is_some()
+        || current_session.session.expires_at <= now
+        || current_session.session.token_hash != token_hash(&current_session.raw_token)
     {
         return Ok(None);
     }
 
-    let Some(user) = state.store.get_user_by_id(session.user_id).await? else {
+    let Some(user) = state
+        .store
+        .get_user_by_id(current_session.session.user_id)
+        .await?
+    else {
         return Ok(None);
     };
     if user.status == UserStatus::Disabled {
@@ -1046,9 +1084,31 @@ pub(crate) async fn resolve_session_user(
 
     state
         .store
-        .touch_user_session(session.session_id, now)
+        .touch_user_session(current_session.session.session_id, now)
         .await?;
     Ok(Some(user))
+}
+
+struct ResolvedSessionCookie {
+    raw_token: String,
+    session: UserSessionRecord,
+}
+
+async fn resolve_session_cookie(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Option<ResolvedSessionCookie>, AppError> {
+    let Some(raw_token) = cookie_value(headers, SESSION_COOKIE_NAME) else {
+        return Ok(None);
+    };
+    let Some(token_id) = parse_signed_token_id(&raw_token) else {
+        return Ok(None);
+    };
+    let Some(session) = state.store.get_user_session(token_id).await? else {
+        return Ok(None);
+    };
+
+    Ok(Some(ResolvedSessionCookie { raw_token, session }))
 }
 
 fn build_auth_session_view(user: UserRecord) -> AuthSessionView {
@@ -1561,6 +1621,7 @@ async fn issue_session_cookie(
     state: &AppState,
     user_id: Uuid,
     now: OffsetDateTime,
+    secure: bool,
 ) -> Result<HeaderValue, AppError> {
     let session_id = Uuid::new_v4();
     let raw_token = signed_token("session", &state.identity_token_secret, session_id);
@@ -1576,11 +1637,31 @@ async fn issue_session_cookie(
         )
         .await?;
 
+    session_cookie_header(&raw_token, SESSION_TTL_SECONDS, secure)
+}
+
+fn expire_session_cookie(secure: bool) -> Result<HeaderValue, AppError> {
     HeaderValue::from_str(&format!(
-        "{SESSION_COOKIE_NAME}={raw_token}; Path=/; HttpOnly; SameSite=Lax; Max-Age={}",
-        SESSION_TTL_DAYS * 24 * 60 * 60
+        "{SESSION_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT{}",
+        secure_cookie_suffix(secure)
     ))
     .map_err(|error| AppError(GatewayError::Internal(error.to_string())))
+}
+
+fn session_cookie_header(
+    value: &str,
+    max_age_seconds: i64,
+    secure: bool,
+) -> Result<HeaderValue, AppError> {
+    HeaderValue::from_str(&format!(
+        "{SESSION_COOKIE_NAME}={value}; Path=/; HttpOnly; SameSite=Lax; Max-Age={max_age_seconds}{}",
+        secure_cookie_suffix(secure)
+    ))
+    .map_err(|error| AppError(GatewayError::Internal(error.to_string())))
+}
+
+fn secure_cookie_suffix(secure: bool) -> &'static str {
+    if secure { "; Secure" } else { "" }
 }
 
 async fn load_enabled_oidc_provider(

--- a/crates/gateway/src/http/mod.rs
+++ b/crates/gateway/src/http/mod.rs
@@ -116,6 +116,7 @@ pub fn build_router(state: AppState, admin_ui: AdminUiConfig) -> Router {
         )
         .route("/api/v1/auth/session", get(get_auth_session))
         .route("/api/v1/auth/login/password", post(login_with_password))
+        .route("/api/v1/auth/logout", post(logout_current_session))
         .route("/api/v1/auth/password/change", post(change_password))
         .route(
             "/api/v1/auth/invitations/{token}",

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -5824,6 +5824,140 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn logout_revokes_only_current_session_and_clears_cookie() {
+        let (app, store, _) =
+            build_default_test_app_with_store(gateway_core::ProviderRegistry::new()).await;
+        ensure_bootstrap_admin(
+            &store,
+            &BootstrapAdminConfig {
+                enabled: true,
+                email: "admin@local".to_string(),
+                password: "literal.admin".to_string(),
+                require_password_change: false,
+            },
+        )
+        .await
+        .expect("bootstrap admin");
+
+        let login = |app: Router| async move {
+            app.oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/login/password")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "email": "admin@local",
+                            "password": "admin"
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("login response")
+        };
+
+        let first_login = login(app.clone()).await;
+        assert_eq!(first_login.status(), StatusCode::OK);
+        let first_cookie = set_cookie_header(&first_login);
+        let second_login = login(app.clone()).await;
+        assert_eq!(second_login.status(), StatusCode::OK);
+        let second_cookie = set_cookie_header(&second_login);
+
+        let logout = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/logout")
+                    .header("cookie", &first_cookie)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("logout response");
+        assert_eq!(logout.status(), StatusCode::OK);
+        let clear_cookie = set_cookie_header(&logout);
+        assert!(clear_cookie.starts_with("ogw_session=;"));
+        assert!(clear_cookie.contains("Max-Age=0"));
+        assert_eq!(read_json(logout).await["data"]["status"], "ok");
+
+        let stale_session = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/auth/session")
+                    .header("cookie", &first_cookie)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("stale session response");
+        assert_eq!(stale_session.status(), StatusCode::OK);
+        assert_eq!(read_json(stale_session).await["data"], Value::Null);
+
+        let protected_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/admin/api-keys")
+                    .header("cookie", &first_cookie)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("protected response");
+        assert_eq!(protected_response.status(), StatusCode::UNAUTHORIZED);
+
+        let active_session = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/auth/session")
+                    .header("cookie", &second_cookie)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("active session response");
+        assert_eq!(active_session.status(), StatusCode::OK);
+        assert_eq!(
+            read_json(active_session).await["data"]["user"]["email"],
+            "admin@local"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn logout_is_idempotent_for_missing_and_invalid_session_cookies() {
+        let (app, _store, _) =
+            build_default_test_app_with_store(gateway_core::ProviderRegistry::new()).await;
+
+        for cookie in [None, Some("ogw_session=not-a-signed-token")] {
+            let mut request = Request::builder().method("POST").uri("/api/v1/auth/logout");
+            if let Some(cookie) = cookie {
+                request = request.header("cookie", cookie);
+            }
+            let response = app
+                .clone()
+                .oneshot(request.body(Body::empty()).expect("request"))
+                .await
+                .expect("response");
+
+            assert_eq!(response.status(), StatusCode::OK);
+            let clear_cookie = set_cookie_header(&response);
+            assert!(clear_cookie.starts_with("ogw_session=;"));
+            assert!(clear_cookie.contains("Max-Age=0"));
+            assert_eq!(read_json(response).await["data"]["status"], "ok");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn forced_password_change_can_be_completed_and_old_password_stops_working() {
         let (app, store, _) =
             build_default_test_app_with_store(gateway_core::ProviderRegistry::new()).await;

--- a/docs/access/admin-control-plane.md
+++ b/docs/access/admin-control-plane.md
@@ -19,7 +19,7 @@ For the generated contract and artifact workflow, use [admin-api-contract-workfl
 
 These areas are backed by real gateway APIs today:
 
-- sign-in, session lookup, and password rotation
+- sign-in, session lookup, current-session logout, and password rotation
 - API key inventory, creation, and revocation
 - identity users and lifecycle management
 - identity teams and member transfer or removal workflows
@@ -80,26 +80,26 @@ Operators can:
 - pre-provision OIDC users against enabled providers
 - remove team members
 - transfer team members between teams with an explicit destination role
+- sign out of the current browser session
 
 Current limits:
 
-- no admin logout flow yet
 - owner memberships stay blocked from removal or transfer in this slice
 - auth-mode switching is limited to invited users
 - OIDC is still development-style
 
 ## Admin Auth and Session Behavior
 
-Current session behavior is mostly implicit:
+Current session behavior is cookie-backed and operator-visible:
 
 - browser cookie state carries the admin session
 - `/api/v1/auth/session` is the machine-readable session lookup
+- `/api/v1/auth/logout` revokes the current cookie-backed session and clears the browser cookie
 - expired or missing session state sends the operator back through the auth flow
 - bootstrap admin and regular admin accounts share the same session mechanics after sign-in
 
 What is still missing:
 
-- a dedicated logout shell
 - broader session-management UI
 
 ## Spend and Observability Workflows Available Today
@@ -121,8 +121,6 @@ Current limits:
 
 ## Current Gaps
 
-- no logout or richer session management yet:
-  - [issue #34](https://github.com/ahstn/oceans-llm/issues/34)
 - OIDC still development-style:
   - [oidc-and-sso-status.md](oidc-and-sso-status.md)
 - Models page still preview-backed:

--- a/docs/access/identity-and-access.md
+++ b/docs/access/identity-and-access.md
@@ -40,6 +40,15 @@ Important rules:
 - the last active platform admin cannot be deactivated or demoted
 - the bootstrap admin stays out of normal user-management views
 
+## Admin Session Lifecycle
+
+Admin sessions are durable server-side records referenced by the `ogw_session` browser cookie.
+
+- normal sign-out revokes only the current cookie-backed session
+- logout is idempotent and clears the browser cookie even when the session is already gone
+- user lifecycle actions such as deactivation can revoke every active session for that user
+- expired, revoked, missing, or disabled-user sessions resolve as unauthenticated and return the operator to sign-in
+
 ## Bootstrap Admin
 
 Bootstrap admin is the first control-plane access path, not a normal user-management path.

--- a/docs/adr/2026-04-23-admin-current-session-logout.md
+++ b/docs/adr/2026-04-23-admin-current-session-logout.md
@@ -1,0 +1,210 @@
+# ADR: Admin Current-Session Logout and Session Lifecycle
+
+- Date: 2026-04-23
+- Status: Accepted
+
+## Implemented By
+
+- GitHub issue: [#34 Admin Logout And Session Lifecycle](https://github.com/ahstn/oceans-llm/issues/34)
+- Pull request: [#104 feat(admin): add current-session logout](https://github.com/ahstn/oceans-llm/pull/104)
+- Backend HTTP:
+  - [../../crates/gateway/src/http/identity.rs](../../crates/gateway/src/http/identity.rs)
+  - [../../crates/gateway/src/http/mod.rs](../../crates/gateway/src/http/mod.rs)
+  - [../../crates/gateway/src/http/admin_contract.rs](../../crates/gateway/src/http/admin_contract.rs)
+- Store boundary:
+  - [../../crates/gateway-store/src/store.rs](../../crates/gateway-store/src/store.rs)
+  - [../../crates/gateway-store/src/libsql_store/identity.rs](../../crates/gateway-store/src/libsql_store/identity.rs)
+  - [../../crates/gateway-store/src/postgres_store/identity.rs](../../crates/gateway-store/src/postgres_store/identity.rs)
+- Admin UI:
+  - [../../crates/admin-ui/web/src/routes/-auth-routing.ts](../../crates/admin-ui/web/src/routes/-auth-routing.ts)
+  - [../../crates/admin-ui/web/src/routes/__root.tsx](../../crates/admin-ui/web/src/routes/__root.tsx)
+  - [../../crates/admin-ui/web/src/routes/-admin-guard.ts](../../crates/admin-ui/web/src/routes/-admin-guard.ts)
+  - [../../crates/admin-ui/web/src/components/layout/app-shell.tsx](../../crates/admin-ui/web/src/components/layout/app-shell.tsx)
+  - [../../crates/admin-ui/web/src/components/app-sidebar.tsx](../../crates/admin-ui/web/src/components/app-sidebar.tsx)
+- Docs:
+  - [../access/admin-control-plane.md](../access/admin-control-plane.md)
+  - [../access/identity-and-access.md](../access/identity-and-access.md)
+  - [../reference/e2e-contract-tests.md](../reference/e2e-contract-tests.md)
+
+## Context
+
+Before issue #34, the admin control plane had durable server-side sessions but no operator-visible sign-out path. Operators could sign in, rotate a required bootstrap password, and access protected admin routes, but leaving the browser session required waiting for expiry or clearing browser state manually.
+
+That gap was small in code but important in meaning. Session lifecycle is part of the trust boundary for the admin control plane. If logout is vague, future contributors can reasonably copy the wrong pattern: revoke every session because it is simpler, clear only the browser cookie because it is visible, or add a client-only redirect that leaves durable server state active.
+
+At the same time, the login and route-guard code had several adjacent auth-hardening concerns:
+
+- password-login failures could reveal whether an account existed, was inactive, was not password-backed, or lacked platform-admin privileges;
+- cookie issuance did not encode the effective HTTPS scheme in the session cookie attributes;
+- root and child admin guards duplicated redirect and platform-admin checks;
+- the shell still displayed stale preview-era copy instead of account actions.
+
+We were still pre-v1, so the right answer was not compatibility layering or fallback routes. The right answer was a small, explicit session lifecycle contract and removal of duplicated or stale patterns while the surface area is still tractable.
+
+## Decision
+
+### 1. Logout revokes the current browser session only
+
+We added `POST /api/v1/auth/logout` as the only admin logout endpoint.
+
+The endpoint resolves the current `ogw_session` cookie, verifies the stored session token hash when a row exists, revokes that one session when it is valid and active, and always emits a clearing cookie.
+
+Why:
+
+- normal sign-out should not surprise operators by invalidating other browsers or devices;
+- server-side session state must be revoked, not just hidden by deleting the browser cookie;
+- the durable session row remains the source of truth for whether a cookie is usable.
+
+The endpoint is intentionally idempotent. Missing, malformed, expired, already revoked, and hash-mismatched cookies all return success and clear the cookie. Hash-mismatched cookies do not revoke any stored row.
+
+Why:
+
+- sign-out should be safe to retry;
+- logout should not create an account/session oracle;
+- a tampered cookie should not be allowed to mutate a real session.
+
+### 2. Keep all-session revocation for lifecycle actions, not normal logout
+
+We added `revoke_user_session(session_id, revoked_at)` beside the existing `revoke_user_sessions(user_id, revoked_at)` store operation.
+
+Why:
+
+- normal logout has current-session semantics;
+- deactivation, reset, and similar lifecycle actions can still revoke every session for a user;
+- separate store methods make the scope explicit at call sites.
+
+This was implemented across the trait, dynamic store dispatch, libsql store, and Postgres store. Store tests assert that revoking one session leaves another session for the same user active.
+
+### 3. Share session-cookie resolution below user-focused auth checks
+
+We split cookie parsing and session-row lookup into a small resolver that returns the raw token and stored session without requiring an active user.
+
+Why:
+
+- logout needs to revoke a session even when user resolution would fail;
+- protected routes still need user-focused validation;
+- shared parsing avoids drift in token-id extraction and hash checks.
+
+Authenticated session lookup remains stricter: it rejects revoked, expired, hash-mismatched, missing-user, or disabled-user sessions and touches the session only after validation.
+
+### 4. Make session cookie issue and expiry share one attribute contract
+
+Session issue and expiry now share the same baseline attributes:
+
+- `Path=/`
+- `HttpOnly`
+- `SameSite=Lax`
+- conditional `Secure`
+
+`Secure` is emitted when the effective forwarded scheme is HTTPS.
+
+Why:
+
+- a clearing cookie must target the same cookie scope as the issued cookie;
+- local HTTP development should still work without a compatibility route;
+- HTTPS deployments should get the stronger cookie attribute automatically.
+
+### 5. Normalize pre-auth password-login failures
+
+Password login now returns the same authentication failure for unknown email, wrong password, non-password accounts, non-admin accounts, and inactive accounts before a session exists.
+
+Why:
+
+- the login endpoint is pre-authenticated and should not disclose account state;
+- platform-admin access is the only supported admin control-plane login scope;
+- detailed lifecycle state remains available only through authenticated admin APIs.
+
+### 6. Centralize admin route-auth semantics
+
+The admin UI now has one auth-routing helper for:
+
+- admin path normalization;
+- the default signed-in path;
+- redirect target construction;
+- public admin route detection;
+- platform-admin session checks.
+
+Both the root route and child admin guards use that helper. Child guards remain in place so protected loaders do not run after an expired session.
+
+Why:
+
+- root and child guards need the same meaning for admin paths and redirect targets;
+- protected loaders should still defend themselves;
+- non-`platform_admin` sessions should be treated as unauthenticated for protected admin routes.
+
+### 7. Put the sign-out transition in the shell and account rendering in the sidebar
+
+`AppShell` owns the sign-out transition. `AppSidebar` owns the account menu rendering.
+
+The sidebar footer now shows an account dropdown with:
+
+- signed-in name;
+- email;
+- role;
+- `Change password`;
+- `Sign out`.
+
+On successful sign-out, the shell calls `window.location.replace('/admin/login')`.
+
+Why:
+
+- the shell is the right place for app-level navigation after the HttpOnly cookie changes;
+- replacing history avoids returning to a now-invalid protected page through browser back;
+- the sidebar stays a rendering component instead of owning session mutation.
+
+### 8. Keep the contract generated and tested
+
+The logout endpoint is part of the `utoipa` admin API document, the checked-in OpenAPI artifact, and the generated TypeScript client.
+
+Why:
+
+- the admin UI should consume the same generated contract as the rest of the admin API;
+- adding auth endpoints outside the contract would weaken the contract discipline established by earlier ADRs;
+- E2E coverage now proves browser logout clears the session and redirects protected revisits to login.
+
+## Consequences
+
+Positive:
+
+- operators now have an explicit sign-out path;
+- normal logout has narrow current-session semantics;
+- lifecycle/admin revocation and normal logout no longer share an ambiguous store operation;
+- login failure behavior leaks less account state;
+- route guard behavior is simpler to reason about and easier to reuse;
+- stale preview shell copy has been removed;
+- the admin UI account area now exposes the actions operators expect.
+
+Tradeoffs:
+
+- there is still no session-management UI for viewing or revoking other sessions;
+- there is no "sign out everywhere" action in this issue;
+- logout is intentionally quiet for invalid cookies, which means debugging cookie corruption requires server-side inspection rather than user-facing detail.
+
+## Post-Implementation Review
+
+The main design choice still looks right: current-session logout should be a server-side session revocation, not a client-only redirect or all-session invalidation. That makes the behavior narrow, understandable, and easy to extend later.
+
+There are two things worth noting for future work:
+
+- The effective-scheme logic for secure cookies is still a small helper inside the identity HTTP module. If more handlers need scheme-aware behavior, that should become a shared request-context helper rather than being copied.
+- The admin account menu introduced a useful pattern for shell-level mutations. If more shell actions appear, we should keep mutation ownership in `AppShell` or a similarly high-level boundary instead of letting sidebar rendering components accumulate side effects.
+
+What we should not do differently:
+
+- Do not add a compatibility logout route.
+- Do not add a client-only logout fallback.
+- Do not make normal logout revoke every session.
+- Do not preserve duplicate auth-routing helpers now that the shared helper exists.
+
+The implementation deliberately removes stale shell copy and duplicated route helper logic rather than preserving old patterns. That is the right posture for the first iteration of the service.
+
+## Follow-Up Work
+
+- Add a dedicated session-management surface only when operators need to inspect or revoke other sessions.
+- Add a separate "sign out everywhere" action only if product requirements call for it, backed by the existing all-session lifecycle revocation path.
+- Keep OIDC redirect hardening with [issue #29](https://github.com/ahstn/oceans-llm/issues/29); it is adjacent auth work but not part of the logout/session lifecycle decision.
+- Consider moving effective request-scheme detection into a shared HTTP helper if another code path needs it.
+
+## Attribution
+
+This ADR documents the implementation and post-implementation review of GitHub issue [#34](https://github.com/ahstn/oceans-llm/issues/34) and PR [#104](https://github.com/ahstn/oceans-llm/pull/104). It was prepared through collaborative human + AI implementation/design work.

--- a/docs/reference/e2e-contract-tests.md
+++ b/docs/reference/e2e-contract-tests.md
@@ -51,6 +51,7 @@ Current intended coverage:
 The current suite already covers:
 
 - browser auth and forced password-rotation flow
+- current-session logout and revoked-session redirect behavior
 - public `/v1/models`
 - public `/v1/chat/completions`
 - admin UI API-key create, live use, and revoke


### PR DESCRIPTION
## Description

Implements issue #34: admin sign-out now revokes only the current `ogw_session` browser session, clears the HttpOnly cookie, and returns the operator to `/admin/login`.

- Summary of changes
  - Adds `POST /api/v1/auth/logout` and generated OpenAPI/TypeScript contract coverage.
  - Adds single-session revocation to the store trait, `AnyStore`, libsql, and Postgres implementations while keeping all-session revocation for lifecycle/admin actions.
  - Shares admin auth-routing helpers across root and child guards, and treats non-`platform_admin` sessions as unauthenticated for protected admin routes.
  - Replaces the sidebar footer identity link with an account dropdown containing identity details, change password, and sign out.
  - Updates docs for admin logout/session lifecycle and E2E contract coverage.

- Why this approach was chosen
  - Logout should be narrow by default: signing out of one browser must not invalidate another active admin session.
  - The gateway remains the session authority; the UI only calls the server function and relies on the existing cookie propagation boundary.
  - Shared routing helpers remove duplicate redirect logic instead of adding another one-off auth case.

- How it works
  - Logout resolves the current cookie token without requiring an active user, verifies the token hash when a stored session exists, revokes only that session when valid/current, and always emits a clearing cookie.
  - Session cookies now share issue/expire attributes and add `Secure` only when the effective request scheme is HTTPS.
  - The admin shell calls `logoutAdminSession()` and uses `window.location.replace('/admin/login')` after the cookie is cleared.

- Risks, tradeoffs, and alternatives considered
  - This does not add a “sign out everywhere” action; user lifecycle flows still own all-session revocation.
  - Postgres-backed runtime checks were compile-verified, but local Postgres integration tests and smoke tests need configured database environment variables.
  - `CardTitle` now renders an `h3`, which improves accessibility and aligns with existing E2E heading assertions while preserving styling.

- Additional context for reviewers
  - Password login failures are normalized before authentication is established so unknown email, wrong password, inactive account, non-admin account, and non-password account do not disclose account state.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [x] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation run:

- `cargo test -p gateway-store libsql_identity_mutation_store_helpers_cover_transfer_removal_and_revocation`
- `cargo test -p gateway logout_`
- `mise run ui-test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run --cwd crates/admin-ui/web lint`
- `mise run e2e-test`
- `mise run docs-check`
- `git diff --check`
