### PR TITLE
fix(gateway): satisfy vertex stream clippy

### DIFF
--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -1072,19 +1072,17 @@ where
                     .unwrap_or_default();
 
                 match kind {
-                    "message_start" => {
-                        if !role_emitted {
-                            let delta = openai_chunk(
-                                &stream_id,
-                                created,
-                                &model,
-                                Some("assistant"),
-                                None,
-                                None,
-                            );
-                            yield Ok(openai_sse_chunk(&delta));
-                            role_emitted = true;
-                        }
+                    "message_start" if !role_emitted => {
+                        let delta = openai_chunk(
+                            &stream_id,
+                            created,
+                            &model,
+                            Some("assistant"),
+                            None,
+                            None,
+                        );
+                        yield Ok(openai_sse_chunk(&delta));
+                        role_emitted = true;
                     }
                     "content_block_delta" => {
                         let delta = payload.get("delta").and_then(Value::as_object);
@@ -1128,19 +1126,17 @@ where
                             finish_emitted = true;
                         }
                     }
-                    "message_stop" => {
-                        if !finish_emitted {
-                            let finish = openai_chunk(
-                                &stream_id,
-                                created,
-                                &model,
-                                None,
-                                None,
-                                Some("stop"),
-                            );
-                            yield Ok(openai_sse_chunk(&finish));
-                            finish_emitted = true;
-                        }
+                    "message_stop" if !finish_emitted => {
+                        let finish = openai_chunk(
+                            &stream_id,
+                            created,
+                            &model,
+                            None,
+                            None,
+                            Some("stop"),
+                        );
+                        yield Ok(openai_sse_chunk(&finish));
+                        finish_emitted = true;
                     }
                     "error" => {
                         let message = payload
@@ -1217,23 +1213,20 @@ impl JsonObjectParser {
                     }
                     depth += 1;
                 }
-                b'}' => {
-                    if depth > 0 {
-                        depth -= 1;
-                        if depth == 0
-                            && let Some(start) = object_start.take()
-                        {
-                            let end = index + 1;
-                            let object_json = &self.buffer[start..end];
-                            let value: Value =
-                                serde_json::from_str(object_json).map_err(|error| {
-                                    ProviderError::Transport(format!(
-                                        "failed parsing streamed google JSON object: {error}"
-                                    ))
-                                })?;
-                            parsed.push(value);
-                            consumed_until = end;
-                        }
+                b'}' if depth > 0 => {
+                    depth -= 1;
+                    if depth == 0
+                        && let Some(start) = object_start.take()
+                    {
+                        let end = index + 1;
+                        let object_json = &self.buffer[start..end];
+                        let value: Value = serde_json::from_str(object_json).map_err(|error| {
+                            ProviderError::Transport(format!(
+                                "failed parsing streamed google JSON object: {error}"
+                            ))
+                        })?;
+                        parsed.push(value);
+                        consumed_until = end;
                     }
                 }
                 _ => {}


### PR DESCRIPTION
## Description

- Summary of changes: collapse clippy-flagged nested `if` blocks in Vertex Anthropic stream handling and JSON object parsing into match guards.
- Why this approach was chosen: it follows the `collapsible_match` suggestion from CI while preserving the existing stream normalization behavior.
- How it works: `message_start`, `message_stop`, and closing-brace parser handling now encode their guard conditions directly on the `match` arms.
- Risks, tradeoffs, and alternatives considered: behavior should be unchanged; this is a lint-only structural cleanup. This is stacked on `codex/stabilize-admin-contract-check` because `origin/main` still fails the admin contract version check before clippy.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`