### PR TITLE
feat(gateway): harden request log payload policy

### DIFF
--- a/crates/admin-ui/web/src/generated/admin-api.ts
+++ b/crates/admin-ui/web/src/generated/admin-api.ts
@@ -1038,6 +1038,18 @@ export interface components {
             /** Format: int64 */
             total: number;
         };
+        /** @enum {string} */
+        RequestLogPayloadCaptureModeView: "disabled" | "summary_only" | "redacted_payloads";
+        RequestLogPayloadPolicyView: {
+            capture_mode: components["schemas"]["RequestLogPayloadCaptureModeView"];
+            /** Format: int64 */
+            request_max_bytes: number;
+            /** Format: int64 */
+            response_max_bytes: number;
+            /** Format: int64 */
+            stream_max_events: number;
+            version: string;
+        };
         RequestLogPayloadView: {
             request_json: unknown;
             response_json: unknown;
@@ -1056,6 +1068,7 @@ export interface components {
             model_icon_key?: null | components["schemas"]["ModelIconKeyView"];
             model_key: string;
             occurred_at: string;
+            payload_policy: components["schemas"]["RequestLogPayloadPolicyView"];
             /** Format: int64 */
             prompt_tokens?: number | null;
             provider_icon_key?: null | components["schemas"]["ProviderIconKeyView"];

--- a/crates/admin-ui/web/src/routes/observability/request-logs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/request-logs.tsx
@@ -3,10 +3,19 @@ import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { BrandIcon } from '@/components/icons/brand-icon'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty'
 import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import {
   Dialog,
   DialogContent,
@@ -192,9 +201,12 @@ export function RequestLogsPage() {
             </Button>
           </div>
           {hasPartialTagFilter ? (
-            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-              Provide both a tag key and tag value to filter bespoke request tags.
-            </div>
+            <Alert>
+              <AlertTitle>Incomplete tag filter</AlertTitle>
+              <AlertDescription>
+                Provide both a tag key and tag value to filter bespoke request tags.
+              </AlertDescription>
+            </Alert>
           ) : null}
           <div className="text-sm text-[var(--color-text-soft)]">
             {logPage.total} total logs loaded from gateway observability APIs.
@@ -264,6 +276,7 @@ export function RequestLogsPage() {
                       {metadataBoolean(item, 'stream') ? (
                         <Badge variant="outline">stream</Badge>
                       ) : null}
+                      <PayloadPolicyBadges item={item} />
                       <RequestTagBadges item={item} />
                     </div>
                     <Button
@@ -317,6 +330,9 @@ export function RequestLogsPage() {
                         <div className="truncate text-xs text-[var(--color-text-muted)]">
                           {item.request_log_id}
                         </div>
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          <PayloadPolicyBadges item={item} />
+                        </div>
                       </div>
                       <span className="flex items-center gap-2 truncate px-3 py-3 text-[var(--color-text)]">
                         <BrandIcon iconKey={item.model_icon_key} size={16} />
@@ -369,11 +385,12 @@ export function RequestLogsPage() {
           </DialogHeader>
 
           {detailPending ? (
-            <div className="text-sm text-[var(--color-text-soft)]">Loading request log detail…</div>
+            <DetailSkeleton />
           ) : detailError ? (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-              {detailError}
-            </div>
+            <Alert variant="destructive">
+              <AlertTitle>Request log detail failed</AlertTitle>
+              <AlertDescription>{detailError}</AlertDescription>
+            </Alert>
           ) : selectedDetail ? (
             <div className="grid gap-4">
               <div className="grid gap-3 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4 md:grid-cols-2">
@@ -426,36 +443,32 @@ export function RequestLogsPage() {
                 />
               </div>
 
-              <section className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4">
-                <h3 className="text-sm font-semibold text-[var(--color-text)]">Request Tags</h3>
-                <div className="mt-3 flex flex-wrap gap-2">
+              <PayloadPolicyCard log={selectedDetail.log} />
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Request Tags</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-2">
                   <RequestTagBadges item={selectedDetail.log} />
-                </div>
-              </section>
+                </CardContent>
+              </Card>
 
               <div className="grid gap-4 lg:grid-cols-2">
                 <PayloadCard
                   title="Request Payload"
-                  note={
-                    selectedDetail.log.request_payload_truncated
-                      ? 'Sanitized request payload was truncated before persistence.'
-                      : 'Sanitized request payload.'
-                  }
+                  truncated={selectedDetail.log.request_payload_truncated}
                   payload={selectedDetail.payload?.request_json}
                 />
                 <PayloadCard
                   title="Response Payload"
-                  note={
-                    selectedDetail.log.response_payload_truncated
-                      ? 'Sanitized response payload was truncated before persistence.'
-                      : 'Sanitized response payload.'
-                  }
+                  truncated={selectedDetail.log.response_payload_truncated}
                   payload={selectedDetail.payload?.response_json}
                 />
               </div>
             </div>
           ) : (
-            <div className="text-sm text-[var(--color-text-soft)]">Loading request log detail…</div>
+            <DetailSkeleton />
           )}
         </DialogContent>
       </Dialog>
@@ -488,17 +501,119 @@ function DetailRow({
   )
 }
 
-function PayloadCard({ title, note, payload }: { title: string; note: string; payload: unknown }) {
+function DetailSkeleton() {
   return (
-    <section className="rounded-md border border-[color:var(--color-border)]">
-      <header className="border-b border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] px-4 py-3">
-        <h3 className="font-semibold text-[var(--color-text)]">{title}</h3>
-        <p className="text-sm text-[var(--color-text-soft)]">{note}</p>
-      </header>
-      <pre className="max-h-[360px] overflow-auto p-4 text-xs leading-6 text-[var(--color-text-muted)]">
-        {payload ? JSON.stringify(payload, null, 2) : 'No payload stored.'}
-      </pre>
-    </section>
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-20 w-full" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-48 w-full" />
+    </div>
+  )
+}
+
+function PayloadPolicyCard({ log }: { log: RequestLogView }) {
+  const policy = log.payload_policy
+  const hasTruncation = log.request_payload_truncated || log.response_payload_truncated
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <CardTitle>Payload Policy</CardTitle>
+            <CardDescription>{payloadPolicyDescription(log)}</CardDescription>
+          </div>
+          <PayloadPolicyBadges item={log} />
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {hasTruncation || !log.has_payload ? (
+          <Alert>
+            <AlertTitle>Payload capture state</AlertTitle>
+            <AlertDescription>
+              {hasTruncation
+                ? 'One or more sanitized payloads were truncated before persistence.'
+                : `Capture mode is ${formatCaptureMode(policy.capture_mode)}, so no payload body is stored for this row.`}
+            </AlertDescription>
+          </Alert>
+        ) : null}
+        <dl className="grid gap-3 text-sm md:grid-cols-4">
+          <DetailRow label="Capture" value={formatCaptureMode(policy.capture_mode)} />
+          <DetailRow label="Request Limit" value={formatBytes(policy.request_max_bytes)} />
+          <DetailRow label="Response Limit" value={formatBytes(policy.response_max_bytes)} />
+          <DetailRow label="Stream Events" value={String(policy.stream_max_events)} />
+        </dl>
+      </CardContent>
+    </Card>
+  )
+}
+
+function PayloadCard({
+  title,
+  truncated,
+  payload,
+}: {
+  title: string
+  truncated: boolean
+  payload: unknown
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>
+              {truncated
+                ? 'Sanitized payload was truncated before persistence.'
+                : 'Sanitized payload.'}
+            </CardDescription>
+          </div>
+          {truncated ? <Badge variant="warning">truncated</Badge> : <Badge variant="outline">full</Badge>}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {payload ? (
+          <pre className="max-h-[360px] overflow-auto text-xs leading-6 text-[var(--color-text-muted)]">
+            {JSON.stringify(payload, null, 2)}
+          </pre>
+        ) : (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>No payload stored</EmptyTitle>
+              <EmptyDescription>
+                Payload capture was disabled or summary-only for this request.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PayloadPolicyBadges({ item }: { item: RequestLogView }) {
+  const policy = item.payload_policy
+  const hasTruncation = item.request_payload_truncated || item.response_payload_truncated
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex flex-wrap gap-1">
+            <Badge variant={item.has_payload ? 'secondary' : 'outline'}>
+              {formatCaptureMode(policy.capture_mode)}
+            </Badge>
+            {item.request_payload_truncated ? <Badge variant="warning">req truncated</Badge> : null}
+            {item.response_payload_truncated ? <Badge variant="warning">resp truncated</Badge> : null}
+            {hasTruncation ? null : item.has_payload ? <Badge variant="outline">payload</Badge> : null}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          {`${formatBytes(policy.request_max_bytes)} request limit, ${formatBytes(policy.response_max_bytes)} response limit, ${policy.stream_max_events} stream events, ${policy.version}`}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 
@@ -516,6 +631,36 @@ function formatLatency(latencyMs: number | null) {
 
 function formatTokenCount(totalTokens: number | null) {
   return totalTokens === null ? 'n/a' : String(totalTokens)
+}
+
+function formatCaptureMode(captureMode: string) {
+  switch (captureMode) {
+    case 'disabled':
+      return 'disabled'
+    case 'summary_only':
+      return 'summary only'
+    case 'redacted_payloads':
+      return 'redacted payloads'
+    default:
+      return captureMode
+  }
+}
+
+function formatBytes(bytes: number) {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KiB`
+  }
+  return `${bytes} B`
+}
+
+function payloadPolicyDescription(log: RequestLogView) {
+  const policy = log.payload_policy
+  return `${formatCaptureMode(policy.capture_mode)} capture with ${formatBytes(
+    policy.request_max_bytes,
+  )} request and ${formatBytes(policy.response_max_bytes)} response budgets.`
 }
 
 function metadataBoolean(item: RequestLogView, key: string) {

--- a/crates/admin-ui/web/src/server/admin-data.server.test.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.test.ts
@@ -413,6 +413,13 @@ describe('server-side admin data wrappers', () => {
                   metadata: {
                     stream: false,
                   },
+                  payload_policy: {
+                    capture_mode: 'redacted_payloads',
+                    request_max_bytes: 65536,
+                    response_max_bytes: 65536,
+                    stream_max_events: 128,
+                    version: 'builtin:v1',
+                  },
                   occurred_at: '2026-03-10T11:32:00Z',
                 },
               ],
@@ -456,6 +463,13 @@ describe('server-side admin data wrappers', () => {
                 },
                 metadata: {
                   stream: false,
+                },
+                payload_policy: {
+                  capture_mode: 'redacted_payloads',
+                  request_max_bytes: 65536,
+                  response_max_bytes: 65536,
+                  stream_max_events: 128,
+                  version: 'builtin:v1',
                 },
                 occurred_at: '2026-03-10T11:32:00Z',
               },

--- a/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
@@ -59,6 +59,13 @@ const items: RequestLogView[] = [
     metadata: {
       stream: false,
     },
+    payload_policy: {
+      capture_mode: 'redacted_payloads',
+      request_max_bytes: 65536,
+      response_max_bytes: 65536,
+      stream_max_events: 128,
+      version: 'builtin:v1',
+    },
     occurred_at: '2026-03-10T11:32:00Z',
   },
 ]
@@ -97,8 +104,8 @@ describe('RequestLogsPage', () => {
       data: {
         log: items[0],
         payload: {
-          requestJson: { body: { prompt: 'ping' } },
-          responseJson: { body: { output: 'pong' } },
+          request_json: { body: { prompt: 'ping' } },
+          response_json: { body: { output: 'pong' } },
         },
       },
     })
@@ -117,6 +124,42 @@ describe('RequestLogsPage', () => {
     ).toBeInTheDocument()
     expect(screen.queryByText('Attempt Count')).not.toBeInTheDocument()
     expect(screen.queryByText('Fallback')).not.toBeInTheDocument()
+    expect(screen.getByText('Payload Policy')).toBeInTheDocument()
+    expect(screen.getAllByText('redacted payloads').length).toBeGreaterThan(0)
+    expect(screen.getByText(/"prompt": "ping"/)).toBeInTheDocument()
+  })
+
+  it('renders the summary-only no-payload state in detail', async () => {
+    const summaryOnlyItem = {
+      ...items[0],
+      has_payload: false,
+      payload_policy: {
+        capture_mode: 'summary_only',
+        request_max_bytes: 65536,
+        response_max_bytes: 65536,
+        stream_max_events: 128,
+        version: 'builtin:v1',
+      },
+    }
+    routeMock.useLoaderData.mockReturnValue({ data: { items: [summaryOnlyItem], total: 1 } })
+    getObservabilityRequestLogDetailMock.mockResolvedValue({
+      data: {
+        log: summaryOnlyItem,
+        payload: null,
+      },
+    })
+
+    const { RequestLogsPage } = await import('@/routes/observability/request-logs')
+
+    render(<RequestLogsPage />)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Inspect' })[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('Payload capture state')).toBeInTheDocument()
+    })
+
+    expect(screen.getAllByText('No payload stored')).toHaveLength(2)
+    expect(screen.getAllByText('summary only').length).toBeGreaterThan(0)
   })
 
   it('renders an error banner when detail lookup fails', async () => {

--- a/crates/gateway-service/src/lib.rs
+++ b/crates/gateway-service/src/lib.rs
@@ -38,6 +38,9 @@ pub use pricing_catalog::{
     PRICING_CATALOG_CACHE_KEY, PricingCatalog, PricingCatalogSnapshotFile, fetch_vendored_snapshot,
     is_supported_pricing_provider_id, snapshot_to_pretty_json,
 };
+pub use redaction::{
+    PayloadPath, RequestLogPayloadCaptureMode, RequestLogPayloadPolicy, parse_payload_path,
+};
 pub use request_logging::{
     ChatRequestLogContext, LoggedRequest, RequestLogging, StreamFailureSummary,
     StreamLogResultInput, StreamResponseCollector, UsageSummary,

--- a/crates/gateway-service/src/redaction.rs
+++ b/crates/gateway-service/src/redaction.rs
@@ -1,10 +1,12 @@
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 
 const SENSITIVE_HEADERS: &[&str] = &[
     "authorization",
+    "anthropic-api-key",
     "proxy-authorization",
     "cookie",
     "set-cookie",
+    "x-goog-api-key",
     "x-api-key",
 ];
 
@@ -15,6 +17,10 @@ const SENSITIVE_JSON_KEYS: &[&str] = &[
     "set_cookie",
     "x_api_key",
     "api_key",
+    "anthropic_api_key",
+    "client_secret",
+    "credentials",
+    "private_key",
     "token",
     "access_token",
     "refresh_token",
@@ -22,10 +28,306 @@ const SENSITIVE_JSON_KEYS: &[&str] = &[
     "password",
 ];
 
+const LARGE_FIELD_PATHS: &[BuiltInPayloadPath] = &[
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("body"),
+        BuiltInPathSegment::Key("messages"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("image_url"),
+        BuiltInPathSegment::Key("url"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("body"),
+        BuiltInPathSegment::Key("messages"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("input_audio"),
+        BuiltInPathSegment::Key("data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("body"),
+        BuiltInPathSegment::Key("messages"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("file"),
+        BuiltInPathSegment::Key("file_data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("body"),
+        BuiltInPathSegment::Key("contents"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("parts"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("inlineData"),
+        BuiltInPathSegment::Key("data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("body"),
+        BuiltInPathSegment::Key("contents"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("parts"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("inline_data"),
+        BuiltInPathSegment::Key("data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("body"),
+        BuiltInPathSegment::Key("messages"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("source"),
+        BuiltInPathSegment::Key("data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("events"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("choices"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("delta"),
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("image_url"),
+        BuiltInPathSegment::Key("url"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("events"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("choices"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("delta"),
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("input_audio"),
+        BuiltInPathSegment::Key("data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("events"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("choices"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("delta"),
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("file"),
+        BuiltInPathSegment::Key("file_data"),
+    ]),
+    BuiltInPayloadPath::new(&[
+        BuiltInPathSegment::Key("events"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("content"),
+        BuiltInPathSegment::Wildcard,
+        BuiltInPathSegment::Key("source"),
+        BuiltInPathSegment::Key("data"),
+    ]),
+];
+
+const DEFAULT_REQUEST_MAX_BYTES: usize = 64 * 1024;
+const DEFAULT_RESPONSE_MAX_BYTES: usize = 64 * 1024;
+const DEFAULT_STREAM_MAX_EVENTS: usize = 128;
+const PAYLOAD_POLICY_VERSION: &str = "builtin:v1";
 const SECRET_MASK: &str = "********";
+const REDACTED_VALUE: &str = "[REDACTED]";
+const LARGE_FIELD_PREVIEW_BYTES: usize = 96;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RequestLogPayloadCaptureMode {
+    Disabled,
+    SummaryOnly,
+    #[default]
+    RedactedPayloads,
+}
+
+impl RequestLogPayloadCaptureMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::SummaryOnly => "summary_only",
+            Self::RedactedPayloads => "redacted_payloads",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestLogPayloadPolicy {
+    pub capture_mode: RequestLogPayloadCaptureMode,
+    pub request_max_bytes: usize,
+    pub response_max_bytes: usize,
+    pub stream_max_events: usize,
+    redaction_paths: Vec<PayloadPath>,
+}
+
+impl Default for RequestLogPayloadPolicy {
+    fn default() -> Self {
+        Self {
+            capture_mode: RequestLogPayloadCaptureMode::default(),
+            request_max_bytes: DEFAULT_REQUEST_MAX_BYTES,
+            response_max_bytes: DEFAULT_RESPONSE_MAX_BYTES,
+            stream_max_events: DEFAULT_STREAM_MAX_EVENTS,
+            redaction_paths: Vec::new(),
+        }
+    }
+}
+
+impl RequestLogPayloadPolicy {
+    #[must_use]
+    pub fn new(
+        capture_mode: RequestLogPayloadCaptureMode,
+        request_max_bytes: usize,
+        response_max_bytes: usize,
+        stream_max_events: usize,
+        redaction_paths: Vec<PayloadPath>,
+    ) -> Self {
+        Self {
+            capture_mode,
+            request_max_bytes,
+            response_max_bytes,
+            stream_max_events,
+            redaction_paths,
+        }
+    }
+
+    #[must_use]
+    pub fn metadata_value(&self) -> Value {
+        json!({
+            "capture_mode": self.capture_mode.as_str(),
+            "request_max_bytes": self.request_max_bytes,
+            "response_max_bytes": self.response_max_bytes,
+            "stream_max_events": self.stream_max_events,
+            "version": PAYLOAD_POLICY_VERSION,
+        })
+    }
+
+    #[must_use]
+    pub fn should_capture_payloads(&self) -> bool {
+        matches!(
+            self.capture_mode,
+            RequestLogPayloadCaptureMode::RedactedPayloads
+        )
+    }
+
+    fn redacts_path(&self, path: &[PathSegment]) -> bool {
+        self.redaction_paths
+            .iter()
+            .any(|candidate| candidate.matches(path))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PayloadPath {
+    segments: Vec<PathSegment>,
+}
+
+impl PayloadPath {
+    #[must_use]
+    pub fn as_string(&self) -> String {
+        self.segments
+            .iter()
+            .map(PathSegment::as_str)
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+
+    fn matches(&self, path: &[PathSegment]) -> bool {
+        self.segments.len() == path.len()
+            && self
+                .segments
+                .iter()
+                .zip(path)
+                .all(|(expected, actual)| expected.matches(actual))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PathSegment {
+    Key(String),
+    Wildcard,
+}
+
+impl PathSegment {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Key(value) => value.as_str(),
+            Self::Wildcard => "*",
+        }
+    }
+
+    fn matches(&self, actual: &Self) -> bool {
+        matches!(self, Self::Wildcard) || self == actual
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuiltInPathSegment {
+    Key(&'static str),
+    Wildcard,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BuiltInPayloadPath {
+    segments: &'static [BuiltInPathSegment],
+}
+
+impl BuiltInPayloadPath {
+    const fn new(segments: &'static [BuiltInPathSegment]) -> Self {
+        Self { segments }
+    }
+
+    fn matches(&self, path: &[PathSegment]) -> bool {
+        self.segments.len() == path.len()
+            && self
+                .segments
+                .iter()
+                .zip(path)
+                .all(|(expected, actual)| expected.matches(actual))
+    }
+}
+
+impl BuiltInPathSegment {
+    fn matches(&self, actual: &PathSegment) -> bool {
+        match (self, actual) {
+            (Self::Wildcard, _) => true,
+            (Self::Key(expected), PathSegment::Key(actual)) => *expected == actual,
+            (Self::Key(_), PathSegment::Wildcard) => false,
+        }
+    }
+}
 
 fn normalize_key(value: &str) -> String {
     value.to_ascii_lowercase().replace('-', "_")
+}
+
+pub fn parse_payload_path(value: &str) -> Result<PayloadPath, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("path cannot be empty".to_string());
+    }
+
+    let mut segments = Vec::new();
+    for segment in trimmed.split('.') {
+        if segment.is_empty() {
+            return Err(format!("path `{value}` contains an empty segment"));
+        }
+        if segment == "*" {
+            segments.push(PathSegment::Wildcard);
+            continue;
+        }
+        if !segment.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '_' || character == '-'
+        }) {
+            return Err(format!(
+                "path `{value}` segment `{segment}` must use ASCII letters, numbers, `_`, `-`, or `*`"
+            ));
+        }
+        segments.push(PathSegment::Key(segment.to_string()));
+    }
+
+    Ok(PayloadPath { segments })
 }
 
 #[must_use]
@@ -47,7 +349,7 @@ pub fn is_sensitive_json_key(key: &str) -> bool {
 #[must_use]
 pub fn redact_header_value(header_name: &str, header_value: &str) -> String {
     if is_sensitive_header(header_name) {
-        "[REDACTED]".to_string()
+        REDACTED_VALUE.to_string()
     } else {
         header_value.to_string()
     }
@@ -55,21 +357,114 @@ pub fn redact_header_value(header_name: &str, header_value: &str) -> String {
 
 #[must_use]
 pub fn redact_json_value(value: &Value) -> Value {
+    redact_json_value_with_policy(value, &RequestLogPayloadPolicy::default())
+}
+
+#[must_use]
+pub fn redact_json_value_with_policy(value: &Value, policy: &RequestLogPayloadPolicy) -> Value {
+    redact_json_value_at_path(value, policy, &mut Vec::new())
+}
+
+fn redact_json_value_at_path(
+    value: &Value,
+    policy: &RequestLogPayloadPolicy,
+    path: &mut Vec<PathSegment>,
+) -> Value {
+    if policy.redacts_path(path) {
+        return Value::String(REDACTED_VALUE.to_string());
+    }
+
     match value {
-        Value::Array(values) => Value::Array(values.iter().map(redact_json_value).collect()),
+        Value::Array(values) => {
+            path.push(PathSegment::Wildcard);
+            let redacted = values
+                .iter()
+                .map(|value| redact_json_value_at_path(value, policy, path))
+                .collect();
+            path.pop();
+            Value::Array(redacted)
+        }
         Value::Object(values) => {
             let mut redacted = Map::with_capacity(values.len());
             for (key, value) in values {
                 if is_sensitive_json_key(key) {
-                    redacted.insert(key.clone(), Value::String("[REDACTED]".to_string()));
+                    redacted.insert(key.clone(), Value::String(REDACTED_VALUE.to_string()));
                 } else {
-                    redacted.insert(key.clone(), redact_json_value(value));
+                    path.push(PathSegment::Key(key.clone()));
+                    redacted.insert(key.clone(), redact_json_value_at_path(value, policy, path));
+                    path.pop();
                 }
             }
             Value::Object(redacted)
         }
         _ => value.clone(),
     }
+}
+
+#[must_use]
+pub fn truncate_large_payload_fields(value: &Value) -> Value {
+    truncate_large_fields_at_path(value, LARGE_FIELD_PATHS, &mut Vec::new())
+}
+
+fn truncate_large_fields_at_path(
+    value: &Value,
+    paths: &[BuiltInPayloadPath],
+    path: &mut Vec<PathSegment>,
+) -> Value {
+    if paths.iter().any(|candidate| candidate.matches(path))
+        && let Some(text) = value.as_str()
+        && should_truncate_known_large_field(text)
+    {
+        return json!({
+            "truncated": true,
+            "size_bytes": text.len(),
+            "preview": safe_preview(text, LARGE_FIELD_PREVIEW_BYTES),
+        });
+    }
+
+    match value {
+        Value::Array(values) => {
+            path.push(PathSegment::Wildcard);
+            let truncated = values
+                .iter()
+                .map(|value| truncate_large_fields_at_path(value, paths, path))
+                .collect();
+            path.pop();
+            Value::Array(truncated)
+        }
+        Value::Object(values) => {
+            let mut truncated = Map::with_capacity(values.len());
+            for (key, value) in values {
+                path.push(PathSegment::Key(key.clone()));
+                truncated.insert(
+                    key.clone(),
+                    truncate_large_fields_at_path(value, paths, path),
+                );
+                path.pop();
+            }
+            Value::Object(truncated)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn should_truncate_known_large_field(value: &str) -> bool {
+    value.starts_with("data:") || is_probably_base64_payload(value)
+}
+
+fn is_probably_base64_payload(value: &str) -> bool {
+    value.len() > 256
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/' | b'=' | b'\n' | b'\r')
+        })
+}
+
+fn safe_preview(value: &str, max_bytes: usize) -> String {
+    value
+        .char_indices()
+        .take_while(|(index, _)| *index < max_bytes)
+        .map(|(_, character)| character)
+        .collect()
 }
 
 #[must_use]
@@ -95,7 +490,9 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        is_sensitive_json_key, mask_secret_leaf_values, redact_header_value, redact_json_value,
+        RequestLogPayloadCaptureMode, RequestLogPayloadPolicy, is_sensitive_json_key,
+        mask_secret_leaf_values, parse_payload_path, redact_header_value, redact_json_value,
+        redact_json_value_with_policy, truncate_large_payload_fields,
     };
 
     #[test]
@@ -155,5 +552,165 @@ mod tests {
     fn sensitive_json_key_check_normalizes_separators() {
         assert!(is_sensitive_json_key("x-api-key"));
         assert!(is_sensitive_json_key("refresh_token"));
+    }
+
+    #[test]
+    fn parses_payload_paths_with_wildcards() {
+        let path = parse_payload_path("body.messages.*.content").expect("path parses");
+        assert_eq!(path.as_string(), "body.messages.*.content");
+        assert!(parse_payload_path("body..messages").is_err());
+        assert!(parse_payload_path("body.messages[0]").is_err());
+    }
+
+    #[test]
+    fn redacts_operator_configured_paths() {
+        let policy = RequestLogPayloadPolicy::new(
+            RequestLogPayloadCaptureMode::RedactedPayloads,
+            1024,
+            1024,
+            10,
+            vec![parse_payload_path("body.messages.*.metadata.internal").expect("path")],
+        );
+        let input = json!({
+            "body": {
+                "messages": [
+                    {"metadata": {"internal": "secret", "public": "kept"}}
+                ]
+            }
+        });
+
+        let redacted = redact_json_value_with_policy(&input, &policy);
+
+        assert_eq!(
+            redacted["body"]["messages"][0]["metadata"]["internal"],
+            "[REDACTED]"
+        );
+        assert_eq!(
+            redacted["body"]["messages"][0]["metadata"]["public"],
+            "kept"
+        );
+    }
+
+    #[test]
+    fn truncates_known_large_provider_fields_without_changing_shape() {
+        let input = json!({
+            "body": {
+                "messages": [
+                    {
+                        "content": [
+                            {
+                                "type": "input_audio",
+                                "input_audio": {
+                                    "data": "a".repeat(400),
+                                    "format": "wav"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let truncated = truncate_large_payload_fields(&input);
+
+        assert_eq!(
+            truncated["body"]["messages"][0]["content"][0]["input_audio"]["data"]["truncated"],
+            true
+        );
+        assert_eq!(
+            truncated["body"]["messages"][0]["content"][0]["input_audio"]["format"],
+            "wav"
+        );
+    }
+
+    #[test]
+    fn leaves_normal_remote_image_urls_unchanged() {
+        let input = json!({
+            "body": {
+                "messages": [
+                    {
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "https://example.com/image.png"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let truncated = truncate_large_payload_fields(&input);
+
+        assert_eq!(
+            truncated["body"]["messages"][0]["content"][0]["image_url"]["url"],
+            "https://example.com/image.png"
+        );
+    }
+
+    #[test]
+    fn truncates_vertex_gemini_inline_data_fields() {
+        let input = json!({
+            "body": {
+                "contents": [
+                    {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": "a".repeat(400)
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let truncated = truncate_large_payload_fields(&input);
+
+        assert_eq!(
+            truncated["body"]["contents"][0]["parts"][0]["inlineData"]["data"]["truncated"],
+            true
+        );
+        assert_eq!(
+            truncated["body"]["contents"][0]["parts"][0]["inlineData"]["mimeType"],
+            "image/png"
+        );
+    }
+
+    #[test]
+    fn truncates_vertex_anthropic_base64_source_data_fields() {
+        let input = json!({
+            "body": {
+                "messages": [
+                    {
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/jpeg",
+                                    "data": "a".repeat(400)
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let truncated = truncate_large_payload_fields(&input);
+
+        assert_eq!(
+            truncated["body"]["messages"][0]["content"][0]["source"]["data"]["truncated"],
+            true
+        );
+        assert_eq!(
+            truncated["body"]["messages"][0]["content"][0]["source"]["media_type"],
+            "image/jpeg"
+        );
     }
 }

--- a/crates/gateway-service/src/request_logging.rs
+++ b/crates/gateway-service/src/request_logging.rs
@@ -12,10 +12,10 @@ use serde_json::{Map, Value, json};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::redaction::{redact_header_value, redact_json_value};
-
-const MAX_PAYLOAD_BYTES: usize = 64 * 1024;
-const MAX_STREAM_EVENTS: usize = 128;
+use crate::redaction::{
+    RequestLogPayloadCaptureMode, RequestLogPayloadPolicy, redact_header_value,
+    redact_json_value_with_policy, truncate_large_payload_fields,
+};
 
 #[derive(Debug, Clone)]
 pub struct ChatRequestLogContext {
@@ -24,7 +24,7 @@ pub struct ChatRequestLogContext {
     pub requested_model_key: String,
     pub resolved_model_key: String,
     pub request_tags: RequestTags,
-    request_json: Value,
+    request_json: Option<Value>,
     request_payload_truncated: bool,
 }
 
@@ -46,6 +46,7 @@ pub struct StreamLogResultInput {
 #[derive(Debug, Clone, Default)]
 pub struct StreamResponseCollector {
     parser: SseEventParser,
+    payload_policy: RequestLogPayloadPolicy,
     events: Vec<Value>,
     usage: Option<Value>,
     failure: Option<StreamFailureSummary>,
@@ -161,17 +162,13 @@ impl StreamResponseCollector {
                 self.failure = Some(failure);
             }
 
-            let redacted = parsed
-                .as_ref()
-                .map(redact_json_value)
-                .unwrap_or_else(|| json!({ "raw": payload }));
-
-            if self.events.len() >= MAX_STREAM_EVENTS {
+            if self.events.len() >= self.payload_policy.stream_max_events {
                 self.truncated = true;
                 continue;
             }
 
-            self.events.push(redacted);
+            self.events
+                .push(parsed.unwrap_or_else(|| json!({ "raw": payload })));
         }
     }
 
@@ -201,17 +198,24 @@ impl StreamResponseCollector {
     }
 
     fn into_payload(self, failure: Option<&StreamFailureSummary>) -> (Value, bool) {
-        truncate_payload(json!({
-            "stream": true,
-            "events": self.events,
-            "usage": self.usage,
-            "error": failure.map(|failure| {
-                json!({
-                    "status_code": failure.status_code,
-                    "code": failure.error_code,
-                })
+        let payload = redact_json_value_with_policy(
+            &json!({
+                "stream": true,
+                "events": self.events,
+                "usage": self.usage,
+                "error": failure.map(|failure| {
+                    json!({
+                        "status_code": failure.status_code,
+                        "code": failure.error_code,
+                    })
+                }),
             }),
-        }))
+            &self.payload_policy,
+        );
+        truncate_payload(
+            truncate_large_payload_fields(&payload),
+            self.payload_policy.response_max_bytes,
+        )
         .map_truncated(self.truncated)
     }
 }
@@ -241,6 +245,7 @@ impl PayloadResultExt for (Value, bool) {
 #[derive(Clone)]
 pub struct RequestLogging<R> {
     repo: Arc<R>,
+    payload_policy: RequestLogPayloadPolicy,
 }
 
 impl<R> RequestLogging<R>
@@ -249,7 +254,15 @@ where
 {
     #[must_use]
     pub fn new(repo: Arc<R>) -> Self {
-        Self { repo }
+        Self::new_with_payload_policy(repo, RequestLogPayloadPolicy::default())
+    }
+
+    #[must_use]
+    pub fn new_with_payload_policy(repo: Arc<R>, payload_policy: RequestLogPayloadPolicy) -> Self {
+        Self {
+            repo,
+            payload_policy,
+        }
     }
 
     #[must_use]
@@ -262,16 +275,29 @@ where
         request_headers: &BTreeMap<String, String>,
         request_tags: RequestTags,
     ) -> ChatRequestLogContext {
-        let sanitized_headers = request_headers
-            .iter()
-            .map(|(key, value)| (key.clone(), Value::String(redact_header_value(key, value))))
-            .collect::<Map<_, _>>();
-        let request_body =
-            redact_json_value(&serde_json::to_value(request).unwrap_or_else(|_| json!({})));
-        let (request_json, request_payload_truncated) = truncate_payload(json!({
-            "headers": sanitized_headers,
-            "body": request_body,
-        }));
+        let (request_json, request_payload_truncated) = if self
+            .payload_policy
+            .should_capture_payloads()
+        {
+            let sanitized_headers = request_headers
+                .iter()
+                .map(|(key, value)| (key.clone(), Value::String(redact_header_value(key, value))))
+                .collect::<Map<_, _>>();
+            let request_body = serde_json::to_value(request).unwrap_or_else(|_| json!({}));
+            let redacted = redact_json_value_with_policy(
+                &json!({
+                    "headers": sanitized_headers,
+                    "body": request_body,
+                }),
+                &self.payload_policy,
+            );
+            let redacted = truncate_large_payload_fields(&redacted);
+            let (request_json, truncated) =
+                truncate_payload(redacted, self.payload_policy.request_max_bytes);
+            (Some(request_json), truncated)
+        } else {
+            (None, false)
+        };
 
         ChatRequestLogContext {
             request_log_id: Uuid::new_v4(),
@@ -304,7 +330,10 @@ where
 
     #[must_use]
     pub fn new_stream_response_collector(&self) -> StreamResponseCollector {
-        StreamResponseCollector::default()
+        StreamResponseCollector {
+            payload_policy: self.payload_policy.clone(),
+            ..StreamResponseCollector::default()
+        }
     }
 
     pub async fn log_non_stream_success(
@@ -316,10 +345,20 @@ where
         latency_ms: i64,
         response_body: &Value,
     ) -> Result<LoggedRequest, GatewayError> {
-        let sanitized_response = redact_json_value(response_body);
-        let usage = usage_summary_from_value(sanitized_response.get("usage"));
+        let usage = usage_summary_from_value(response_body.get("usage"));
         let (response_json, response_payload_truncated) =
-            truncate_payload(json!({ "body": sanitized_response }));
+            if self.payload_policy.should_capture_payloads() {
+                let sanitized_response = redact_json_value_with_policy(
+                    &json!({ "body": response_body }),
+                    &self.payload_policy,
+                );
+                let sanitized_response = truncate_large_payload_fields(&sanitized_response);
+                let (response_json, truncated) =
+                    truncate_payload(sanitized_response, self.payload_policy.response_max_bytes);
+                (Some(response_json), truncated)
+            } else {
+                (None, false)
+            };
         self.persist_chat_log(
             api_key,
             context,
@@ -345,13 +384,23 @@ where
         latency_ms: i64,
         gateway_error: &GatewayError,
     ) -> Result<LoggedRequest, GatewayError> {
-        let response_json = json!({
-            "body": redact_json_value(
-                &serde_json::to_value(OpenAiErrorEnvelope::from_gateway_error(gateway_error))
-                    .unwrap_or_else(|_| json!({ "error": gateway_error.to_string() })),
-            ),
-        });
-        let (response_json, response_payload_truncated) = truncate_payload(response_json);
+        let (response_json, response_payload_truncated) = if self
+            .payload_policy
+            .should_capture_payloads()
+        {
+            let response_json = redact_json_value_with_policy(
+                &json!({
+                    "body": serde_json::to_value(OpenAiErrorEnvelope::from_gateway_error(gateway_error))
+                        .unwrap_or_else(|_| json!({ "error": gateway_error.to_string() })),
+                }),
+                &self.payload_policy,
+            );
+            let (response_json, truncated) =
+                truncate_payload(response_json, self.payload_policy.response_max_bytes);
+            (Some(response_json), truncated)
+        } else {
+            (None, false)
+        };
         self.persist_chat_log(
             api_key,
             context,
@@ -385,7 +434,14 @@ where
         collector.finish();
         let failure = failure.or_else(|| collector.failure().cloned());
         let usage = usage_summary_from_value(collector.usage());
-        let (response_json, response_payload_truncated) = collector.into_payload(failure.as_ref());
+        let (response_json, response_payload_truncated) =
+            if self.payload_policy.should_capture_payloads() {
+                let (response_json, response_payload_truncated) =
+                    collector.into_payload(failure.as_ref());
+                (Some(response_json), response_payload_truncated)
+            } else {
+                (None, false)
+            };
         let summary = match failure {
             Some(failure) => ChatCompletionLogSummary::failure(
                 provider_key,
@@ -435,17 +491,23 @@ where
         api_key: &AuthenticatedApiKey,
         context: &ChatRequestLogContext,
         summary: ChatCompletionLogSummary,
-        response_json: Value,
+        response_json: Option<Value>,
         response_payload_truncated: bool,
     ) -> Result<LoggedRequest, GatewayError> {
-        if !self.should_log_request(api_key).await? {
+        if self.payload_policy.capture_mode == RequestLogPayloadCaptureMode::Disabled
+            || !self.should_log_request(api_key).await?
+        {
             return Ok(LoggedRequest {
                 request_log_id: context.request_log_id,
                 wrote: false,
             });
         }
 
-        let metadata = request_log_metadata(summary.stream, &summary.icon_metadata);
+        let metadata =
+            request_log_metadata(summary.stream, &summary.icon_metadata, &self.payload_policy);
+        let has_payload = self.payload_policy.should_capture_payloads()
+            && context.request_json.is_some()
+            && response_json.is_some();
         let log = RequestLogRecord {
             request_log_id: context.request_log_id,
             request_id: context.request_id.clone(),
@@ -461,20 +523,23 @@ where
             completion_tokens: summary.usage.completion_tokens,
             total_tokens: summary.usage.total_tokens,
             error_code: summary.error_code,
-            has_payload: true,
-            request_payload_truncated: context.request_payload_truncated,
-            response_payload_truncated,
+            has_payload,
+            request_payload_truncated: has_payload && context.request_payload_truncated,
+            response_payload_truncated: has_payload && response_payload_truncated,
             request_tags: context.request_tags.clone(),
             metadata,
             occurred_at: OffsetDateTime::now_utc(),
         };
-        let payload = RequestLogPayloadRecord {
-            request_log_id: context.request_log_id,
-            request_json: context.request_json.clone(),
-            response_json,
+        let payload = match (has_payload, context.request_json.clone(), response_json) {
+            (true, Some(request_json), Some(response_json)) => Some(RequestLogPayloadRecord {
+                request_log_id: context.request_log_id,
+                request_json,
+                response_json,
+            }),
+            _ => None,
         };
 
-        self.repo.insert_request_log(&log, Some(&payload)).await?;
+        self.repo.insert_request_log(&log, payload.as_ref()).await?;
 
         Ok(LoggedRequest {
             request_log_id: context.request_log_id,
@@ -509,6 +574,7 @@ pub fn usage_summary_from_value(value: Option<&Value>) -> UsageSummary {
 fn request_log_metadata(
     stream: bool,
     icon_metadata: &RequestLogIconMetadata,
+    payload_policy: &RequestLogPayloadPolicy,
 ) -> Map<String, Value> {
     let mut metadata = Map::new();
     metadata.insert(
@@ -516,6 +582,10 @@ fn request_log_metadata(
         Value::String("chat_completions".to_string()),
     );
     metadata.insert("stream".to_string(), Value::Bool(stream));
+    metadata.insert(
+        "payload_policy".to_string(),
+        payload_policy.metadata_value(),
+    );
     metadata.insert(
         REQUEST_LOG_PROVIDER_ICON_KEY.to_string(),
         Value::String(icon_metadata.provider_icon_key.as_str().to_string()),
@@ -529,13 +599,13 @@ fn request_log_metadata(
     metadata
 }
 
-fn truncate_payload(value: Value) -> (Value, bool) {
+fn truncate_payload(value: Value, max_bytes: usize) -> (Value, bool) {
     match serde_json::to_vec(&value) {
-        Ok(bytes) if bytes.len() > MAX_PAYLOAD_BYTES => (
+        Ok(bytes) if bytes.len() > max_bytes => (
             json!({
                 "truncated": true,
                 "size_bytes": bytes.len(),
-                "preview": String::from_utf8_lossy(&bytes[..MAX_PAYLOAD_BYTES.min(bytes.len())]).to_string(),
+                "preview": String::from_utf8_lossy(&bytes[..max_bytes.min(bytes.len())]).to_string(),
             }),
             true,
         ),
@@ -569,7 +639,10 @@ mod tests {
     use time::OffsetDateTime;
     use uuid::Uuid;
 
-    use crate::RequestLogIconMetadata;
+    use crate::{
+        RequestLogIconMetadata,
+        redaction::{RequestLogPayloadCaptureMode, RequestLogPayloadPolicy, parse_payload_path},
+    };
 
     use super::{
         RequestLogging, StreamFailureSummary, StreamLogResultInput, StreamResponseCollector,
@@ -702,6 +775,61 @@ mod tests {
         }
     }
 
+    fn sample_team_auth() -> AuthenticatedApiKey {
+        AuthenticatedApiKey {
+            id: Uuid::new_v4(),
+            public_id: "dev123".to_string(),
+            name: "dev".to_string(),
+            owner_kind: ApiKeyOwnerKind::Team,
+            owner_user_id: None,
+            owner_team_id: Some(Uuid::new_v4()),
+        }
+    }
+
+    fn sample_icon_metadata() -> RequestLogIconMetadata {
+        RequestLogIconMetadata {
+            provider_icon_key: crate::ProviderIconKey::OpenAI,
+            model_icon_key: Some(crate::ModelIconKey::OpenAI),
+        }
+    }
+
+    fn sample_request(stream: bool) -> ChatCompletionsRequest {
+        ChatCompletionsRequest {
+            model: "fast".to_string(),
+            messages: Vec::new(),
+            stream,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    fn policy(
+        capture_mode: RequestLogPayloadCaptureMode,
+        request_max_bytes: usize,
+        response_max_bytes: usize,
+        stream_max_events: usize,
+    ) -> RequestLogPayloadPolicy {
+        RequestLogPayloadPolicy::new(
+            capture_mode,
+            request_max_bytes,
+            response_max_bytes,
+            stream_max_events,
+            Vec::new(),
+        )
+    }
+
+    fn policy_with_redaction_paths(paths: &[&str]) -> RequestLogPayloadPolicy {
+        RequestLogPayloadPolicy::new(
+            RequestLogPayloadCaptureMode::RedactedPayloads,
+            4096,
+            4096,
+            4,
+            paths
+                .iter()
+                .map(|path| parse_payload_path(path).expect("test path should parse"))
+                .collect(),
+        )
+    }
+
     #[tokio::test]
     async fn suppresses_logging_for_user_toggle_disabled() {
         let user_id = Uuid::new_v4();
@@ -821,6 +949,161 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disabled_payload_policy_writes_no_request_log_rows() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new_with_payload_policy(
+            repo.clone(),
+            policy(RequestLogPayloadCaptureMode::Disabled, 1024, 1024, 4),
+        );
+        let auth = sample_team_auth();
+        let context = logging.begin_chat_request(
+            "req_1",
+            "fast",
+            "fast",
+            &sample_request(false),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+
+        let wrote = logging
+            .log_non_stream_success(
+                &auth,
+                &context,
+                "openai-prod",
+                sample_icon_metadata(),
+                120,
+                &json!({"usage": {"prompt_tokens": 1, "completion_tokens": 2}}),
+            )
+            .await
+            .expect("request logging should evaluate");
+
+        assert!(!wrote.wrote);
+        assert!(repo.logs.lock().expect("logs lock").is_empty());
+        assert!(repo.payloads.lock().expect("payloads lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn summary_only_payload_policy_writes_summary_without_payload() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new_with_payload_policy(
+            repo.clone(),
+            policy(RequestLogPayloadCaptureMode::SummaryOnly, 1024, 1024, 4),
+        );
+        let auth = sample_team_auth();
+        let context = logging.begin_chat_request(
+            "req_1",
+            "fast",
+            "fast",
+            &sample_request(false),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+
+        let wrote = logging
+            .log_non_stream_success(
+                &auth,
+                &context,
+                "openai-prod",
+                sample_icon_metadata(),
+                120,
+                &json!({"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}}),
+            )
+            .await
+            .expect("summary log");
+
+        let logs = repo.logs.lock().expect("logs lock");
+        assert!(wrote.wrote);
+        assert_eq!(logs.len(), 1);
+        assert!(!logs[0].has_payload);
+        assert!(!logs[0].request_payload_truncated);
+        assert!(!logs[0].response_payload_truncated);
+        assert_eq!(
+            logs[0].metadata["payload_policy"]["capture_mode"],
+            "summary_only"
+        );
+        assert!(repo.payloads.lock().expect("payloads lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn separate_payload_limits_mark_only_affected_side_truncated() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new_with_payload_policy(
+            repo.clone(),
+            policy(RequestLogPayloadCaptureMode::RedactedPayloads, 4096, 80, 4),
+        );
+        let auth = sample_team_auth();
+        let context = logging.begin_chat_request(
+            "req_1",
+            "fast",
+            "fast",
+            &sample_request(false),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+
+        logging
+            .log_non_stream_success(
+                &auth,
+                &context,
+                "openai-prod",
+                sample_icon_metadata(),
+                120,
+                &json!({
+                    "choices": [{"message": {"content": "x".repeat(512)}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+                }),
+            )
+            .await
+            .expect("truncated log");
+
+        let logs = repo.logs.lock().expect("logs lock");
+        let payloads = repo.payloads.lock().expect("payloads lock");
+        assert!(logs[0].has_payload);
+        assert!(!logs[0].request_payload_truncated);
+        assert!(logs[0].response_payload_truncated);
+        assert_eq!(payloads[0].response_json["truncated"], true);
+    }
+
+    #[tokio::test]
+    async fn operator_redaction_paths_apply_to_wrapped_response_payloads() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new_with_payload_policy(
+            repo.clone(),
+            policy_with_redaction_paths(&["body.choices.*.message.content"]),
+        );
+        let auth = sample_team_auth();
+        let context = logging.begin_chat_request(
+            "req_1",
+            "fast",
+            "fast",
+            &sample_request(false),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+
+        logging
+            .log_non_stream_success(
+                &auth,
+                &context,
+                "openai-prod",
+                sample_icon_metadata(),
+                120,
+                &json!({
+                    "choices": [{"message": {"content": "operator-secret"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+                }),
+            )
+            .await
+            .expect("redacted response log");
+
+        let payloads = repo.payloads.lock().expect("payloads lock");
+        assert_eq!(
+            payloads[0].response_json["body"]["choices"][0]["message"]["content"],
+            "[REDACTED]"
+        );
+    }
+
+    #[tokio::test]
     async fn records_stream_failures_with_payload() {
         let repo = Arc::new(InMemoryRepo::default());
         let logging = RequestLogging::new(repo.clone());
@@ -884,6 +1167,106 @@ mod tests {
         assert!(logs[0].metadata.get("fallback_used").is_none());
         assert!(logs[0].metadata.get("attempt_count").is_none());
         assert_eq!(payload[0].response_json["error"]["code"], "stream_error");
+    }
+
+    #[tokio::test]
+    async fn stream_event_storage_cap_does_not_stop_usage_parsing() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new_with_payload_policy(
+            repo.clone(),
+            policy(
+                RequestLogPayloadCaptureMode::RedactedPayloads,
+                4096,
+                4096,
+                1,
+            ),
+        );
+        let auth = sample_team_auth();
+        let context = logging.begin_chat_request(
+            "req_1",
+            "fast",
+            "fast",
+            &sample_request(true),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+        let mut collector = logging.new_stream_response_collector();
+        collector.observe_chunk(
+            br#"data: {"choices":[{"delta":{"content":"hello"}}]}
+
+data: {"usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9}}
+
+"#,
+        );
+
+        logging
+            .log_stream_result(
+                &auth,
+                &context,
+                StreamLogResultInput {
+                    provider_key: "openai-prod".to_string(),
+                    icon_metadata: sample_icon_metadata(),
+                    latency_ms: 120,
+                    collector,
+                    failure: None,
+                },
+            )
+            .await
+            .expect("stream log");
+
+        let logs = repo.logs.lock().expect("logs lock");
+        let payload = repo.payloads.lock().expect("payloads lock");
+        assert_eq!(logs[0].total_tokens, Some(9));
+        assert!(logs[0].response_payload_truncated);
+        assert_eq!(
+            payload[0].response_json["events"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_redaction_paths_apply_to_wrapped_stream_payloads() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new_with_payload_policy(
+            repo.clone(),
+            policy_with_redaction_paths(&["events.*.choices.*.delta.content"]),
+        );
+        let auth = sample_team_auth();
+        let context = logging.begin_chat_request(
+            "req_1",
+            "fast",
+            "fast",
+            &sample_request(true),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+        let mut collector = logging.new_stream_response_collector();
+        collector.observe_chunk(
+            br#"data: {"choices":[{"delta":{"content":"operator-secret"}}]}
+
+"#,
+        );
+
+        logging
+            .log_stream_result(
+                &auth,
+                &context,
+                StreamLogResultInput {
+                    provider_key: "openai-prod".to_string(),
+                    icon_metadata: sample_icon_metadata(),
+                    latency_ms: 120,
+                    collector,
+                    failure: None,
+                },
+            )
+            .await
+            .expect("stream log");
+
+        let payloads = repo.payloads.lock().expect("payloads lock");
+        assert_eq!(
+            payloads[0].response_json["events"][0]["choices"][0]["delta"]["content"],
+            "[REDACTED]"
+        );
     }
 
     #[test]

--- a/crates/gateway-service/src/service.rs
+++ b/crates/gateway-service/src/service.rs
@@ -15,8 +15,9 @@ use uuid::Uuid;
 
 use crate::{
     Authenticator, ChatRequestLogContext, LoggedRequest, ModelAccess, ModelResolver,
-    PricingCatalog, RequestLogIconMetadata, RequestLogging, ResolvedGatewayRequest,
-    ResolvedProviderConnection, StreamLogResultInput, StreamResponseCollector,
+    PricingCatalog, RequestLogIconMetadata, RequestLogPayloadPolicy, RequestLogging,
+    ResolvedGatewayRequest, ResolvedProviderConnection, StreamLogResultInput,
+    StreamResponseCollector,
     budget_alerts::{BudgetAlertSender, BudgetAlertService, SinkBudgetAlertSender},
     budget_guard::{BudgetGuard, BudgetGuardDisposition},
 };
@@ -71,13 +72,29 @@ where
         planner: Arc<P>,
         sender: Arc<dyn BudgetAlertSender>,
     ) -> Self {
+        Self::new_with_budget_alert_sender_and_payload_policy(
+            store,
+            planner,
+            sender,
+            RequestLogPayloadPolicy::default(),
+        )
+    }
+
+    #[must_use]
+    pub fn new_with_budget_alert_sender_and_payload_policy(
+        store: Arc<S>,
+        planner: Arc<P>,
+        sender: Arc<dyn BudgetAlertSender>,
+        payload_policy: RequestLogPayloadPolicy,
+    ) -> Self {
         let authenticator = Authenticator::new(store.clone());
         let budget_alerts = BudgetAlertService::new(store.clone(), sender);
         let budget_guard = BudgetGuard::new(store.clone());
         let model_access = ModelAccess::new(store.clone());
         let model_resolver = ModelResolver::new(store.clone());
         let pricing_catalog = PricingCatalog::new(store.clone());
-        let request_logging = RequestLogging::new(store.clone());
+        let request_logging =
+            RequestLogging::new_with_payload_policy(store.clone(), payload_policy);
 
         Self {
             store,

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -3918,17 +3918,17 @@
           "request_max_bytes": {
             "type": "integer",
             "format": "int64",
-            "minimum": 0
+            "minimum": 1
           },
           "response_max_bytes": {
             "type": "integer",
             "format": "int64",
-            "minimum": 0
+            "minimum": 1
           },
           "stream_max_events": {
             "type": "integer",
             "format": "int64",
-            "minimum": 0
+            "minimum": 1
           },
           "version": {
             "type": "string"

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -3869,6 +3869,47 @@
           }
         }
       },
+      "RequestLogPayloadCaptureModeView": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "summary_only",
+          "redacted_payloads"
+        ]
+      },
+      "RequestLogPayloadPolicyView": {
+        "type": "object",
+        "required": [
+          "capture_mode",
+          "request_max_bytes",
+          "response_max_bytes",
+          "stream_max_events",
+          "version"
+        ],
+        "properties": {
+          "capture_mode": {
+            "$ref": "#/components/schemas/RequestLogPayloadCaptureModeView"
+          },
+          "request_max_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "response_max_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "stream_max_events": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
       "RequestLogPayloadView": {
         "type": "object",
         "required": [
@@ -3892,6 +3933,7 @@
           "has_payload",
           "request_payload_truncated",
           "response_payload_truncated",
+          "payload_policy",
           "request_tags",
           "metadata",
           "occurred_at"
@@ -3942,6 +3984,9 @@
           },
           "occurred_at": {
             "type": "string"
+          },
+          "payload_policy": {
+            "$ref": "#/components/schemas/RequestLogPayloadPolicyView"
           },
           "prompt_tokens": {
             "type": [

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -7,7 +7,10 @@ use gateway_core::{
     SeedTeam, SeedUser, SeedUserMembership, parse_gateway_api_key,
 };
 use gateway_providers::{OpenAiCompatConfig, VertexAuthConfig, VertexProviderConfig};
-use gateway_service::{ProviderIconKey, hash_gateway_key_secret, is_supported_pricing_provider_id};
+use gateway_service::{
+    PayloadPath, ProviderIconKey, RequestLogPayloadCaptureMode, RequestLogPayloadPolicy,
+    hash_gateway_key_secret, is_supported_pricing_provider_id, parse_payload_path,
+};
 use gateway_store::StoreConnectionOptions;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -22,6 +25,8 @@ pub struct GatewayConfig {
     pub auth: AuthConfig,
     #[serde(default)]
     pub budget_alerts: BudgetAlertConfig,
+    #[serde(default)]
+    pub request_logging: RequestLoggingConfig,
     #[serde(default)]
     pub providers: Vec<ProviderConfig>,
     #[serde(default)]
@@ -53,6 +58,7 @@ impl GatewayConfig {
     fn validate(&self) -> anyhow::Result<()> {
         let _ = self.database.connection_options()?;
         self.budget_alerts.validate()?;
+        self.request_logging.validate()?;
 
         let provider_by_id = self
             .providers
@@ -538,6 +544,10 @@ impl GatewayConfig {
     pub fn database_options(&self) -> anyhow::Result<StoreConnectionOptions> {
         self.database.connection_options()
     }
+
+    pub fn request_log_payload_policy(&self) -> anyhow::Result<RequestLogPayloadPolicy> {
+        self.request_logging.payloads.to_policy()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -631,6 +641,107 @@ pub struct AuthConfig {
 pub struct BudgetAlertConfig {
     #[serde(default)]
     pub email: BudgetAlertEmailConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct RequestLoggingConfig {
+    #[serde(default)]
+    pub payloads: RequestLogPayloadConfig,
+}
+
+impl RequestLoggingConfig {
+    fn validate(&self) -> anyhow::Result<()> {
+        self.payloads.validate()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequestLogPayloadConfig {
+    #[serde(default)]
+    pub capture_mode: RequestLogPayloadCaptureModeConfig,
+    #[serde(default = "default_request_log_request_max_bytes")]
+    pub request_max_bytes: usize,
+    #[serde(default = "default_request_log_response_max_bytes")]
+    pub response_max_bytes: usize,
+    #[serde(default = "default_request_log_stream_max_events")]
+    pub stream_max_events: usize,
+    #[serde(default)]
+    pub redaction_paths: Vec<String>,
+}
+
+impl Default for RequestLogPayloadConfig {
+    fn default() -> Self {
+        Self {
+            capture_mode: RequestLogPayloadCaptureModeConfig::default(),
+            request_max_bytes: default_request_log_request_max_bytes(),
+            response_max_bytes: default_request_log_response_max_bytes(),
+            stream_max_events: default_request_log_stream_max_events(),
+            redaction_paths: Vec::new(),
+        }
+    }
+}
+
+impl RequestLogPayloadConfig {
+    fn validate(&self) -> anyhow::Result<()> {
+        if self.request_max_bytes == 0 {
+            bail!("request_logging.payloads.request_max_bytes must be > 0");
+        }
+        if self.response_max_bytes == 0 {
+            bail!("request_logging.payloads.response_max_bytes must be > 0");
+        }
+        if self.stream_max_events == 0 {
+            bail!("request_logging.payloads.stream_max_events must be > 0");
+        }
+        for path in &self.redaction_paths {
+            parse_payload_path(path).map_err(|error| {
+                anyhow::anyhow!(
+                    "request_logging.payloads.redaction_paths `{path}` is invalid: {error}"
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    fn to_policy(&self) -> anyhow::Result<RequestLogPayloadPolicy> {
+        let paths = self
+            .redaction_paths
+            .iter()
+            .map(|path| {
+                parse_payload_path(path).map_err(|error| {
+                    anyhow::anyhow!(
+                        "request_logging.payloads.redaction_paths `{path}` is invalid: {error}"
+                    )
+                })
+            })
+            .collect::<anyhow::Result<Vec<PayloadPath>>>()?;
+
+        Ok(RequestLogPayloadPolicy::new(
+            self.capture_mode.into(),
+            self.request_max_bytes,
+            self.response_max_bytes,
+            self.stream_max_events,
+            paths,
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestLogPayloadCaptureModeConfig {
+    Disabled,
+    SummaryOnly,
+    #[default]
+    RedactedPayloads,
+}
+
+impl From<RequestLogPayloadCaptureModeConfig> for RequestLogPayloadCaptureMode {
+    fn from(value: RequestLogPayloadCaptureModeConfig) -> Self {
+        match value {
+            RequestLogPayloadCaptureModeConfig::Disabled => Self::Disabled,
+            RequestLogPayloadCaptureModeConfig::SummaryOnly => Self::SummaryOnly,
+            RequestLogPayloadCaptureModeConfig::RedactedPayloads => Self::RedactedPayloads,
+        }
+    }
 }
 
 impl BudgetAlertConfig {
@@ -1129,6 +1240,18 @@ const fn default_request_logging_enabled() -> bool {
     true
 }
 
+const fn default_request_log_request_max_bytes() -> usize {
+    64 * 1024
+}
+
+const fn default_request_log_response_max_bytes() -> usize {
+    64 * 1024
+}
+
+const fn default_request_log_stream_max_events() -> usize {
+    128
+}
+
 const fn default_user_global_role() -> GlobalRole {
     GlobalRole::User
 }
@@ -1186,12 +1309,119 @@ mod tests {
     use std::{env, path::Path};
 
     use gateway_core::{AuthMode, BudgetCadence, GlobalRole, MembershipRole, Money4};
+    use gateway_service::RequestLogPayloadCaptureMode;
     use tempfile::tempdir;
 
     use super::GatewayConfig;
 
     fn write_config(path: &Path, yaml: &str) {
         std::fs::write(path, yaml).expect("write config");
+    }
+
+    #[test]
+    fn request_log_payload_policy_defaults_match_current_capture_behavior() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(&config_path, "");
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let policy = config.request_log_payload_policy().expect("policy");
+
+        assert_eq!(
+            policy.capture_mode,
+            RequestLogPayloadCaptureMode::RedactedPayloads
+        );
+        assert_eq!(policy.request_max_bytes, 64 * 1024);
+        assert_eq!(policy.response_max_bytes, 64 * 1024);
+        assert_eq!(policy.stream_max_events, 128);
+    }
+
+    #[test]
+    fn parses_request_log_payload_policy_config() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+request_logging:
+  payloads:
+    capture_mode: summary_only
+    request_max_bytes: 1024
+    response_max_bytes: 2048
+    stream_max_events: 3
+    redaction_paths:
+      - body.messages.*.metadata.internal
+"#,
+        );
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let policy = config.request_log_payload_policy().expect("policy");
+
+        assert_eq!(
+            policy.capture_mode,
+            RequestLogPayloadCaptureMode::SummaryOnly
+        );
+        assert_eq!(policy.request_max_bytes, 1024);
+        assert_eq!(policy.response_max_bytes, 2048);
+        assert_eq!(policy.stream_max_events, 3);
+    }
+
+    #[test]
+    fn rejects_invalid_request_log_payload_policy_config() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 0
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("request_logging.payloads.request_max_bytes must be > 0"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+request_logging:
+  payloads:
+    stream_max_events: 0
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("request_logging.payloads.stream_max_events must be > 0"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+request_logging:
+  payloads:
+    redaction_paths:
+      - body..messages
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("request_logging.payloads.redaction_paths"),
+            "unexpected error: {error_text}"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -628,8 +628,11 @@ pub struct RequestLogSummaryView {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct RequestLogPayloadPolicyView {
     pub capture_mode: RequestLogPayloadCaptureModeView,
+    #[schema(minimum = 1)]
     pub request_max_bytes: u64,
+    #[schema(minimum = 1)]
     pub response_max_bytes: u64,
+    #[schema(minimum = 1)]
     pub stream_max_events: u64,
     pub version: String,
 }

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -618,10 +618,28 @@ pub struct RequestLogSummaryView {
     pub has_payload: bool,
     pub request_payload_truncated: bool,
     pub response_payload_truncated: bool,
+    pub payload_policy: RequestLogPayloadPolicyView,
     pub request_tags: RequestTagsView,
     #[schema(additional_properties = true)]
     pub metadata: Map<String, Value>,
     pub occurred_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RequestLogPayloadPolicyView {
+    pub capture_mode: RequestLogPayloadCaptureModeView,
+    pub request_max_bytes: u64,
+    pub response_max_bytes: u64,
+    pub stream_max_events: u64,
+    pub version: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestLogPayloadCaptureModeView {
+    Disabled,
+    SummaryOnly,
+    RedactedPayloads,
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/crates/gateway/src/http/observability.rs
+++ b/crates/gateway/src/http/observability.rs
@@ -13,6 +13,7 @@ use gateway_service::{
     model_icon_key_from_metadata, provider_icon_key_from_metadata, resolve_model_icon_key,
     resolve_provider_display,
 };
+use serde_json::{Map, Value};
 use time::{Duration, OffsetDateTime, UtcOffset};
 use uuid::Uuid;
 
@@ -22,8 +23,8 @@ use crate::http::{
         Envelope, LeaderboardChartUserView, LeaderboardLeaderView, LeaderboardQuery,
         LeaderboardSeriesPointView, LeaderboardSeriesValueView, LeaderboardView,
         OpenAiErrorEnvelopeView, RequestLogDetailView, RequestLogListQuery, RequestLogPageView,
-        RequestLogPayloadView, RequestLogSummaryView, RequestTagView, RequestTagsView, envelope,
-        format_timestamp,
+        RequestLogPayloadCaptureModeView, RequestLogPayloadPolicyView, RequestLogPayloadView,
+        RequestLogSummaryView, RequestTagView, RequestTagsView, envelope, format_timestamp,
     },
     error::AppError,
     request_tags::build_bespoke_tag_filter,
@@ -178,12 +179,13 @@ pub async fn list_request_logs(
 
     let page = state.service.list_request_logs(&query).await?;
     let providers = provider_connections_by_key(&state, &page.items).await?;
+    let items = page
+        .items
+        .iter()
+        .map(|log| summary_view(log, providers.get(log.provider_key.as_str())))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(Json(envelope(RequestLogPageView {
-        items: page
-            .items
-            .iter()
-            .map(|log| summary_view(log, providers.get(log.provider_key.as_str())))
-            .collect(),
+        items,
         page: page.page,
         page_size: page.page_size,
         total: page.total,
@@ -209,7 +211,7 @@ pub async fn get_request_log_detail(
 
     let detail = state.service.get_request_log_detail(request_log_id).await?;
     let provider = provider_connection(&state, detail.log.provider_key.as_str()).await?;
-    Ok(Json(envelope(detail_view(detail, provider.as_ref()))))
+    Ok(Json(envelope(detail_view(detail, provider.as_ref())?)))
 }
 
 async fn provider_connections_by_key(
@@ -246,7 +248,7 @@ async fn provider_connection(
 fn summary_view(
     log: &RequestLogRecord,
     provider: Option<&ProviderConnection>,
-) -> RequestLogSummaryView {
+) -> Result<RequestLogSummaryView, AppError> {
     let provider_icon_key = provider_icon_key_from_metadata(&log.metadata)
         .or_else(|| Some(resolve_provider_display(log.provider_key.as_str(), provider).icon_key))
         .map(Into::into);
@@ -256,7 +258,7 @@ fn summary_view(
         })
         .map(Into::into);
 
-    RequestLogSummaryView {
+    Ok(RequestLogSummaryView {
         request_log_id: log.request_log_id.to_string(),
         request_id: log.request_id.clone(),
         api_key_id: log.api_key_id.to_string(),
@@ -276,20 +278,80 @@ fn summary_view(
         has_payload: log.has_payload,
         request_payload_truncated: log.request_payload_truncated,
         response_payload_truncated: log.response_payload_truncated,
+        payload_policy: payload_policy_view(&log.metadata)?,
         request_tags: request_tags_view(&log.request_tags),
         metadata: log.metadata.clone(),
         occurred_at: format_timestamp(log.occurred_at),
+    })
+}
+
+fn payload_policy_view(
+    metadata: &Map<String, Value>,
+) -> Result<RequestLogPayloadPolicyView, AppError> {
+    let policy = metadata
+        .get("payload_policy")
+        .and_then(Value::as_object)
+        .ok_or_else(|| payload_policy_contract_error("missing payload_policy object"))?;
+
+    Ok(RequestLogPayloadPolicyView {
+        capture_mode: match required_payload_policy_string(policy, "capture_mode")? {
+            "disabled" => RequestLogPayloadCaptureModeView::Disabled,
+            "summary_only" => RequestLogPayloadCaptureModeView::SummaryOnly,
+            "redacted_payloads" => RequestLogPayloadCaptureModeView::RedactedPayloads,
+            other => {
+                return Err(payload_policy_contract_error(format!(
+                    "unknown capture_mode `{other}`"
+                )));
+            }
+        },
+        request_max_bytes: required_positive_payload_policy_u64(policy, "request_max_bytes")?,
+        response_max_bytes: required_positive_payload_policy_u64(policy, "response_max_bytes")?,
+        stream_max_events: required_positive_payload_policy_u64(policy, "stream_max_events")?,
+        version: required_payload_policy_string(policy, "version")?.to_string(),
+    })
+}
+
+fn required_payload_policy_string<'a>(
+    policy: &'a Map<String, Value>,
+    field: &str,
+) -> Result<&'a str, AppError> {
+    policy
+        .get(field)
+        .and_then(Value::as_str)
+        .ok_or_else(|| payload_policy_contract_error(format!("missing string field `{field}`")))
+}
+
+fn required_positive_payload_policy_u64(
+    policy: &Map<String, Value>,
+    field: &str,
+) -> Result<u64, AppError> {
+    let value = policy
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| payload_policy_contract_error(format!("missing u64 field `{field}`")))?;
+    if value == 0 {
+        return Err(payload_policy_contract_error(format!(
+            "field `{field}` must be greater than zero"
+        )));
     }
+    Ok(value)
+}
+
+fn payload_policy_contract_error(message: impl Into<String>) -> AppError {
+    AppError(GatewayError::Internal(format!(
+        "invalid request log payload_policy metadata: {}",
+        message.into()
+    )))
 }
 
 fn detail_view(
     detail: RequestLogDetail,
     provider: Option<&ProviderConnection>,
-) -> RequestLogDetailView {
-    RequestLogDetailView {
-        log: summary_view(&detail.log, provider),
+) -> Result<RequestLogDetailView, AppError> {
+    Ok(RequestLogDetailView {
+        log: summary_view(&detail.log, provider)?,
         payload: detail.payload.map(payload_view),
-    }
+    })
 }
 
 fn payload_view(payload: RequestLogPayloadRecord) -> RequestLogPayloadView {
@@ -414,7 +476,7 @@ mod tests {
 
     #[test]
     fn summary_view_uses_provider_display_config_when_metadata_is_missing() {
-        let log = request_log_record(Map::new());
+        let log = request_log_record(payload_policy_metadata());
         let provider = ProviderConnection {
             provider_key: "router".to_string(),
             provider_type: "openai_compat".to_string(),
@@ -428,7 +490,8 @@ mod tests {
             secrets: None,
         };
 
-        let summary = summary_view(&log, Some(&provider));
+        let summary = summary_view(&log, Some(&provider))
+            .unwrap_or_else(|error| panic!("summary should succeed: {}", error.0));
 
         assert!(matches!(
             summary.provider_icon_key,
@@ -438,9 +501,10 @@ mod tests {
 
     #[test]
     fn summary_view_falls_back_to_provider_key_when_provider_config_is_unavailable() {
-        let log = request_log_record(Map::new());
+        let log = request_log_record(payload_policy_metadata());
 
-        let summary = summary_view(&log, None);
+        let summary = summary_view(&log, None)
+            .unwrap_or_else(|error| panic!("summary should succeed: {}", error.0));
 
         assert!(matches!(
             summary.provider_icon_key,
@@ -450,7 +514,7 @@ mod tests {
 
     #[test]
     fn summary_view_prefers_stored_metadata_over_provider_fallbacks() {
-        let mut metadata = Map::new();
+        let mut metadata = payload_policy_metadata();
         metadata.insert(
             REQUEST_LOG_PROVIDER_ICON_KEY.to_string(),
             Value::String("anthropic".to_string()),
@@ -469,12 +533,84 @@ mod tests {
             secrets: None,
         };
 
-        let summary = summary_view(&log, Some(&provider));
+        let summary = summary_view(&log, Some(&provider))
+            .unwrap_or_else(|error| panic!("summary should succeed: {}", error.0));
 
         assert!(matches!(
             summary.provider_icon_key,
             Some(crate::http::admin_contract::ProviderIconKeyView::Anthropic)
         ));
+    }
+
+    #[test]
+    fn summary_view_requires_payload_policy_metadata() {
+        let log = request_log_record(Map::new());
+
+        let error = summary_view(&log, None).expect_err("summary should fail");
+
+        assert!(
+            error
+                .0
+                .to_string()
+                .contains("missing payload_policy object")
+        );
+    }
+
+    #[test]
+    fn summary_view_rejects_unknown_payload_policy_capture_mode() {
+        let mut metadata = payload_policy_metadata();
+        metadata["payload_policy"]
+            .as_object_mut()
+            .expect("policy")
+            .insert("capture_mode".to_string(), json!("legacy"));
+        let log = request_log_record(metadata);
+
+        let error = summary_view(&log, None).expect_err("summary should fail");
+
+        assert!(
+            error
+                .0
+                .to_string()
+                .contains("unknown capture_mode `legacy`")
+        );
+    }
+
+    #[test]
+    fn summary_view_rejects_malformed_payload_policy_metadata() {
+        let mut metadata = payload_policy_metadata();
+        metadata["payload_policy"]
+            .as_object_mut()
+            .expect("policy")
+            .insert("request_max_bytes".to_string(), json!("65536"));
+        let log = request_log_record(metadata);
+
+        let error = summary_view(&log, None).expect_err("summary should fail");
+
+        assert!(
+            error
+                .0
+                .to_string()
+                .contains("missing u64 field `request_max_bytes`")
+        );
+    }
+
+    #[test]
+    fn summary_view_rejects_zero_payload_policy_limits() {
+        let mut metadata = payload_policy_metadata();
+        metadata["payload_policy"]
+            .as_object_mut()
+            .expect("policy")
+            .insert("stream_max_events".to_string(), json!(0));
+        let log = request_log_record(metadata);
+
+        let error = summary_view(&log, None).expect_err("summary should fail");
+
+        assert!(
+            error
+                .0
+                .to_string()
+                .contains("field `stream_max_events` must be greater than zero")
+        );
     }
 
     #[test]
@@ -535,5 +671,20 @@ mod tests {
             metadata,
             occurred_at: OffsetDateTime::now_utc(),
         }
+    }
+
+    fn payload_policy_metadata() -> Map<String, Value> {
+        let mut metadata = Map::new();
+        metadata.insert(
+            "payload_policy".to_string(),
+            json!({
+                "capture_mode": "redacted_payloads",
+                "request_max_bytes": 65536,
+                "response_max_bytes": 65536,
+                "stream_max_events": 128,
+                "version": "builtin:v1"
+            }),
+        );
+        metadata
     }
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -166,11 +166,17 @@ async fn run_serve_with_store(
     let planner = Arc::new(WeightedRoutePlanner::default());
     let budget_alert_sender = build_budget_alert_sender(&config.budget_alerts.email)
         .context("failed to build budget alert email sender")?;
-    let service = Arc::new(GatewayService::new_with_budget_alert_sender(
-        store,
-        planner,
-        budget_alert_sender,
-    ));
+    let payload_policy = config
+        .request_log_payload_policy()
+        .context("failed to build request log payload policy")?;
+    let service = Arc::new(
+        GatewayService::new_with_budget_alert_sender_and_payload_policy(
+            store,
+            planner,
+            budget_alert_sender,
+            payload_policy,
+        ),
+    );
     if let Err(error) = service.refresh_pricing_catalog_if_stale().await {
         tracing::warn!(error = %error, "initial pricing catalog refresh failed");
     }
@@ -1211,7 +1217,10 @@ mod tests {
         SeedProvider, UsageLedgerRecord, UsagePricingStatus, parse_gateway_api_key,
     };
     use gateway_providers::{OpenAiCompatConfig, OpenAiCompatProvider};
-    use gateway_service::{GatewayService, WeightedRoutePlanner, hash_gateway_key_secret};
+    use gateway_service::{
+        GatewayService, RequestLogPayloadPolicy, SinkBudgetAlertSender, WeightedRoutePlanner,
+        hash_gateway_key_secret,
+    };
     use gateway_store::{
         AnyStore, GatewayStore, LibsqlStore, StoreConnectionOptions, run_migrations,
         run_migrations_with_options,
@@ -1426,6 +1435,9 @@ mod tests {
         completion_tokens: Option<i64>,
         total_tokens: Option<i64>,
         error_code: Option<String>,
+        has_payload: bool,
+        request_payload_truncated: bool,
+        response_payload_truncated: bool,
         metadata: Value,
     }
 
@@ -1446,6 +1458,7 @@ mod tests {
 
     #[derive(Debug)]
     struct RequestLogPayloadRow {
+        request_json: Value,
         response_json: Value,
     }
 
@@ -1459,7 +1472,9 @@ mod tests {
             .query(
                 r#"
                 SELECT user_id, team_id, model_key, resolved_model_key, provider_key, status_code,
-                       latency_ms, prompt_tokens, completion_tokens, total_tokens, error_code, metadata_json
+                       latency_ms, prompt_tokens, completion_tokens, total_tokens, error_code,
+                       has_payload, request_payload_truncated, response_payload_truncated,
+                       metadata_json
                 FROM request_logs
                 ORDER BY occurred_at ASC, rowid ASC
                 "#,
@@ -1470,7 +1485,10 @@ mod tests {
 
         let mut logs = Vec::new();
         while let Some(row) = rows.next().await.expect("request logs row") {
-            let metadata_json: String = row.get(11).expect("metadata json");
+            let metadata_json: String = row.get(14).expect("metadata json");
+            let has_payload: i64 = row.get(11).expect("has_payload");
+            let request_payload_truncated: i64 = row.get(12).expect("request_payload_truncated");
+            let response_payload_truncated: i64 = row.get(13).expect("response_payload_truncated");
             logs.push(RequestLogRow {
                 user_id: row.get(0).expect("user_id"),
                 team_id: row.get(1).expect("team_id"),
@@ -1483,6 +1501,9 @@ mod tests {
                 completion_tokens: row.get(8).expect("completion_tokens"),
                 total_tokens: row.get(9).expect("total_tokens"),
                 error_code: row.get(10).expect("error_code"),
+                has_payload: has_payload != 0,
+                request_payload_truncated: request_payload_truncated != 0,
+                response_payload_truncated: response_payload_truncated != 0,
                 metadata: serde_json::from_str(&metadata_json).expect("metadata value"),
             });
         }
@@ -1539,7 +1560,7 @@ mod tests {
         let mut rows = connection
             .query(
                 r#"
-                SELECT response_json
+                SELECT request_json, response_json
                 FROM request_log_payloads
                 ORDER BY rowid ASC
                 "#,
@@ -1550,8 +1571,10 @@ mod tests {
 
         let mut payloads = Vec::new();
         while let Some(row) = rows.next().await.expect("request log payload row") {
-            let response_json: String = row.get(0).expect("response json");
+            let request_json: String = row.get(0).expect("request json");
+            let response_json: String = row.get(1).expect("response json");
             payloads.push(RequestLogPayloadRow {
+                request_json: serde_json::from_str(&request_json).expect("request json value"),
                 response_json: serde_json::from_str(&response_json).expect("response json value"),
             });
         }
@@ -1655,6 +1678,15 @@ mod tests {
         models: Vec<SeedModel>,
         provider_registry: gateway_core::ProviderRegistry,
     ) -> (Router, String, PathBuf) {
+        build_test_app_with_payload_policy(seed_providers, models, provider_registry, None).await
+    }
+
+    async fn build_test_app_with_payload_policy(
+        seed_providers: Vec<SeedProvider>,
+        models: Vec<SeedModel>,
+        provider_registry: gateway_core::ProviderRegistry,
+        payload_policy: Option<RequestLogPayloadPolicy>,
+    ) -> (Router, String, PathBuf) {
         let tmp = tempdir().expect("tempdir");
         let tmp_path = tmp.keep();
         let db_path = tmp_path.join("gateway.db");
@@ -1681,10 +1713,18 @@ mod tests {
             .await
             .expect("seed data");
 
-        let service = Arc::new(GatewayService::new(
-            store.clone(),
-            Arc::new(WeightedRoutePlanner::seeded(11)),
-        ));
+        let planner = Arc::new(WeightedRoutePlanner::seeded(11));
+        let service = Arc::new(match payload_policy {
+            Some(payload_policy) => {
+                GatewayService::new_with_budget_alert_sender_and_payload_policy(
+                    store.clone(),
+                    planner,
+                    Arc::new(SinkBudgetAlertSender),
+                    payload_policy,
+                )
+            }
+            None => GatewayService::new(store.clone(), planner),
+        });
 
         let app = build_router(
             AppState {
@@ -2251,6 +2291,139 @@ mod tests {
         assert_eq!(ledgers[0].pricing_provider_id.as_deref(), Some("openai"));
         assert_eq!(ledgers[0].pricing_model_id.as_deref(), Some("gpt-5"));
         assert!(ledgers[0].computed_cost_10000 >= 0);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn request_log_payload_policy_from_config_affects_persisted_chat_log() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 4096
+    response_max_bytes: 96
+    stream_max_events: 2
+    redaction_paths:
+      - body.messages.*.metadata.internal
+"#,
+        )
+        .expect("write config");
+        let config = GatewayConfig::from_path(&config_path).expect("config");
+        let payload_policy = config.request_log_payload_policy().expect("payload policy");
+
+        let (_, provider) = make_chat_provider(
+            "openai-prod",
+            MockChatResult::Value(json!({
+                "id": "chatcmpl_config_policy",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "x".repeat(300)
+                    },
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+            })),
+            vec![],
+            ProviderCapabilities::openai_compat_baseline(),
+        );
+        let mut registry = gateway_core::ProviderRegistry::new();
+        registry.register(Arc::new(provider));
+        let seed_providers = vec![SeedProvider {
+            provider_key: "openai-prod".to_string(),
+            provider_type: "openai_compat".to_string(),
+            config: serde_json::json!({
+                "base_url": "https://api.openai.com/v1",
+                "pricing_provider_id": "openai"
+            }),
+            secrets: None,
+        }];
+        let models = vec![SeedModel {
+            model_key: "fast".to_string(),
+            alias_target_model_key: None,
+            description: Some("Fast tier".to_string()),
+            tags: vec!["fast".to_string()],
+            rank: 10,
+            routes: vec![SeedModelRoute {
+                provider_key: "openai-prod".to_string(),
+                upstream_model: "gpt-5".to_string(),
+                priority: 10,
+                weight: 1.0,
+                enabled: true,
+                extra_headers: Map::<String, Value>::new(),
+                extra_body: Map::<String, Value>::new(),
+                capabilities: ProviderCapabilities::all_enabled(),
+            }],
+        }];
+        let (app, raw_key, db_path) = build_test_app_with_payload_policy(
+            seed_providers,
+            models,
+            registry,
+            Some(payload_policy),
+        )
+        .await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {raw_key}"))
+                    .body(Body::from(
+                        json!({
+                            "model": "fast",
+                            "messages": [{
+                                "role": "user",
+                                "content": "ping",
+                                "metadata": {
+                                    "internal": "redact-me",
+                                    "public": "keep-me"
+                                }
+                            }]
+                        })
+                        .to_string(),
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let logs = load_request_logs(&db_path).await;
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].has_payload);
+        assert!(!logs[0].request_payload_truncated);
+        assert!(logs[0].response_payload_truncated);
+        assert_eq!(
+            logs[0].metadata["payload_policy"],
+            json!({
+                "capture_mode": "redacted_payloads",
+                "request_max_bytes": 4096,
+                "response_max_bytes": 96,
+                "stream_max_events": 2,
+                "version": "builtin:v1"
+            })
+        );
+
+        let payloads = load_request_log_payloads(&db_path).await;
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(
+            payloads[0].request_json["body"]["messages"][0]["metadata"]["internal"],
+            "[REDACTED]"
+        );
+        assert_eq!(
+            payloads[0].request_json["body"]["messages"][0]["metadata"]["public"],
+            "keep-me"
+        );
+        assert_eq!(payloads[0].response_json["truncated"], true);
     }
 
     #[tokio::test]

--- a/deploy/config/gateway.yaml
+++ b/deploy/config/gateway.yaml
@@ -16,6 +16,14 @@ auth:
     - name: default
       value: env.GATEWAY_API_KEY
 
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 65536
+    response_max_bytes: 65536
+    stream_max_events: 128
+    redaction_paths: []
+
 teams:
   - key: platform
     name: Platform

--- a/docs/access/admin-control-plane.md
+++ b/docs/access/admin-control-plane.md
@@ -112,6 +112,9 @@ Operators can:
 - inspect request-log summaries
 - filter request logs by caller service, component, environment, and one bespoke tag match
 - inspect sanitized request-log payload detail
+- see per-row payload capture mode, byte limits, stream event limit, policy version, and truncation state
+
+Request-log payload policy is read-only in the admin UI. Operators configure it through `gateway.yaml`; see [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
 
 Current limits:
 

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -21,6 +21,7 @@ This page owns config syntax and parse-time rules. It does not own the full runt
 - `database`
 - `auth`
 - `budget_alerts`
+- `request_logging`
 - `providers`
 - `models`
 - `teams`
@@ -141,6 +142,10 @@ Important defaults from config parsing and domain deserialization:
 - route capability flags default to all enabled
 - Vertex `location` defaults to `global`
 - Vertex `api_host` defaults to `aiplatform.googleapis.com`
+- `request_logging.payloads.capture_mode` defaults to `redacted_payloads`
+- `request_logging.payloads.request_max_bytes` defaults to `65536`
+- `request_logging.payloads.response_max_bytes` defaults to `65536`
+- `request_logging.payloads.stream_max_events` defaults to `128`
 
 The startup meaning of bootstrap-admin and seeded API keys lives in [runtime-bootstrap-and-access.md](../setup/runtime-bootstrap-and-access.md).
 
@@ -155,6 +160,40 @@ Important fields:
 - `otel_export_interval_secs`
 
 For collector assumptions and request-log implications, see [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
+
+## `request_logging`
+
+`request_logging.payloads` controls chat-completion request-log payload persistence.
+
+```yaml
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 65536
+    response_max_bytes: 65536
+    stream_max_events: 128
+    redaction_paths: []
+```
+
+Important fields:
+
+- `capture_mode`
+  - `disabled`: skip chat-completion request-log persistence
+  - `summary_only`: write summary rows with `has_payload=false` and no payload row
+  - `redacted_payloads`: write summary rows and sanitized payload rows
+- `request_max_bytes`: final persisted request payload budget
+- `response_max_bytes`: final persisted response payload budget
+- `stream_max_events`: maximum stored stream events; stream usage and error parsing still sees later frames
+- `redaction_paths`: additive operator redaction paths anchored from the wrapped payload root
+
+Validation rules:
+
+- byte limits must be greater than zero
+- `stream_max_events` must be greater than zero
+- `redaction_paths` use dot-separated object keys plus `*` as a full-segment wildcard
+- malformed paths such as `body..messages` or indexed paths such as `body.messages[0]` are rejected at config parse time
+
+The runtime redaction/truncation policy and admin display behavior are owned by [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
 
 ## `database`
 

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -88,7 +88,7 @@ The summary row stores:
 - universal caller tags
 - status, latency, and usage totals
 - truncation flags
-- metadata such as `operation` and `stream`
+- metadata such as `operation`, `stream`, and `payload_policy`
 
 Streaming requests persist a bounded transcript payload rather than raw transport bytes.
 
@@ -99,26 +99,94 @@ The stream payload contract is incremental rather than chunk-local:
 - both `data:` and `data: ` forms are accepted
 - the latest coherent `usage` object is retained for request-log and ledger work
 
+## Payload Policy
+
+Chat-completion request-log payload persistence is controlled by `request_logging.payloads` in `gateway.yaml`.
+
+Default config:
+
+```yaml
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 65536
+    response_max_bytes: 65536
+    stream_max_events: 128
+    redaction_paths: []
+```
+
+Capture modes:
+
+- `disabled`: skip request-log persistence for chat completions
+- `summary_only`: write `request_logs` summary rows with `has_payload=false`; do not write `request_log_payloads`
+- `redacted_payloads`: write summary rows and sanitized payload rows
+
+The policy is read from YAML only. The admin UI displays the policy used for each row, but does not edit it.
+
+Validation rules:
+
+- `request_max_bytes` must be greater than zero
+- `response_max_bytes` must be greater than zero
+- `stream_max_events` must be greater than zero
+- `redaction_paths` must use dot-separated object keys, with `*` as a full-segment wildcard
+- paths are anchored from the wrapped payload root, for example `body.messages.*.content.*.image_url.url`
+
+Each request-log row persists lightweight policy metadata in `request_logs.metadata_json`:
+
+```json
+{
+  "payload_policy": {
+    "capture_mode": "redacted_payloads",
+    "request_max_bytes": 65536,
+    "response_max_bytes": 65536,
+    "stream_max_events": 128,
+    "version": "builtin:v1"
+  }
+}
+```
+
 ## Redaction and Truncation Boundaries
 
-Current redaction is key-driven and header-driven.
+Payloads are wrapped before policy application:
 
-Sensitive headers include:
+- requests: `{ "headers": ..., "body": ... }`
+- responses: `{ "body": ... }`
+- streams: `{ "stream": true, "events": ..., "usage": ..., "error": ... }`
+
+Redaction applies one explicit built-in policy plus additive operator paths from `request_logging.payloads.redaction_paths`.
+
+Sensitive built-in headers include:
 
 - `authorization`
+- `anthropic-api-key`
 - `cookie`
 - `set-cookie`
+- `x-goog-api-key`
 - `x-api-key`
 
-Sensitive JSON keys include:
+Sensitive built-in JSON keys include:
 
 - `token`
 - `access_token`
 - `refresh_token`
+- `api_key`
+- `anthropic_api_key`
+- `client_secret`
+- `credentials`
+- `private_key`
 - `secret`
 - `password`
 
-Current payload policy is still heuristic and bounded. It is not operator-configurable yet.
+Known bulky provider fields are shape-preserving truncated before the whole-payload byte budget is applied. Built-ins cover OpenAI-compatible image/audio/file payloads, Vertex Gemini inline data, and Vertex Anthropic base64 source data.
+
+Processing order:
+
+1. wrap the payload
+2. apply built-in and operator redaction rules
+3. truncate known bulky fields while preserving JSON shape where possible
+4. apply `request_max_bytes` or `response_max_bytes` as a final guardrail
+
+For streams, the gateway keeps parsing every frame for usage and provider errors. Only stored event payloads are capped by `stream_max_events`; if the cap is hit, `response_payload_truncated=true`.
 
 ## Recent Contract Cleanup
 
@@ -160,9 +228,8 @@ Current list filters:
 ## Current Gaps
 
 - no documented retention or archival policy yet for `request_log_payloads`
+  - retention and purge work is tracked separately in [issue #105](https://github.com/ahstn/oceans-llm/issues/105)
 - deploy examples do not ship an OTLP collector by default
-- request-log payload policy is not operator-configurable yet
-  - [issue #18](https://github.com/ahstn/oceans-llm/issues/18)
 - stream and non-stream chat paths still differ on post-provider ledger-write failure behavior
   - [issue #49](https://github.com/ahstn/oceans-llm/issues/49)
 

--- a/docs/reference/data-relationships.md
+++ b/docs/reference/data-relationships.md
@@ -93,10 +93,10 @@ This document is schema-oriented. It describes the persistent relationships that
   - Notes: this is the canonical spend ledger used for enforcement and reporting
 - `request_logs`
   - Key columns: `request_log_id`, `request_id`, `api_key_id`, `user_id`, `team_id`, `model_key`, `resolved_model_key`, `provider_key`, `caller_service`, `caller_component`, `caller_env`, `status_code`, `metadata_json`, `occurred_at`
-  - Notes: one summary row per final request outcome
+  - Notes: one summary row per final request outcome; `metadata_json.payload_policy` records the capture mode and limits used for the row when request logging is enabled
 - `request_log_payloads`
   - Key columns: `request_log_id`, `request_json`, `response_json`
-  - Notes: summary and payload are intentionally split
+  - Notes: summary and payload are intentionally split; rows exist only when the payload policy captures redacted payloads
 - `request_log_tags`
   - Key columns: `request_log_id`, `tag_key`, `tag_value`
   - Notes: bounded bespoke caller tags for request-log filtering and attribution

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -151,12 +151,12 @@ That separation matters in two common cases:
 - a request can be logged even when it becomes `unpriced`
 - a request can be logged even when a later accounting step hits a rough edge
 
-For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure.
+For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure. Stored stream events can be capped by payload policy without weakening usage or provider-error parsing.
 
 ## Known Rough Edges
 
 - Stream and non-stream chat paths still differ when a post-provider ledger write fails.
-- Request-log payload policy is still bounded and heuristic, not operator-configurable.
+- Request-log payload policy details, redaction rules, and retention status are owned by [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
 
 For the current observability cleanup notes, see [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
 

--- a/gateway.prod.yaml
+++ b/gateway.prod.yaml
@@ -14,6 +14,14 @@ auth:
     password: literal.admin
     require_password_change: true
 
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 65536
+    response_max_bytes: 65536
+    stream_max_events: 128
+    redaction_paths: []
+
 providers:
   - id: openai-prod
     type: openai_compat

--- a/gateway.yaml
+++ b/gateway.yaml
@@ -13,6 +13,14 @@ auth:
     password: literal.admin
     require_password_change: false
 
+request_logging:
+  payloads:
+    capture_mode: redacted_payloads
+    request_max_bytes: 65536
+    response_max_bytes: 65536
+    stream_max_events: 128
+    redaction_paths: []
+
 teams:
   - key: platform
     name: Platform


### PR DESCRIPTION
## Description

Implements request-log payload policy hardening for issue #18.

- Adds configurable `request_logging.payloads` capture policy with explicit `disabled`, `summary_only`, and `redacted_payloads` modes.
- Persists typed payload policy metadata on request-log summary rows and exposes it as a required admin API field.
- Replaces hidden heuristic payload handling with explicit built-in redaction/truncation rules plus additive operator redaction paths.
- Caps stored stream events without weakening full-stream usage and provider-error parsing.
- Updates admin request-log UI with read-only policy badges, policy detail card, truncation alerts, empty states, and skeleton loading.
- Regenerates OpenAPI and TypeScript admin contracts.
- Updates request-log, configuration, admin control-plane, data relationship, and lifecycle documentation.

This approach keeps policy configuration in `gateway.yaml` only, treats malformed policy metadata as a server-side invariant violation, and avoids fallback behavior for pre-v1 rows. Retention and purge behavior remains tracked separately in issue #105.

Risks and tradeoffs:

- Existing pre-policy request-log rows are intentionally not supported by the stricter admin contract. This matches the pre-v1 agreement to avoid legacy compatibility shims.
- Built-in bulky payload paths remain versioned as `builtin:v1`; expanding the policy later should include an explicit metadata version bump if semantics change.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation run:

- [x] `cargo fmt`
- [x] `cargo test -p gateway-service request_logging`
- [x] `cargo test -p gateway-service redaction`
- [x] `cargo test -p gateway request_log_payload`
- [x] `cargo test -p gateway observability`
- [x] `bun run --cwd crates/admin-ui/web test src/test/routes/request-logs-route.test.tsx src/server/admin-data.server.test.ts`
- [x] `mise run admin-contract-generate`