### PR TITLE
feat(gateway): add AWS Bedrock streaming and Claude support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -136,7 +136,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -193,6 +193,374 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-config"
+version = "1.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
 
 [[package]]
 name = "axum"
@@ -316,6 +684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +749,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -381,6 +759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -414,6 +801,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +826,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -482,7 +881,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -547,6 +946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,10 +967,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -582,6 +1003,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -636,6 +1066,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,9 +1099,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -672,6 +1132,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -786,6 +1252,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -910,7 +1382,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "time",
@@ -946,6 +1418,10 @@ version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-runtime-api",
  "axum 0.8.8",
  "bytes",
  "futures-util",
@@ -1167,7 +1643,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1176,7 +1652,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1273,6 +1758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,7 +1824,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -1347,6 +1841,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1611,6 +2106,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1915,7 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2037,6 +2542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,6 +2622,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -2576,6 +3093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +3173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +3227,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2710,11 +3243,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2753,6 +3298,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2816,7 +3362,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2953,6 +3512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,8 +3535,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3084,7 +3665,7 @@ dependencies = [
  "rustls 0.23.37",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -3122,7 +3703,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-postgres",
  "syn",
@@ -3148,7 +3729,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -3158,7 +3739,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3762,9 +4343,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uncased"
@@ -3831,6 +4412,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3906,6 +4493,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4523,6 +5116,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio-rustls"] }
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["request-id", "trace", "util"] }
 tracing = "0.1"

--- a/crates/gateway-providers/Cargo.toml
+++ b/crates/gateway-providers/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2024"
 [dependencies]
 async-trait.workspace = true
 async-stream = "0.3"
+aws-config = "1.8"
+aws-credential-types = "1.2"
+aws-sigv4 = { version = "1.4", features = ["sign-http", "http1"] }
+aws-smithy-runtime-api = "1.12"
 bytes.workspace = true
 futures-util.workspace = true
 gateway-core.workspace = true

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1,6 +1,9 @@
 use std::{collections::BTreeMap, time::Duration};
 
+use async_stream::stream;
 use async_trait::async_trait;
+use bytes::{Buf, Bytes};
+use futures_util::StreamExt;
 use gateway_core::{
     CoreChatRequest, CoreEmbeddingsRequest, CoreResponsesRequest, ProviderCapabilities,
     ProviderClient, ProviderError, ProviderRequestContext, ProviderStream,
@@ -11,6 +14,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::http::map_reqwest_error;
+use crate::streaming::{done_sse_chunk, openai_sse_error_chunk, render_sse_event_chunk};
 
 #[derive(Debug, Clone)]
 pub enum BedrockAuthConfig {
@@ -83,24 +87,51 @@ impl BedrockProvider {
     }
 
     fn converse_endpoint(&self, upstream_model: &str) -> String {
+        self.bedrock_model_endpoint(upstream_model, "converse")
+    }
+
+    fn converse_stream_endpoint(&self, upstream_model: &str) -> String {
+        self.bedrock_model_endpoint(upstream_model, "converse-stream")
+    }
+
+    fn bedrock_model_endpoint(&self, upstream_model: &str, operation: &str) -> String {
         let encoded_model_id: String =
             url::form_urlencoded::byte_serialize(upstream_model.as_bytes()).collect();
         format!(
-            "{}/model/{encoded_model_id}/converse",
+            "{}/model/{encoded_model_id}/{operation}",
             self.config.endpoint_url
         )
     }
 
-    fn build_converse_request(
+    fn invoke_endpoint(&self, upstream_model: &str) -> String {
+        let encoded_model_id: String =
+            url::form_urlencoded::byte_serialize(upstream_model.as_bytes()).collect();
+        format!(
+            "{}/model/{encoded_model_id}/invoke",
+            self.config.endpoint_url
+        )
+    }
+
+    fn build_chat_request(
         &self,
         request: &CoreChatRequest,
         context: &ProviderRequestContext,
     ) -> Result<reqwest::Request, ProviderError> {
-        let body = map_chat_request_to_converse(request, context)?;
-        let url = self.converse_endpoint(&context.upstream_model);
+        let (body, url) = if is_anthropic_claude_model(&context.upstream_model) {
+            (
+                map_chat_request_to_anthropic_messages(request, context)?,
+                self.invoke_endpoint(&context.upstream_model),
+            )
+        } else {
+            (
+                map_chat_request_to_converse(request, context)?,
+                self.converse_endpoint(&context.upstream_model),
+            )
+        };
 
         let mut request = self.client.post(url).json(&body);
         request = request.header("content-type", "application/json");
+        request = request.header("accept", "application/json");
         request = request.header("x-request-id", &context.request_id);
 
         for (name, value) in &self.config.default_headers {
@@ -127,6 +158,67 @@ impl BedrockProvider {
 
         request.build().map_err(map_reqwest_error)
     }
+
+    fn build_converse_stream_request(
+        &self,
+        request: &CoreChatRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<reqwest::Request, ProviderError> {
+        let mut stream_request = request.clone();
+        stream_request.stream = true;
+        let body = map_chat_request_to_converse(&stream_request, context)?;
+        let url = self.converse_stream_endpoint(&context.upstream_model);
+
+        let mut request = self.client.post(url).json(&body);
+        request = request.header("content-type", "application/json");
+        request = request.header("accept", "application/vnd.amazon.eventstream");
+        request = request.header("x-request-id", &context.request_id);
+
+        for (name, value) in &self.config.default_headers {
+            request = request.header(name, value);
+        }
+
+        for (name, value) in &context.extra_headers {
+            if let Some(value) = value.as_str() {
+                request = request.header(name, value);
+            }
+        }
+
+        match &self.config.auth {
+            BedrockAuthConfig::Bearer { token } => {
+                request = request.bearer_auth(token);
+            }
+            BedrockAuthConfig::DefaultChain | BedrockAuthConfig::StaticCredentials { .. } => {
+                return Err(ProviderError::NotImplemented(
+                    "aws_bedrock IAM SigV4 request signing is owned by the provider auth foundation"
+                        .to_string(),
+                ));
+            }
+        }
+
+        request.build().map_err(map_reqwest_error)
+    }
+
+    async fn execute_stream_request(
+        &self,
+        request: reqwest::Request,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let response = self
+            .client
+            .execute(request)
+            .await
+            .map_err(map_reqwest_error)?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.map_err(map_reqwest_error)?;
+            return Err(ProviderError::UpstreamHttp {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        Ok(response)
+    }
 }
 
 #[async_trait]
@@ -140,7 +232,7 @@ impl ProviderClient for BedrockProvider {
     }
 
     fn capabilities(&self) -> ProviderCapabilities {
-        ProviderCapabilities::with_dimensions(true, false, false, true, false, false, true)
+        ProviderCapabilities::with_dimensions(true, true, false, true, true, false, true)
     }
 
     async fn chat_completions(
@@ -148,7 +240,8 @@ impl ProviderClient for BedrockProvider {
         request: &CoreChatRequest,
         context: &ProviderRequestContext,
     ) -> Result<Value, ProviderError> {
-        let request = self.build_converse_request(request, context)?;
+        let is_anthropic_claude = is_anthropic_claude_model(&context.upstream_model);
+        let request = self.build_chat_request(request, context)?;
         let response = self
             .client
             .execute(request)
@@ -165,17 +258,27 @@ impl ProviderClient for BedrockProvider {
         }
 
         let value: Value = serde_json::from_str(&text).map_err(|error| {
-            ProviderError::Transport(format!("invalid JSON from aws_bedrock converse: {error}"))
+            ProviderError::Transport(format!("invalid JSON from aws_bedrock chat: {error}"))
         })?;
-        Ok(normalize_converse_response(&value, context))
+        if is_anthropic_claude {
+            Ok(normalize_anthropic_messages_response(&value, context))
+        } else {
+            Ok(normalize_converse_response(&value, context))
+        }
     }
 
     async fn chat_completions_stream(
         &self,
-        _request: &CoreChatRequest,
-        _context: &ProviderRequestContext,
+        request: &CoreChatRequest,
+        context: &ProviderRequestContext,
     ) -> Result<ProviderStream, ProviderError> {
-        Err(Self::unsupported("chat completions streaming"))
+        let request = self.build_converse_stream_request(request, context)?;
+        let response = self.execute_stream_request(request).await?;
+
+        Ok(normalize_bedrock_converse_stream(
+            response.bytes_stream(),
+            context.clone(),
+        ))
     }
 
     async fn embeddings(
@@ -207,12 +310,6 @@ fn map_chat_request_to_converse(
     request: &CoreChatRequest,
     context: &ProviderRequestContext,
 ) -> Result<Value, ProviderError> {
-    if request.stream {
-        return Err(ProviderError::InvalidRequest(
-            "aws_bedrock Converse streaming is not supported in this slice".to_string(),
-        ));
-    }
-
     let mut body = Map::new();
     let mut system = Vec::new();
     let mut messages = Vec::new();
@@ -288,6 +385,103 @@ fn map_chat_request_to_converse(
 
     reject_openai_only_fields(&passthrough)?;
     merge_object_overrides(&mut body, &context.extra_body);
+    Ok(Value::Object(body))
+}
+
+fn is_anthropic_claude_model(upstream_model: &str) -> bool {
+    upstream_model
+        .to_ascii_lowercase()
+        .contains("anthropic.claude")
+}
+
+fn map_chat_request_to_anthropic_messages(
+    request: &CoreChatRequest,
+    context: &ProviderRequestContext,
+) -> Result<Value, ProviderError> {
+    if request.stream {
+        return Err(ProviderError::InvalidRequest(
+            "aws_bedrock Anthropic Claude Messages streaming is gated until native InvokeModelWithResponseStream mapping lands"
+                .to_string(),
+        ));
+    }
+
+    let mut body = Map::new();
+    body.insert(
+        "anthropic_version".to_string(),
+        Value::String("bedrock-2023-05-31".to_string()),
+    );
+
+    let mut system = Vec::new();
+    let mut messages = Vec::new();
+
+    for message in &request.messages {
+        match message.role.as_str() {
+            "system" | "developer" => {
+                let text = message_content_as_text(&message.content)?;
+                if !text.is_empty() {
+                    system.push(text);
+                }
+            }
+            "user" => {
+                messages.push(json!({
+                    "role": "user",
+                    "content": map_anthropic_content_blocks(&message.content)?
+                }));
+            }
+            "assistant" => {
+                let mut content = map_anthropic_content_blocks(&message.content)?;
+                content.extend(map_anthropic_assistant_tool_uses(message)?);
+                messages.push(json!({
+                    "role": "assistant",
+                    "content": content
+                }));
+            }
+            "tool" => {
+                messages.push(json!({
+                    "role": "user",
+                    "content": [map_anthropic_tool_result(message)?]
+                }));
+            }
+            other => {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "unsupported message role `{other}` for aws_bedrock Anthropic Claude Messages mapping"
+                )));
+            }
+        }
+    }
+
+    if messages.is_empty() {
+        return Err(ProviderError::InvalidRequest(
+            "aws_bedrock Anthropic Claude Messages requires at least one user, assistant, or tool message"
+                .to_string(),
+        ));
+    }
+
+    if !system.is_empty() {
+        body.insert("system".to_string(), Value::String(system.join("\n")));
+    }
+    body.insert("messages".to_string(), Value::Array(messages));
+
+    let mut passthrough = request.extra.clone();
+    passthrough.remove("model");
+    passthrough.remove("messages");
+    passthrough.remove("stream");
+
+    extract_anthropic_inference_fields(&mut body, &mut passthrough)?;
+    if let Some(tools) = extract_anthropic_tools(&mut passthrough)? {
+        body.extend(tools);
+    }
+    extract_anthropic_passthrough_fields(&mut body, &mut passthrough);
+    reject_openai_only_fields(&passthrough)?;
+
+    merge_object_overrides(&mut body, &context.extra_body);
+    if !body.contains_key("max_tokens") {
+        return Err(ProviderError::InvalidRequest(
+            "aws_bedrock Anthropic Claude Messages requires `max_tokens` or `max_completion_tokens`"
+                .to_string(),
+        ));
+    }
+
     Ok(Value::Object(body))
 }
 
@@ -376,6 +570,123 @@ fn map_bedrock_content_blocks(content: &Value) -> Result<Vec<Value>, ProviderErr
     }
 }
 
+fn map_anthropic_content_blocks(content: &Value) -> Result<Vec<Value>, ProviderError> {
+    match content {
+        Value::Null => Ok(Vec::new()),
+        Value::String(text) => Ok(vec![json!({ "type": "text", "text": text })]),
+        Value::Array(items) => {
+            let mut blocks = Vec::new();
+            for item in items {
+                let object = item.as_object().ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "content array entries must be objects".to_string(),
+                    )
+                })?;
+                let kind = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "content array entries must include `type`".to_string(),
+                    )
+                })?;
+                match kind {
+                    "text" | "input_text" => {
+                        let text = object.get("text").and_then(Value::as_str).ok_or_else(|| {
+                            ProviderError::InvalidRequest(
+                                "text content entries must include a string `text`".to_string(),
+                            )
+                        })?;
+                        blocks.push(json!({ "type": "text", "text": text }));
+                    }
+                    "image" | "image_url" | "input_image" => {
+                        blocks.push(map_anthropic_image_block(object)?);
+                    }
+                    "tool_result" => {
+                        blocks.push(map_anthropic_tool_result_content_block(object)?);
+                    }
+                    other => {
+                        return Err(ProviderError::InvalidRequest(format!(
+                            "unsupported content type `{other}` for aws_bedrock Anthropic Claude Messages mapping"
+                        )));
+                    }
+                }
+            }
+            Ok(blocks)
+        }
+        _ => Err(ProviderError::InvalidRequest(
+            "message content must be a string or typed content array".to_string(),
+        )),
+    }
+}
+
+fn map_anthropic_image_block(object: &Map<String, Value>) -> Result<Value, ProviderError> {
+    let image_url = object
+        .get("image_url")
+        .or_else(|| object.get("source"))
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "image content entries must include `image_url` or `source`".to_string(),
+            )
+        })?;
+
+    match image_url {
+        Value::Object(image_object) => {
+            if image_object.get("type").and_then(Value::as_str) == Some("base64") {
+                return Ok(json!({ "type": "image", "source": image_object }));
+            }
+            if let Some(source) = image_object.get("source").and_then(Value::as_object)
+                && source.get("type").and_then(Value::as_str) == Some("base64")
+            {
+                return Ok(json!({ "type": "image", "source": source }));
+            }
+
+            let url = image_object
+                .get("url")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ProviderError::InvalidRequest("image_url.url must be a string".to_string())
+                })?;
+            map_anthropic_data_url_image(url, image_object)
+        }
+        Value::String(url) => map_anthropic_data_url_image(url, object),
+        _ => Err(ProviderError::InvalidRequest(
+            "image_url must be a string or object for aws_bedrock Anthropic Claude Messages"
+                .to_string(),
+        )),
+    }
+}
+
+fn map_anthropic_data_url_image(
+    url: &str,
+    metadata: &Map<String, Value>,
+) -> Result<Value, ProviderError> {
+    let Some((media_type, data)) = url
+        .strip_prefix("data:")
+        .and_then(|rest| rest.split_once(";base64,"))
+    else {
+        return Err(ProviderError::InvalidRequest(
+            "aws_bedrock Anthropic Claude Messages only supports base64 image data URLs; remote image URLs are not supported"
+                .to_string(),
+        ));
+    };
+    let media_type = metadata
+        .get("mime_type")
+        .and_then(Value::as_str)
+        .unwrap_or(media_type);
+
+    match media_type {
+        "image/jpeg" | "image/png" | "image/webp" | "image/gif" => Ok(json!({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": media_type,
+                "data": data
+            }
+        })),
+        other => Err(ProviderError::InvalidRequest(format!(
+            "unsupported image media type `{other}` for aws_bedrock Anthropic Claude Messages"
+        ))),
+    }
+}
+
 fn map_assistant_tool_uses(
     message: &gateway_core::CoreChatMessage,
 ) -> Result<Vec<Value>, ProviderError> {
@@ -443,6 +754,73 @@ fn map_assistant_tool_uses(
         .collect()
 }
 
+fn map_anthropic_assistant_tool_uses(
+    message: &gateway_core::CoreChatMessage,
+) -> Result<Vec<Value>, ProviderError> {
+    let Some(tool_calls) = message.extra.get("tool_calls") else {
+        return Ok(Vec::new());
+    };
+    let calls = tool_calls.as_array().ok_or_else(|| {
+        ProviderError::InvalidRequest("assistant tool_calls must be an array".to_string())
+    })?;
+
+    calls
+        .iter()
+        .map(|call| {
+            let object = call.as_object().ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "assistant tool_calls entries must be objects".to_string(),
+                )
+            })?;
+            if object.get("type").and_then(Value::as_str) != Some("function") {
+                return Err(ProviderError::InvalidRequest(
+                    "only function tool_calls are supported for aws_bedrock Anthropic Claude Messages"
+                        .to_string(),
+                ));
+            }
+            let id = object.get("id").and_then(Value::as_str).ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "assistant tool_calls entries must include `id`".to_string(),
+                )
+            })?;
+            let function = object
+                .get("function")
+                .and_then(Value::as_object)
+                .ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "assistant function tool_calls must include `function`".to_string(),
+                    )
+                })?;
+            let name = function
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "assistant function tool_calls must include function.name".to_string(),
+                    )
+                })?;
+            let input = match function.get("arguments") {
+                Some(Value::String(arguments)) => {
+                    serde_json::from_str(arguments).map_err(|error| {
+                        ProviderError::InvalidRequest(format!(
+                            "assistant function tool_call arguments must be JSON: {error}"
+                        ))
+                    })?
+                }
+                Some(value) => value.clone(),
+                None => Value::Object(Map::new()),
+            };
+
+            Ok(json!({
+                "type": "tool_use",
+                "id": id,
+                "name": name,
+                "input": input
+            }))
+        })
+        .collect()
+}
+
 fn map_tool_result(message: &gateway_core::CoreChatMessage) -> Result<Value, ProviderError> {
     let tool_call_id = message
         .extra
@@ -484,6 +862,50 @@ fn map_tool_result(message: &gateway_core::CoreChatMessage) -> Result<Value, Pro
     }))
 }
 
+fn map_anthropic_tool_result(
+    message: &gateway_core::CoreChatMessage,
+) -> Result<Value, ProviderError> {
+    let tool_use_id = message
+        .extra
+        .get("tool_call_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest("tool messages must include `tool_call_id`".to_string())
+        })?;
+    let content = match &message.content {
+        Value::String(text) => Value::String(text.clone()),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| {
+                    let object = item.as_object().ok_or_else(|| {
+                        ProviderError::InvalidRequest(
+                            "tool message content array entries must be objects".to_string(),
+                        )
+                    })?;
+                    let text = object.get("text").and_then(Value::as_str).ok_or_else(|| {
+                        ProviderError::InvalidRequest(
+                            "tool message content entries must include string `text`".to_string(),
+                        )
+                    })?;
+                    Ok(json!({ "type": "text", "text": text }))
+                })
+                .collect::<Result<Vec<_>, ProviderError>>()?,
+        ),
+        _ => {
+            return Err(ProviderError::InvalidRequest(
+                "tool message content must be a string or text content array".to_string(),
+            ));
+        }
+    };
+
+    Ok(json!({
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": content
+    }))
+}
+
 fn map_tool_result_content_block(object: &Map<String, Value>) -> Result<Value, ProviderError> {
     let tool_use_id = object
         .get("tool_use_id")
@@ -503,6 +925,40 @@ fn map_tool_result_content_block(object: &Map<String, Value>) -> Result<Value, P
             "toolUseId": tool_use_id,
             "content": [{ "text": text }]
         }
+    }))
+}
+
+fn map_anthropic_tool_result_content_block(
+    object: &Map<String, Value>,
+) -> Result<Value, ProviderError> {
+    let tool_use_id = object
+        .get("tool_use_id")
+        .or_else(|| object.get("toolUseId"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "tool_result content must include tool_use_id".to_string(),
+            )
+        })?;
+    let content = object
+        .get("content")
+        .cloned()
+        .or_else(|| {
+            object
+                .get("text")
+                .and_then(Value::as_str)
+                .map(|text| Value::String(text.to_string()))
+        })
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "tool_result content must include `content` or string `text`".to_string(),
+            )
+        })?;
+
+    Ok(json!({
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": content
     }))
 }
 
@@ -529,6 +985,36 @@ fn extract_inference_config(
         );
     }
     Ok(config)
+}
+
+fn extract_anthropic_inference_fields(
+    body: &mut Map<String, Value>,
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<(), ProviderError> {
+    if let Some(value) = extra
+        .remove("max_completion_tokens")
+        .or_else(|| extra.remove("max_tokens"))
+    {
+        body.insert("max_tokens".to_string(), value);
+    }
+    for field in ["temperature", "top_p", "top_k"] {
+        if let Some(value) = extra.remove(field) {
+            body.insert(field.to_string(), value);
+        }
+    }
+    if let Some(value) = extra.remove("stop") {
+        body.insert(
+            "stop_sequences".to_string(),
+            normalize_stop_sequences(value)?,
+        );
+    }
+    if let Some(value) = extra.remove("stop_sequences") {
+        body.insert(
+            "stop_sequences".to_string(),
+            normalize_stop_sequences(value)?,
+        );
+    }
+    Ok(())
 }
 
 fn normalize_stop_sequences(value: Value) -> Result<Value, ProviderError> {
@@ -621,6 +1107,108 @@ fn extract_tool_config(
     Ok(Some(Value::Object(tool_config)))
 }
 
+fn extract_anthropic_tools(
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<Option<Map<String, Value>>, ProviderError> {
+    let tool_choice = extra.remove("tool_choice");
+    let Some(tools) = extra.remove("tools") else {
+        if let Some(tool_choice) = tool_choice
+            && !tool_choice_is_none_or_auto(&tool_choice)
+        {
+            return Err(ProviderError::InvalidRequest(
+                "tool_choice requires non-empty tools for aws_bedrock Anthropic Claude Messages"
+                    .to_string(),
+            ));
+        }
+        return Ok(None);
+    };
+
+    if tool_choice.as_ref().is_some_and(tool_choice_is_none) {
+        return Ok(None);
+    }
+
+    let tools_array = tools.as_array().ok_or_else(|| {
+        ProviderError::InvalidRequest(
+            "tools must be an array for aws_bedrock Anthropic Claude Messages".to_string(),
+        )
+    })?;
+    if tools_array.is_empty() {
+        return Ok(None);
+    }
+
+    let mut anthropic_tools = Vec::new();
+    for tool in tools_array {
+        let object = tool.as_object().ok_or_else(|| {
+            ProviderError::InvalidRequest("tool entries must be objects".to_string())
+        })?;
+        if object.get("type").and_then(Value::as_str) != Some("function") {
+            return Err(ProviderError::InvalidRequest(
+                "only OpenAI function tools are supported for aws_bedrock Anthropic Claude Messages"
+                    .to_string(),
+            ));
+        }
+        let function = object
+            .get("function")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                ProviderError::InvalidRequest("function tools must include `function`".to_string())
+            })?;
+        let name = function
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "function tools must include function.name".to_string(),
+                )
+            })?;
+        let schema = function
+            .get("parameters")
+            .cloned()
+            .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
+        let mut spec = Map::new();
+        spec.insert("name".to_string(), Value::String(name.to_string()));
+        if let Some(description) = function
+            .get("description")
+            .and_then(Value::as_str)
+            .filter(|description| !description.trim().is_empty())
+        {
+            spec.insert(
+                "description".to_string(),
+                Value::String(description.to_string()),
+            );
+        }
+        spec.insert("input_schema".to_string(), schema);
+        anthropic_tools.push(Value::Object(spec));
+    }
+
+    let mut mapped = Map::new();
+    mapped.insert("tools".to_string(), Value::Array(anthropic_tools));
+    if let Some(tool_choice) = tool_choice
+        && let Some(choice) = map_anthropic_tool_choice(&tool_choice)?
+    {
+        mapped.insert("tool_choice".to_string(), choice);
+    }
+    Ok(Some(mapped))
+}
+
+fn extract_anthropic_passthrough_fields(
+    body: &mut Map<String, Value>,
+    extra: &mut BTreeMap<String, Value>,
+) {
+    for field in [
+        "anthropic_beta",
+        "thinking",
+        "output_config",
+        "container",
+        "context_management",
+        "metadata",
+    ] {
+        if let Some(value) = extra.remove(field) {
+            body.insert(field.to_string(), value);
+        }
+    }
+}
+
 fn tool_choice_is_none_or_auto(value: &Value) -> bool {
     matches!(value.as_str(), Some("none" | "auto"))
         || value
@@ -628,6 +1216,15 @@ fn tool_choice_is_none_or_auto(value: &Value) -> bool {
             .and_then(|object| object.get("type"))
             .and_then(Value::as_str)
             .is_some_and(|kind| matches!(kind, "none" | "auto"))
+}
+
+fn tool_choice_is_none(value: &Value) -> bool {
+    value.as_str() == Some("none")
+        || value
+            .as_object()
+            .and_then(|object| object.get("type"))
+            .and_then(Value::as_str)
+            == Some("none")
 }
 
 fn map_tool_choice(value: &Value) -> Result<Option<Value>, ProviderError> {
@@ -677,6 +1274,62 @@ fn map_tool_choice(value: &Value) -> Result<Option<Value>, ProviderError> {
     }
 }
 
+fn map_anthropic_tool_choice(value: &Value) -> Result<Option<Value>, ProviderError> {
+    match value {
+        Value::String(choice) => match choice.as_str() {
+            "auto" => Ok(Some(json!({ "type": "auto" }))),
+            "required" => Ok(Some(json!({ "type": "any" }))),
+            "none" => Ok(None),
+            other => Err(ProviderError::InvalidRequest(format!(
+                "unsupported tool_choice `{other}` for aws_bedrock Anthropic Claude Messages"
+            ))),
+        },
+        Value::Object(object) => match object.get("type").and_then(Value::as_str) {
+            Some("auto") => Ok(Some(json!({ "type": "auto" }))),
+            Some("required") => Ok(Some(json!({ "type": "any" }))),
+            Some("none") => Ok(None),
+            Some("function") => {
+                let function = object
+                    .get("function")
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(
+                            "function tool_choice must include `function`".to_string(),
+                        )
+                    })?;
+                let name = function
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(
+                            "function tool_choice must include function.name".to_string(),
+                        )
+                    })?;
+                Ok(Some(json!({ "type": "tool", "name": name })))
+            }
+            Some("tool") => {
+                let name = object.get("name").and_then(Value::as_str).ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "tool tool_choice must include `name`".to_string(),
+                    )
+                })?;
+                Ok(Some(json!({ "type": "tool", "name": name })))
+            }
+            Some(other) => Err(ProviderError::InvalidRequest(format!(
+                "unsupported tool_choice type `{other}` for aws_bedrock Anthropic Claude Messages"
+            ))),
+            None => Err(ProviderError::InvalidRequest(
+                "tool_choice object must include `type`".to_string(),
+            )),
+        },
+        Value::Null => Ok(None),
+        _ => Err(ProviderError::InvalidRequest(
+            "tool_choice must be a string or object for aws_bedrock Anthropic Claude Messages"
+                .to_string(),
+        )),
+    }
+}
+
 fn reject_openai_only_fields(extra: &BTreeMap<String, Value>) -> Result<(), ProviderError> {
     const UNSUPPORTED: &[&str] = &[
         "frequency_penalty",
@@ -695,7 +1348,7 @@ fn reject_openai_only_fields(extra: &BTreeMap<String, Value>) -> Result<(), Prov
 
     if let Some(field) = UNSUPPORTED.iter().find(|field| extra.contains_key(**field)) {
         return Err(ProviderError::InvalidRequest(format!(
-            "`{field}` is not supported for aws_bedrock Converse in this slice"
+            "`{field}` is not supported for aws_bedrock chat in this slice"
         )));
     }
 
@@ -766,6 +1419,74 @@ fn normalize_converse_response(value: &Value, context: &ProviderRequestContext) 
     Value::Object(completion)
 }
 
+fn normalize_anthropic_messages_response(value: &Value, context: &ProviderRequestContext) -> Value {
+    let id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("chatcmpl-{}", Uuid::new_v4().simple()));
+    let created = OffsetDateTime::now_utc().unix_timestamp();
+    let blocks = value
+        .get("content")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let content = blocks
+        .iter()
+        .filter_map(|block| {
+            if block.get("type").and_then(Value::as_str) == Some("text") {
+                block.get("text").and_then(Value::as_str)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    let tool_calls = extract_anthropic_tool_calls(blocks);
+    let finish_reason = value
+        .get("stop_reason")
+        .and_then(Value::as_str)
+        .map(map_stop_reason)
+        .unwrap_or("stop");
+
+    let mut message = Map::new();
+    message.insert("role".to_string(), Value::String("assistant".to_string()));
+    message.insert("content".to_string(), Value::String(content));
+    if !tool_calls.is_empty() {
+        message.insert("tool_calls".to_string(), Value::Array(tool_calls));
+    }
+
+    let mut completion = Map::new();
+    completion.insert("id".to_string(), Value::String(id));
+    completion.insert(
+        "object".to_string(),
+        Value::String("chat.completion".to_string()),
+    );
+    completion.insert("created".to_string(), Value::Number(created.into()));
+    completion.insert(
+        "model".to_string(),
+        Value::String(context.model_key.clone()),
+    );
+    completion.insert(
+        "provider_model".to_string(),
+        Value::String(context.upstream_model.clone()),
+    );
+    completion.insert(
+        "choices".to_string(),
+        Value::Array(vec![json!({
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason
+        })]),
+    );
+
+    if let Some(usage) = map_usage(value) {
+        completion.insert("usage".to_string(), usage);
+    }
+
+    Value::Object(completion)
+}
+
 fn extract_tool_calls(blocks: &[Value]) -> Vec<Value> {
     blocks
         .iter()
@@ -789,12 +1510,37 @@ fn extract_tool_calls(blocks: &[Value]) -> Vec<Value> {
         .collect()
 }
 
+fn extract_anthropic_tool_calls(blocks: &[Value]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| {
+            if block.get("type").and_then(Value::as_str) != Some("tool_use") {
+                return None;
+            }
+            let id = block.get("id").and_then(Value::as_str)?;
+            let name = block.get("name").and_then(Value::as_str)?;
+            let arguments = block
+                .get("input")
+                .cloned()
+                .unwrap_or_else(|| Value::Object(Map::new()));
+            Some(json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": arguments.to_string()
+                }
+            }))
+        })
+        .collect()
+}
+
 fn map_stop_reason(reason: &str) -> &'static str {
     match reason {
         "end_turn" | "stop_sequence" => "stop",
         "max_tokens" | "model_context_window_exceeded" => "length",
         "tool_use" => "tool_calls",
-        "guardrail_intervened" | "content_filtered" => "content_filter",
+        "guardrail_intervened" | "content_filtered" | "refusal" => "content_filter",
         "malformed_model_output" | "malformed_tool_use" => "stop",
         _ => "stop",
     }
@@ -804,14 +1550,17 @@ fn map_usage(value: &Value) -> Option<Value> {
     let usage = value.get("usage")?.as_object()?;
     let prompt = usage
         .get("inputTokens")
+        .or_else(|| usage.get("input_tokens"))
         .and_then(Value::as_i64)
         .unwrap_or(0);
     let completion = usage
         .get("outputTokens")
+        .or_else(|| usage.get("output_tokens"))
         .and_then(Value::as_i64)
         .unwrap_or(0);
     let total = usage
         .get("totalTokens")
+        .or_else(|| usage.get("total_tokens"))
         .and_then(Value::as_i64)
         .unwrap_or(prompt + completion);
 
@@ -824,6 +1573,500 @@ fn map_usage(value: &Value) -> Option<Value> {
     mapped.insert("total_tokens".to_string(), Value::Number(total.into()));
     mapped.insert("provider_usage".to_string(), Value::Object(usage.clone()));
     Some(Value::Object(mapped))
+}
+
+#[derive(Debug, Clone)]
+struct BedrockEvent {
+    message_type: Option<String>,
+    event_type: Option<String>,
+    exception_type: Option<String>,
+    payload: Bytes,
+}
+
+#[derive(Debug, Default)]
+struct BedrockEventStreamDecoder {
+    buffer: Vec<u8>,
+}
+
+impl BedrockEventStreamDecoder {
+    const PRELUDE_LEN: usize = 12;
+    const MESSAGE_CRC_LEN: usize = 4;
+    const MAX_FRAME_LEN: usize = 16 * 1024 * 1024;
+
+    fn push_bytes(&mut self, chunk: &[u8]) -> Result<Vec<BedrockEvent>, ProviderError> {
+        self.buffer.extend_from_slice(chunk);
+        let mut events = Vec::new();
+
+        loop {
+            if self.buffer.len() < Self::PRELUDE_LEN {
+                break;
+            }
+
+            let total_len = u32::from_be_bytes(self.buffer[0..4].try_into().unwrap()) as usize;
+            let headers_len = u32::from_be_bytes(self.buffer[4..8].try_into().unwrap()) as usize;
+
+            if total_len < Self::PRELUDE_LEN + Self::MESSAGE_CRC_LEN {
+                return Err(ProviderError::Transport(format!(
+                    "invalid aws_bedrock EventStream frame length `{total_len}`"
+                )));
+            }
+            if total_len > Self::MAX_FRAME_LEN {
+                return Err(ProviderError::Transport(format!(
+                    "aws_bedrock EventStream frame length `{total_len}` exceeds limit"
+                )));
+            }
+            let payload_start = Self::PRELUDE_LEN.checked_add(headers_len).ok_or_else(|| {
+                ProviderError::Transport(
+                    "aws_bedrock EventStream headers length overflow".to_string(),
+                )
+            })?;
+            let payload_end = total_len
+                .checked_sub(Self::MESSAGE_CRC_LEN)
+                .ok_or_else(|| {
+                    ProviderError::Transport(
+                        "aws_bedrock EventStream payload length underflow".to_string(),
+                    )
+                })?;
+            if payload_start > payload_end {
+                return Err(ProviderError::Transport(format!(
+                    "aws_bedrock EventStream headers length `{headers_len}` exceeds frame payload"
+                )));
+            }
+            if self.buffer.len() < total_len {
+                break;
+            }
+
+            let frame = self.buffer.drain(..total_len).collect::<Vec<_>>();
+            let headers = parse_eventstream_headers(&frame[Self::PRELUDE_LEN..payload_start])?;
+            let payload = Bytes::copy_from_slice(&frame[payload_start..payload_end]);
+            events.push(BedrockEvent {
+                message_type: headers.get(":message-type").cloned(),
+                event_type: headers.get(":event-type").cloned(),
+                exception_type: headers.get(":exception-type").cloned(),
+                payload,
+            });
+        }
+
+        Ok(events)
+    }
+
+    fn finish(&self) -> Result<(), ProviderError> {
+        if self.buffer.is_empty() {
+            Ok(())
+        } else {
+            Err(ProviderError::Transport(format!(
+                "stream ended with incomplete aws_bedrock EventStream frame ({} bytes buffered)",
+                self.buffer.len()
+            )))
+        }
+    }
+}
+
+fn parse_eventstream_headers(headers: &[u8]) -> Result<BTreeMap<String, String>, ProviderError> {
+    let mut cursor = headers;
+    let mut parsed = BTreeMap::new();
+
+    while cursor.has_remaining() {
+        if cursor.remaining() < 1 {
+            return Err(ProviderError::Transport(
+                "malformed aws_bedrock EventStream header name length".to_string(),
+            ));
+        }
+        let name_len = cursor.get_u8() as usize;
+        if cursor.remaining() < name_len + 1 {
+            return Err(ProviderError::Transport(
+                "malformed aws_bedrock EventStream header".to_string(),
+            ));
+        }
+        let name = std::str::from_utf8(&cursor[..name_len]).map_err(|error| {
+            ProviderError::Transport(format!(
+                "aws_bedrock EventStream header name was not utf8: {error}"
+            ))
+        })?;
+        cursor.advance(name_len);
+        let value_type = cursor.get_u8();
+
+        let value = match value_type {
+            7 => {
+                if cursor.remaining() < 2 {
+                    return Err(ProviderError::Transport(
+                        "malformed aws_bedrock EventStream string header length".to_string(),
+                    ));
+                }
+                let value_len = cursor.get_u16() as usize;
+                if cursor.remaining() < value_len {
+                    return Err(ProviderError::Transport(
+                        "malformed aws_bedrock EventStream string header value".to_string(),
+                    ));
+                }
+                let value = std::str::from_utf8(&cursor[..value_len]).map_err(|error| {
+                    ProviderError::Transport(format!(
+                        "aws_bedrock EventStream string header was not utf8: {error}"
+                    ))
+                })?;
+                cursor.advance(value_len);
+                value.to_string()
+            }
+            0 => "true".to_string(),
+            1 => "false".to_string(),
+            other => {
+                return Err(ProviderError::Transport(format!(
+                    "unsupported aws_bedrock EventStream header value type `{other}`"
+                )));
+            }
+        };
+        parsed.insert(name.to_string(), value);
+    }
+
+    Ok(parsed)
+}
+
+#[derive(Debug)]
+enum BedrockStreamAction {
+    Chunk(Value),
+    Error { code: String, message: String },
+}
+
+#[derive(Debug)]
+struct BedrockConverseStreamNormalizer {
+    id: String,
+    created: i64,
+    model: String,
+    provider_model: String,
+    role_sent: bool,
+    saw_payload: bool,
+    saw_terminal: bool,
+}
+
+impl BedrockConverseStreamNormalizer {
+    fn new(context: &ProviderRequestContext) -> Self {
+        Self {
+            id: format!("chatcmpl-{}", Uuid::new_v4().simple()),
+            created: OffsetDateTime::now_utc().unix_timestamp(),
+            model: context.model_key.clone(),
+            provider_model: context.upstream_model.clone(),
+            role_sent: false,
+            saw_payload: false,
+            saw_terminal: false,
+        }
+    }
+
+    fn process_event(
+        &mut self,
+        event: BedrockEvent,
+    ) -> Result<Vec<BedrockStreamAction>, ProviderError> {
+        if event.message_type.as_deref() == Some("exception") || event.exception_type.is_some() {
+            let code = event
+                .exception_type
+                .or(event.event_type)
+                .unwrap_or_else(|| "bedrock_eventstream_exception".to_string());
+            let message = bedrock_event_payload_message(&event.payload)
+                .unwrap_or_else(|| "aws_bedrock EventStream exception".to_string());
+            return Ok(vec![BedrockStreamAction::Error { code, message }]);
+        }
+
+        let event_type = event.event_type.as_deref().ok_or_else(|| {
+            ProviderError::Transport(
+                "aws_bedrock EventStream event is missing :event-type".to_string(),
+            )
+        })?;
+
+        let payload: Value = serde_json::from_slice(&event.payload).map_err(|error| {
+            ProviderError::Transport(format!(
+                "invalid JSON payload in aws_bedrock `{event_type}` EventStream event: {error}"
+            ))
+        })?;
+
+        self.saw_payload = true;
+        let mut actions = Vec::new();
+        match event_type {
+            "messageStart" => {
+                if let Some(conversation_id) = payload.get("conversationId").and_then(Value::as_str)
+                {
+                    self.id = format!("chatcmpl-{conversation_id}");
+                }
+                if !self.role_sent {
+                    let role = payload
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .unwrap_or("assistant");
+                    actions.push(BedrockStreamAction::Chunk(self.delta_chunk(
+                        json!({
+                            "role": role
+                        }),
+                        Value::Null,
+                    )));
+                    self.role_sent = true;
+                }
+            }
+            "contentBlockStart" => {
+                if let Some(tool_use) = payload
+                    .get("start")
+                    .and_then(|start| start.get("toolUse"))
+                    .and_then(Value::as_object)
+                {
+                    let index = payload
+                        .get("contentBlockIndex")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    let id = tool_use
+                        .get("toolUseId")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    let name = tool_use
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    actions.push(BedrockStreamAction::Chunk(self.delta_chunk(
+                        json!({
+                            "tool_calls": [{
+                                "index": index,
+                                "id": id,
+                                "type": "function",
+                                "function": {
+                                    "name": name,
+                                    "arguments": ""
+                                }
+                            }]
+                        }),
+                        Value::Null,
+                    )));
+                }
+            }
+            "contentBlockDelta" => {
+                let delta = payload.get("delta").ok_or_else(|| {
+                    ProviderError::Transport(
+                        "aws_bedrock contentBlockDelta event is missing `delta`".to_string(),
+                    )
+                })?;
+                if let Some(text) = delta.get("text").and_then(Value::as_str) {
+                    actions.push(BedrockStreamAction::Chunk(self.delta_chunk(
+                        json!({
+                            "content": text
+                        }),
+                        Value::Null,
+                    )));
+                } else if let Some(tool_use) = delta.get("toolUse").and_then(Value::as_object) {
+                    let index = payload
+                        .get("contentBlockIndex")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    let input = tool_use
+                        .get("input")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    actions.push(BedrockStreamAction::Chunk(self.delta_chunk(
+                        json!({
+                            "tool_calls": [{
+                                "index": index,
+                                "function": {
+                                    "arguments": input
+                                }
+                            }]
+                        }),
+                        Value::Null,
+                    )));
+                }
+            }
+            "contentBlockStop" => {}
+            "messageStop" => {
+                let finish_reason = payload
+                    .get("stopReason")
+                    .and_then(Value::as_str)
+                    .map(map_stop_reason)
+                    .unwrap_or("stop");
+                actions.push(BedrockStreamAction::Chunk(
+                    self.delta_chunk(json!({}), Value::String(finish_reason.to_string())),
+                ));
+                self.saw_terminal = true;
+            }
+            "metadata" => {
+                if let Some(usage) = map_stream_usage(&payload) {
+                    actions.push(BedrockStreamAction::Chunk(self.usage_chunk(usage)));
+                }
+            }
+            other => {
+                return Err(ProviderError::Transport(format!(
+                    "unsupported aws_bedrock ConverseStream event `{other}`"
+                )));
+            }
+        }
+
+        Ok(actions)
+    }
+
+    fn delta_chunk(&self, delta: Value, finish_reason: Value) -> Value {
+        json!({
+            "id": self.id,
+            "object": "chat.completion.chunk",
+            "created": self.created,
+            "model": self.model,
+            "provider_model": self.provider_model,
+            "choices": [{
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason
+            }]
+        })
+    }
+
+    fn usage_chunk(&self, usage: Value) -> Value {
+        json!({
+            "id": self.id,
+            "object": "chat.completion.chunk",
+            "created": self.created,
+            "model": self.model,
+            "provider_model": self.provider_model,
+            "choices": [],
+            "usage": usage
+        })
+    }
+}
+
+fn bedrock_event_payload_message(payload: &[u8]) -> Option<String> {
+    serde_json::from_slice::<Value>(payload)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .or_else(|| value.get("Message"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| value.as_str().map(str::to_string))
+        })
+}
+
+fn map_stream_usage(value: &Value) -> Option<Value> {
+    let usage = value.get("usage")?.as_object()?;
+    let prompt = usage
+        .get("inputTokens")
+        .or_else(|| usage.get("input_tokens"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let completion = usage
+        .get("outputTokens")
+        .or_else(|| usage.get("output_tokens"))
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let total = usage
+        .get("totalTokens")
+        .or_else(|| usage.get("total_tokens"))
+        .and_then(Value::as_i64)
+        .unwrap_or(prompt + completion);
+
+    let mut mapped = Map::new();
+    mapped.insert("prompt_tokens".to_string(), Value::Number(prompt.into()));
+    mapped.insert(
+        "completion_tokens".to_string(),
+        Value::Number(completion.into()),
+    );
+    mapped.insert("total_tokens".to_string(), Value::Number(total.into()));
+    mapped.insert("provider_usage".to_string(), Value::Object(usage.clone()));
+    Some(Value::Object(mapped))
+}
+
+fn normalize_bedrock_converse_stream<S>(
+    upstream: S,
+    context: ProviderRequestContext,
+) -> ProviderStream
+where
+    S: futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+{
+    Box::pin(stream! {
+        let mut decoder = BedrockEventStreamDecoder::default();
+        let mut normalizer = BedrockConverseStreamNormalizer::new(&context);
+        let mut stream_failed = false;
+        futures_util::pin_mut!(upstream);
+
+        while let Some(chunk) = upstream.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    yield Ok(openai_sse_error_chunk(
+                        "upstream_bedrock_eventstream_error",
+                        &error.to_string(),
+                    ));
+                    stream_failed = true;
+                    break;
+                }
+            };
+
+            let events = match decoder.push_bytes(&chunk) {
+                Ok(events) => events,
+                Err(error) => {
+                    yield Ok(openai_sse_error_chunk(
+                        "bedrock_eventstream_parse_error",
+                        &error.to_string(),
+                    ));
+                    stream_failed = true;
+                    break;
+                }
+            };
+
+            for event in events {
+                let actions = match normalizer.process_event(event) {
+                    Ok(actions) => actions,
+                    Err(error) => {
+                        yield Ok(openai_sse_error_chunk(
+                            "bedrock_conversestream_normalization_error",
+                            &error.to_string(),
+                        ));
+                        stream_failed = true;
+                        break;
+                    }
+                };
+
+                for action in actions {
+                    match action {
+                        BedrockStreamAction::Chunk(value) => {
+                            yield Ok(render_sse_event_chunk(None, &value.to_string()));
+                        }
+                        BedrockStreamAction::Error { code, message } => {
+                            yield Ok(openai_sse_error_chunk(&code, &message));
+                            stream_failed = true;
+                            break;
+                        }
+                    }
+                }
+
+                if stream_failed {
+                    break;
+                }
+            }
+
+            if stream_failed {
+                break;
+            }
+        }
+
+        if !stream_failed && let Err(error) = decoder.finish() {
+            yield Ok(openai_sse_error_chunk(
+                "bedrock_eventstream_finalization_error",
+                &error.to_string(),
+            ));
+            stream_failed = true;
+        }
+
+        if !stream_failed && !normalizer.saw_payload {
+            yield Ok(openai_sse_error_chunk(
+                "bedrock_eventstream_empty_stream",
+                "upstream stream ended without Bedrock EventStream payload events",
+            ));
+            stream_failed = true;
+        }
+
+        if !stream_failed && !normalizer.saw_terminal {
+            yield Ok(openai_sse_error_chunk(
+                "bedrock_eventstream_missing_terminal_event",
+                "upstream Bedrock ConverseStream ended without messageStop",
+            ));
+            stream_failed = true;
+        }
+
+        if !stream_failed {
+            yield Ok(done_sse_chunk());
+        }
+    })
 }
 
 fn merge_object_overrides(base: &mut Map<String, Value>, overrides: &Map<String, Value>) {
@@ -850,11 +2093,15 @@ fn merge_object_overrides(base: &mut Map<String, Value>, overrides: &Map<String,
 mod tests {
     use std::collections::BTreeMap;
 
+    use bytes::Bytes;
+    use futures_util::StreamExt;
     use gateway_core::{CoreChatMessage, CoreChatRequest, ProviderRequestContext};
     use serde_json::{Map, Value, json};
 
     use super::{
-        BedrockAuthConfig, BedrockProvider, BedrockProviderConfig, map_chat_request_to_converse,
+        BedrockAuthConfig, BedrockEventStreamDecoder, BedrockProvider, BedrockProviderConfig,
+        map_chat_request_to_anthropic_messages, map_chat_request_to_converse,
+        normalize_anthropic_messages_response, normalize_bedrock_converse_stream,
         normalize_converse_response,
     };
 
@@ -918,6 +2165,52 @@ mod tests {
     }
 
     #[test]
+    fn maps_text_chat_request_to_anthropic_messages_invoke_body() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![
+                message("system", "Be terse."),
+                message("developer", "Prefer SI units."),
+                message("user", "Hello"),
+            ],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_completion_tokens".to_string(), json!(128)),
+                ("temperature".to_string(), json!(0.2)),
+                ("top_p".to_string(), json!(0.9)),
+                ("stop".to_string(), json!(["END"])),
+                (
+                    "anthropic_beta".to_string(),
+                    json!(["token-efficient-tools-2025-02-19"]),
+                ),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            body,
+            json!({
+                "anthropic_version": "bedrock-2023-05-31",
+                "anthropic_beta": ["token-efficient-tools-2025-02-19"],
+                "system": "Be terse.\nPrefer SI units.",
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}]
+                }],
+                "max_tokens": 128,
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "stop_sequences": ["END"]
+            })
+        );
+    }
+
+    #[test]
     fn builds_bearer_converse_request_with_encoded_model_path_and_headers() {
         let provider = BedrockProvider::new(BedrockProviderConfig {
             provider_key: "bedrock".to_string(),
@@ -941,17 +2234,14 @@ mod tests {
         };
 
         let built = provider
-            .build_converse_request(
-                &request,
-                &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
-            )
+            .build_chat_request(&request, &context("amazon.nova-pro-v1:0"))
             .expect("request");
         let body: Value =
             serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
 
         assert_eq!(
             built.url().as_str(),
-            "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-5-sonnet-20241022-v2%3A0/converse"
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.nova-pro-v1%3A0/converse"
         );
         assert_eq!(
             built.headers().get("authorization").unwrap(),
@@ -970,6 +2260,84 @@ mod tests {
                     "content": [{"text": "Hello"}]
                 }]
             })
+        );
+    }
+
+    #[test]
+    fn builds_bearer_anthropic_invoke_request_with_encoded_model_path() {
+        let provider = BedrockProvider::new(BedrockProviderConfig {
+            provider_key: "bedrock".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint_url: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            auth: BedrockAuthConfig::Bearer {
+                token: "test-token".to_string(),
+            },
+            default_headers: BTreeMap::new(),
+            request_timeout_ms: 1_000,
+        })
+        .expect("provider");
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::from([("max_tokens".to_string(), json!(64))]),
+        };
+
+        let built = provider
+            .build_chat_request(
+                &request,
+                &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            )
+            .expect("request");
+        let body: Value =
+            serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+
+        assert_eq!(
+            built.url().as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-5-sonnet-20241022-v2%3A0/invoke"
+        );
+        assert_eq!(
+            built.headers().get("authorization").unwrap(),
+            "Bearer test-token"
+        );
+        assert_eq!(body["anthropic_version"], "bedrock-2023-05-31");
+        assert_eq!(body["max_tokens"], 64);
+    }
+
+    #[test]
+    fn builds_bearer_converse_stream_request_with_eventstream_accept_header() {
+        let provider = BedrockProvider::new(BedrockProviderConfig {
+            provider_key: "bedrock".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint_url: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            auth: BedrockAuthConfig::Bearer {
+                token: "test-token".to_string(),
+            },
+            default_headers: BTreeMap::new(),
+            request_timeout_ms: 1_000,
+        })
+        .expect("provider");
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: true,
+            extra: BTreeMap::new(),
+        };
+
+        let built = provider
+            .build_converse_stream_request(
+                &request,
+                &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            )
+            .expect("request");
+
+        assert_eq!(
+            built.url().as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-5-sonnet-20241022-v2%3A0/converse-stream"
+        );
+        assert_eq!(
+            built.headers().get("accept").unwrap(),
+            "application/vnd.amazon.eventstream"
         );
     }
 
@@ -1024,6 +2392,188 @@ mod tests {
                 "toolChoice": {"tool": {"name": "get_weather"}}
             })
         );
+    }
+
+    #[test]
+    fn maps_anthropic_function_tools_tool_choice_and_tool_results() {
+        let mut assistant = message("assistant", "Calling tool");
+        assistant.extra.insert(
+            "tool_calls".to_string(),
+            json!([{
+                "id": "toolu_123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": "{\"city\":\"London\"}"
+                }
+            }]),
+        );
+        let mut tool = message("tool", "12 C");
+        tool.extra
+            .insert("tool_call_id".to_string(), json!("toolu_123"));
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Check weather"), assistant, tool],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(256)),
+                (
+                    "tools".to_string(),
+                    json!([{
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"]
+                            }
+                        }
+                    }]),
+                ),
+                (
+                    "tool_choice".to_string(),
+                    json!({"type":"function","function":{"name":"get_weather"}}),
+                ),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            body["tools"],
+            json!([{
+                "name": "get_weather",
+                "description": "Get weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"]
+                }
+            }])
+        );
+        assert_eq!(
+            body["tool_choice"],
+            json!({"type": "tool", "name": "get_weather"})
+        );
+        assert_eq!(
+            body["messages"][1]["content"][1],
+            json!({
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "get_weather",
+                "input": {"city": "London"}
+            })
+        );
+        assert_eq!(
+            body["messages"][2]["content"][0],
+            json!({
+                "type": "tool_result",
+                "tool_use_id": "toolu_123",
+                "content": "12 C"
+            })
+        );
+    }
+
+    #[test]
+    fn maps_anthropic_base64_image_blocks_and_rejects_remote_urls() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![CoreChatMessage {
+                role: "user".to_string(),
+                content: json!([
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "aW1hZ2U="
+                        }
+                    },
+                    {"type": "text", "text": "Describe it"}
+                ]),
+                name: None,
+                extra: BTreeMap::new(),
+            }],
+            stream: false,
+            extra: BTreeMap::from([("max_tokens".to_string(), json!(64))]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        )
+        .expect("mapped");
+        assert_eq!(
+            body["messages"][0]["content"][0],
+            json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "aW1hZ2U="
+                }
+            })
+        );
+
+        let remote = CoreChatRequest {
+            messages: vec![CoreChatMessage {
+                content: json!([{
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.test/image.png"}
+                }]),
+                ..message("user", "")
+            }],
+            ..request
+        };
+        let error = map_chat_request_to_anthropic_messages(
+            &remote,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        )
+        .expect_err("remote image rejected")
+        .to_string();
+        assert!(error.contains("remote image URLs are not supported"));
+    }
+
+    #[test]
+    fn rejects_anthropic_messages_without_max_tokens() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::new(),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        )
+        .expect_err("max tokens rejected")
+        .to_string();
+        assert!(error.contains("requires `max_tokens` or `max_completion_tokens`"));
+    }
+
+    #[test]
+    fn gates_anthropic_messages_streaming_mapping() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: true,
+            extra: BTreeMap::from([("max_tokens".to_string(), json!(64))]),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        )
+        .expect_err("streaming gated")
+        .to_string();
+        assert!(error.contains("streaming is gated"));
     }
 
     #[test]
@@ -1125,6 +2675,232 @@ mod tests {
         );
     }
 
+    #[test]
+    fn normalizes_anthropic_messages_response_with_usage_and_cache_tokens() {
+        let response = json!({
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-3-5-sonnet",
+            "content": [{"type": "text", "text": "Hello from Claude."}],
+            "stop_reason": "stop_sequence",
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 5,
+                "cache_read_input_tokens": 2,
+                "cache_creation_input_tokens": 3
+            }
+        });
+
+        let normalized = normalize_anthropic_messages_response(
+            &response,
+            &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        );
+
+        assert_eq!(normalized["id"], "msg_123");
+        assert_eq!(
+            normalized["choices"][0]["message"]["content"],
+            "Hello from Claude."
+        );
+        assert_eq!(normalized["choices"][0]["finish_reason"], "stop");
+        assert_eq!(normalized["usage"]["prompt_tokens"], 12);
+        assert_eq!(normalized["usage"]["completion_tokens"], 5);
+        assert_eq!(normalized["usage"]["total_tokens"], 17);
+        assert_eq!(
+            normalized["usage"]["provider_usage"]["cache_read_input_tokens"],
+            2
+        );
+        assert_eq!(
+            normalized["usage"]["provider_usage"]["cache_creation_input_tokens"],
+            3
+        );
+    }
+
+    #[test]
+    fn normalizes_anthropic_tool_use_response() {
+        let response = json!({
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "get_weather",
+                "input": {"city": "London"}
+            }],
+            "stop_reason": "tool_use",
+            "usage": {
+                "input_tokens": 30,
+                "output_tokens": 8
+            }
+        });
+
+        let normalized = normalize_anthropic_messages_response(
+            &response,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        );
+
+        assert_eq!(normalized["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            normalized["choices"][0]["message"]["tool_calls"][0],
+            json!({
+                "id": "toolu_123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": "{\"city\":\"London\"}"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn decodes_fragmented_eventstream_frames() {
+        let frame = eventstream_frame(
+            &[
+                (":message-type", "event"),
+                (":event-type", "contentBlockDelta"),
+            ],
+            br#"{"delta":{"text":"hel"}}"#,
+        );
+        let mut decoder = BedrockEventStreamDecoder::default();
+
+        assert!(decoder.push_bytes(&frame[..7]).expect("first").is_empty());
+        let events = decoder.push_bytes(&frame[7..]).expect("second");
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message_type.as_deref(), Some("event"));
+        assert_eq!(events[0].event_type.as_deref(), Some("contentBlockDelta"));
+        assert_eq!(
+            events[0].payload,
+            Bytes::from_static(br#"{"delta":{"text":"hel"}}"#)
+        );
+        decoder.finish().expect("complete");
+    }
+
+    #[test]
+    fn rejects_malformed_eventstream_lengths() {
+        let mut decoder = BedrockEventStreamDecoder::default();
+        let error = decoder
+            .push_bytes(&[0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0])
+            .expect_err("malformed")
+            .to_string();
+
+        assert!(error.contains("invalid aws_bedrock EventStream frame length"));
+    }
+
+    #[tokio::test]
+    async fn normalizes_text_finish_usage_and_done_from_converse_stream() {
+        let frames = vec![
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStart")],
+                br#"{"role":"assistant","conversationId":"conv-123"}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":0,"delta":{"text":"Hello "}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":0,"delta":{"text":"world"}}"#,
+            ),
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStop")],
+                br#"{"stopReason":"end_turn"}"#,
+            ),
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "metadata")],
+                br#"{"usage":{"inputTokens":11,"outputTokens":4,"totalTokens":15},"metrics":{"latencyMs":10}}"#,
+            ),
+        ];
+
+        let transcript = collect_bedrock_stream(frames).await;
+
+        assert!(transcript.contains(r#""id":"chatcmpl-conv-123""#));
+        assert!(transcript.contains(r#""delta":{"role":"assistant"}"#));
+        assert!(transcript.contains(r#""delta":{"content":"Hello "}"#));
+        assert!(transcript.contains(r#""delta":{"content":"world"}"#));
+        assert!(transcript.contains(r#""finish_reason":"stop""#));
+        assert!(transcript.contains(r#""prompt_tokens":11"#));
+        assert!(transcript.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn normalizes_tool_deltas_from_converse_stream() {
+        let frames = vec![
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStart")],
+                br#"{"role":"assistant"}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockStart"),
+                ],
+                br#"{"contentBlockIndex":1,"start":{"toolUse":{"toolUseId":"tool_123","name":"get_weather"}}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":1,"delta":{"toolUse":{"input":"{\"city\":"}}}"#,
+            ),
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStop")],
+                br#"{"stopReason":"tool_use"}"#,
+            ),
+        ];
+
+        let transcript = collect_bedrock_stream(frames).await;
+
+        assert!(transcript.contains(r#""tool_calls":[{"function":{"arguments":"","name":"get_weather"},"id":"tool_123","index":1,"type":"function"}]"#));
+        assert!(
+            transcript
+                .contains(r#""tool_calls":[{"function":{"arguments":"{\"city\":"},"index":1}]"#)
+        );
+        assert!(transcript.contains(r#""finish_reason":"tool_calls""#));
+        assert!(transcript.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn emits_structured_error_for_exception_event_without_done() {
+        let frames = vec![eventstream_frame(
+            &[
+                (":message-type", "exception"),
+                (":exception-type", "throttlingException"),
+            ],
+            br#"{"message":"rate limited"}"#,
+        )];
+
+        let transcript = collect_bedrock_stream(frames).await;
+
+        assert!(transcript.contains(r#""code":"throttlingException""#));
+        assert!(transcript.contains(r#""message":"rate limited""#));
+        assert!(!transcript.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn emits_structured_error_for_incomplete_frame_without_done() {
+        let frame = eventstream_frame(
+            &[(":message-type", "event"), (":event-type", "messageStart")],
+            br#"{"role":"assistant"}"#,
+        );
+        let truncated = frame[..frame.len() - 3].to_vec();
+
+        let transcript = collect_bedrock_stream(vec![truncated]).await;
+
+        assert!(transcript.contains(r#""code":"bedrock_eventstream_finalization_error""#));
+        assert!(transcript.contains("incomplete aws_bedrock EventStream frame"));
+        assert!(!transcript.contains("[DONE]"));
+    }
+
     fn message(role: &str, content: &str) -> CoreChatMessage {
         CoreChatMessage {
             role: role.to_string(),
@@ -1145,5 +2921,40 @@ mod tests {
             request_headers: BTreeMap::new(),
             compatibility: Default::default(),
         }
+    }
+
+    fn eventstream_frame(headers: &[(&str, &str)], payload: &[u8]) -> Vec<u8> {
+        let mut encoded_headers = Vec::new();
+        for (name, value) in headers {
+            encoded_headers.push(name.len() as u8);
+            encoded_headers.extend_from_slice(name.as_bytes());
+            encoded_headers.push(7);
+            encoded_headers.extend_from_slice(&(value.len() as u16).to_be_bytes());
+            encoded_headers.extend_from_slice(value.as_bytes());
+        }
+
+        let total_len = 12 + encoded_headers.len() + payload.len() + 4;
+        let mut frame = Vec::with_capacity(total_len);
+        frame.extend_from_slice(&(total_len as u32).to_be_bytes());
+        frame.extend_from_slice(&(encoded_headers.len() as u32).to_be_bytes());
+        frame.extend_from_slice(&0_u32.to_be_bytes());
+        frame.extend_from_slice(&encoded_headers);
+        frame.extend_from_slice(payload);
+        frame.extend_from_slice(&0_u32.to_be_bytes());
+        frame
+    }
+
+    async fn collect_bedrock_stream(frames: Vec<Vec<u8>>) -> String {
+        let chunks = frames.into_iter().map(|frame| Ok(Bytes::from(frame)));
+        let mut stream =
+            normalize_bedrock_converse_stream(futures_util::stream::iter(chunks), context("nova"));
+        let mut transcript = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.expect("stream chunk");
+            transcript.push_str(std::str::from_utf8(&chunk).expect("utf8"));
+        }
+
+        transcript
     }
 }

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1,7 +1,18 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use async_stream::stream;
 use async_trait::async_trait;
+use aws_config::{Region, default_provider::credentials::DefaultCredentialsChain};
+use aws_credential_types::{Credentials, provider::ProvideCredentials};
+use aws_sigv4::{
+    http_request::{SignableBody, SignableRequest, SigningSettings, sign},
+    sign::v4,
+};
+use aws_smithy_runtime_api::client::identity::Identity;
 use bytes::{Buf, Bytes};
 use futures_util::StreamExt;
 use gateway_core::{
@@ -10,6 +21,7 @@ use gateway_core::{
 };
 use serde_json::{Map, Value, json};
 use time::OffsetDateTime;
+use tokio::sync::OnceCell;
 use url::Url;
 use uuid::Uuid;
 
@@ -62,6 +74,7 @@ impl BedrockProviderConfig {
 pub struct BedrockProvider {
     config: BedrockProviderConfig,
     client: reqwest::Client,
+    default_credentials_chain: Arc<OnceCell<DefaultCredentialsChain>>,
 }
 
 impl BedrockProvider {
@@ -77,7 +90,11 @@ impl BedrockProvider {
             .build()
             .map_err(map_reqwest_error)?;
 
-        Ok(Self { config, client })
+        Ok(Self {
+            config,
+            client,
+            default_credentials_chain: Arc::new(OnceCell::new()),
+        })
     }
 
     fn unsupported(method: &str) -> ProviderError {
@@ -112,7 +129,7 @@ impl BedrockProvider {
         )
     }
 
-    fn build_chat_request(
+    async fn build_chat_request(
         &self,
         request: &CoreChatRequest,
         context: &ProviderRequestContext,
@@ -129,7 +146,12 @@ impl BedrockProvider {
             )
         };
 
-        let mut request = self.client.post(url).json(&body);
+        let body = serde_json::to_vec(&body).map_err(|error| {
+            ProviderError::InvalidRequest(format!(
+                "failed to serialize aws_bedrock request: {error}"
+            ))
+        })?;
+        let mut request = self.client.post(url).body(body);
         request = request.header("content-type", "application/json");
         request = request.header("accept", "application/json");
         request = request.header("x-request-id", &context.request_id);
@@ -144,22 +166,11 @@ impl BedrockProvider {
             }
         }
 
-        match &self.config.auth {
-            BedrockAuthConfig::Bearer { token } => {
-                request = request.bearer_auth(token);
-            }
-            BedrockAuthConfig::DefaultChain | BedrockAuthConfig::StaticCredentials { .. } => {
-                return Err(ProviderError::NotImplemented(
-                    "aws_bedrock IAM SigV4 request signing is owned by the provider auth foundation"
-                        .to_string(),
-                ));
-            }
-        }
-
-        request.build().map_err(map_reqwest_error)
+        self.apply_auth(request.build().map_err(map_reqwest_error)?)
+            .await
     }
 
-    fn build_converse_stream_request(
+    async fn build_converse_stream_request(
         &self,
         request: &CoreChatRequest,
         context: &ProviderRequestContext,
@@ -169,7 +180,12 @@ impl BedrockProvider {
         let body = map_chat_request_to_converse(&stream_request, context)?;
         let url = self.converse_stream_endpoint(&context.upstream_model);
 
-        let mut request = self.client.post(url).json(&body);
+        let body = serde_json::to_vec(&body).map_err(|error| {
+            ProviderError::InvalidRequest(format!(
+                "failed to serialize aws_bedrock request: {error}"
+            ))
+        })?;
+        let mut request = self.client.post(url).body(body);
         request = request.header("content-type", "application/json");
         request = request.header("accept", "application/vnd.amazon.eventstream");
         request = request.header("x-request-id", &context.request_id);
@@ -184,19 +200,151 @@ impl BedrockProvider {
             }
         }
 
+        self.apply_auth(request.build().map_err(map_reqwest_error)?)
+            .await
+    }
+
+    async fn apply_auth(
+        &self,
+        mut request: reqwest::Request,
+    ) -> Result<reqwest::Request, ProviderError> {
         match &self.config.auth {
             BedrockAuthConfig::Bearer { token } => {
-                request = request.bearer_auth(token);
+                request.headers_mut().insert(
+                    reqwest::header::AUTHORIZATION,
+                    reqwest::header::HeaderValue::from_str(&format!("Bearer {token}")).map_err(
+                        |error| {
+                            ProviderError::InvalidRequest(format!(
+                                "aws_bedrock bearer token cannot be used as a header: {error}"
+                            ))
+                        },
+                    )?,
+                );
+                Ok(request)
             }
-            BedrockAuthConfig::DefaultChain | BedrockAuthConfig::StaticCredentials { .. } => {
-                return Err(ProviderError::NotImplemented(
-                    "aws_bedrock IAM SigV4 request signing is owned by the provider auth foundation"
-                        .to_string(),
-                ));
+            BedrockAuthConfig::DefaultChain => {
+                let provider = self.default_credentials_provider().await;
+                let credentials = provider.provide_credentials().await.map_err(|error| {
+                    ProviderError::Transport(format!(
+                        "failed to resolve aws_bedrock default credentials: {error}"
+                    ))
+                })?;
+                self.sign_request(request, credentials)
             }
+            BedrockAuthConfig::StaticCredentials {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => self.sign_request(
+                request,
+                Credentials::new(
+                    access_key_id,
+                    secret_access_key,
+                    session_token.clone(),
+                    None,
+                    "oceans-llm-static-bedrock-credentials",
+                ),
+            ),
+        }
+    }
+
+    async fn default_credentials_provider(&self) -> &DefaultCredentialsChain {
+        let region = self.config.region.clone();
+        self.default_credentials_chain
+            .get_or_init(|| async move {
+                DefaultCredentialsChain::builder()
+                    .region(Region::new(region))
+                    .build()
+                    .await
+            })
+            .await
+    }
+
+    fn sign_request(
+        &self,
+        mut request: reqwest::Request,
+        credentials: Credentials,
+    ) -> Result<reqwest::Request, ProviderError> {
+        request.headers_mut().remove(reqwest::header::AUTHORIZATION);
+        request.headers_mut().remove("x-amz-date");
+        request.headers_mut().remove("x-amz-security-token");
+
+        let method = request.method().as_str().to_string();
+        let uri = request.url().as_str().to_string();
+        let body = request
+            .body()
+            .and_then(reqwest::Body::as_bytes)
+            .ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "aws_bedrock SigV4 signing requires an in-memory request body".to_string(),
+                )
+            })?
+            .to_vec();
+
+        let headers = request
+            .headers()
+            .iter()
+            .map(|(name, value)| {
+                value
+                    .to_str()
+                    .map(|value| (name.as_str(), value))
+                    .map_err(|error| {
+                        ProviderError::InvalidRequest(format!(
+                            "aws_bedrock request header `{name}` cannot be signed: {error}"
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let identity: Identity = credentials.into();
+        let signing_params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(&self.config.region)
+            .name("bedrock")
+            .time(SystemTime::now())
+            .settings(SigningSettings::default())
+            .build()
+            .map_err(|error| {
+                ProviderError::Transport(format!(
+                    "failed to build aws_bedrock SigV4 signing parameters: {error}"
+                ))
+            })?
+            .into();
+        let signable_request = SignableRequest::new(
+            method.as_str(),
+            uri.as_str(),
+            headers.iter().copied(),
+            SignableBody::Bytes(&body),
+        )
+        .map_err(|error| {
+            ProviderError::Transport(format!(
+                "failed to construct aws_bedrock SigV4 canonical request: {error}"
+            ))
+        })?;
+
+        let (signing_instructions, _signature) = sign(signable_request, &signing_params)
+            .map_err(|error| {
+                ProviderError::Transport(format!("failed to sign aws_bedrock request: {error}"))
+            })?
+            .into_parts();
+        for header in signing_instructions.headers() {
+            let value = reqwest::header::HeaderValue::from_str(header.1).map_err(|error| {
+                ProviderError::Transport(format!(
+                    "aws_bedrock SigV4 signer produced invalid header `{}`: {error}",
+                    header.0
+                ))
+            })?;
+            request.headers_mut().insert(
+                reqwest::header::HeaderName::from_bytes(header.0.as_bytes()).map_err(|error| {
+                    ProviderError::Transport(format!(
+                        "aws_bedrock SigV4 signer produced invalid header name `{}`: {error}",
+                        header.0
+                    ))
+                })?,
+                value,
+            );
         }
 
-        request.build().map_err(map_reqwest_error)
+        Ok(request)
     }
 
     async fn execute_stream_request(
@@ -241,7 +389,7 @@ impl ProviderClient for BedrockProvider {
         context: &ProviderRequestContext,
     ) -> Result<Value, ProviderError> {
         let is_anthropic_claude = is_anthropic_claude_model(&context.upstream_model);
-        let request = self.build_chat_request(request, context)?;
+        let request = self.build_chat_request(request, context).await?;
         let response = self
             .client
             .execute(request)
@@ -272,7 +420,7 @@ impl ProviderClient for BedrockProvider {
         request: &CoreChatRequest,
         context: &ProviderRequestContext,
     ) -> Result<ProviderStream, ProviderError> {
-        let request = self.build_converse_stream_request(request, context)?;
+        let request = self.build_converse_stream_request(request, context).await?;
         let response = self.execute_stream_request(request).await?;
 
         Ok(normalize_bedrock_converse_stream(
@@ -2222,6 +2370,7 @@ mod tests {
     use futures_util::StreamExt;
     use gateway_core::{CoreChatMessage, CoreChatRequest, ProviderRequestContext};
     use serde_json::{Map, Value, json};
+    use serial_test::serial;
 
     use super::{
         BedrockAuthConfig, BedrockEventStreamDecoder, BedrockProvider, BedrockProviderConfig,
@@ -2387,8 +2536,8 @@ mod tests {
         assert!(error.contains("remote image URLs are not supported"));
     }
 
-    #[test]
-    fn builds_bearer_converse_request_with_encoded_model_path_and_headers() {
+    #[tokio::test]
+    async fn builds_bearer_converse_request_with_encoded_model_path_and_headers() {
         let provider = BedrockProvider::new(BedrockProviderConfig {
             provider_key: "bedrock".to_string(),
             region: "us-east-1".to_string(),
@@ -2412,6 +2561,7 @@ mod tests {
 
         let built = provider
             .build_chat_request(&request, &context("amazon.nova-pro-v1:0"))
+            .await
             .expect("request");
         let body: Value =
             serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
@@ -2440,8 +2590,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn builds_bearer_anthropic_invoke_request_with_encoded_model_path() {
+    #[tokio::test]
+    async fn builds_bearer_anthropic_invoke_request_with_encoded_model_path() {
         let provider = BedrockProvider::new(BedrockProviderConfig {
             provider_key: "bedrock".to_string(),
             region: "us-east-1".to_string(),
@@ -2465,6 +2615,7 @@ mod tests {
                 &request,
                 &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
             )
+            .await
             .expect("request");
         let body: Value =
             serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
@@ -2481,8 +2632,8 @@ mod tests {
         assert_eq!(body["max_tokens"], 64);
     }
 
-    #[test]
-    fn builds_bearer_converse_stream_request_with_eventstream_accept_header() {
+    #[tokio::test]
+    async fn builds_bearer_converse_stream_request_with_eventstream_accept_header() {
         let provider = BedrockProvider::new(BedrockProviderConfig {
             provider_key: "bedrock".to_string(),
             region: "us-east-1".to_string(),
@@ -2506,6 +2657,7 @@ mod tests {
                 &request,
                 &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
             )
+            .await
             .expect("request");
 
         assert_eq!(
@@ -2516,6 +2668,129 @@ mod tests {
             built.headers().get("accept").unwrap(),
             "application/vnd.amazon.eventstream"
         );
+    }
+
+    #[tokio::test]
+    async fn builds_static_credentials_converse_request_with_sigv4_headers() {
+        let provider = static_credentials_provider(Some("test-session-token"));
+        let request = CoreChatRequest {
+            model: "nova".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::new(),
+        };
+
+        let built = provider
+            .build_chat_request(&request, &context("amazon.nova-pro-v1:0"))
+            .await
+            .expect("request");
+
+        assert_eq!(
+            built.url().as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.nova-pro-v1%3A0/converse"
+        );
+        let authorization = built
+            .headers()
+            .get("authorization")
+            .expect("authorization")
+            .to_str()
+            .expect("authorization utf8");
+        assert!(authorization.starts_with("AWS4-HMAC-SHA256 "));
+        assert!(authorization.contains("Credential=test-access-key/"));
+        assert!(authorization.contains("/us-east-1/bedrock/aws4_request"));
+        assert!(authorization.contains("SignedHeaders="));
+        assert!(built.headers().get("x-amz-date").is_some());
+        assert_eq!(
+            built.headers().get("x-amz-security-token").unwrap(),
+            "test-session-token"
+        );
+    }
+
+    #[tokio::test]
+    async fn builds_static_credentials_invoke_and_converse_stream_requests_with_sigv4_headers() {
+        let provider = static_credentials_provider(None);
+        let invoke_request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::from([("max_tokens".to_string(), json!(64))]),
+        };
+        let stream_request = CoreChatRequest {
+            model: "nova".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: true,
+            extra: BTreeMap::new(),
+        };
+
+        let invoke = provider
+            .build_chat_request(
+                &invoke_request,
+                &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            )
+            .await
+            .expect("invoke request");
+        let stream = provider
+            .build_converse_stream_request(&stream_request, &context("amazon.nova-pro-v1:0"))
+            .await
+            .expect("stream request");
+
+        assert_eq!(
+            invoke.url().as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-5-sonnet-20241022-v2%3A0/invoke"
+        );
+        assert!(invoke.headers().get("authorization").is_some());
+        assert!(invoke.headers().get("x-amz-date").is_some());
+        assert!(invoke.headers().get("x-amz-security-token").is_none());
+        assert_eq!(
+            stream.url().as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/amazon.nova-pro-v1%3A0/converse-stream"
+        );
+        assert!(stream.headers().get("authorization").is_some());
+        assert!(stream.headers().get("x-amz-date").is_some());
+        assert_eq!(
+            stream.headers().get("accept").unwrap(),
+            "application/vnd.amazon.eventstream"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn default_chain_uses_aws_provider_chain_for_sigv4_signing() {
+        let _env = AwsCredentialEnvGuard::set();
+        let provider = BedrockProvider::new(BedrockProviderConfig {
+            provider_key: "bedrock".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint_url: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            auth: BedrockAuthConfig::DefaultChain,
+            default_headers: BTreeMap::new(),
+            request_timeout_ms: 1_000,
+        })
+        .expect("provider");
+        let request = CoreChatRequest {
+            model: "nova".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::new(),
+        };
+
+        let built = provider
+            .build_chat_request(&request, &context("amazon.nova-pro-v1:0"))
+            .await
+            .expect("request");
+        let authorization = built
+            .headers()
+            .get("authorization")
+            .expect("authorization")
+            .to_str()
+            .expect("authorization utf8");
+
+        assert!(authorization.contains("Credential=chain-access-key/"));
+        assert!(authorization.contains("/us-east-1/bedrock/aws4_request"));
+        assert_eq!(
+            built.headers().get("x-amz-security-token").unwrap(),
+            "chain-session-token"
+        );
+        assert!(built.headers().get("x-amz-date").is_some());
     }
 
     #[test]
@@ -3137,6 +3412,61 @@ mod tests {
             extra_body: Map::new(),
             request_headers: BTreeMap::new(),
             compatibility: Default::default(),
+        }
+    }
+
+    fn static_credentials_provider(session_token: Option<&str>) -> BedrockProvider {
+        BedrockProvider::new(BedrockProviderConfig {
+            provider_key: "bedrock".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint_url: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            auth: BedrockAuthConfig::StaticCredentials {
+                access_key_id: "test-access-key".to_string(),
+                secret_access_key: "test-secret-key".to_string(),
+                session_token: session_token.map(ToString::to_string),
+            },
+            default_headers: BTreeMap::new(),
+            request_timeout_ms: 1_000,
+        })
+        .expect("provider")
+    }
+
+    struct AwsCredentialEnvGuard {
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl AwsCredentialEnvGuard {
+        fn set() -> Self {
+            let keys = [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+                "AWS_PROFILE",
+            ];
+            let previous = keys
+                .into_iter()
+                .map(|key| (key, std::env::var(key).ok()))
+                .collect::<Vec<_>>();
+            unsafe {
+                std::env::set_var("AWS_ACCESS_KEY_ID", "chain-access-key");
+                std::env::set_var("AWS_SECRET_ACCESS_KEY", "chain-secret-key");
+                std::env::set_var("AWS_SESSION_TOKEN", "chain-session-token");
+                std::env::remove_var("AWS_PROFILE");
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for AwsCredentialEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                for (key, value) in &self.previous {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+            }
         }
     }
 

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1,0 +1,1149 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use async_trait::async_trait;
+use gateway_core::{
+    CoreChatRequest, CoreEmbeddingsRequest, CoreResponsesRequest, ProviderCapabilities,
+    ProviderClient, ProviderError, ProviderRequestContext, ProviderStream,
+};
+use serde_json::{Map, Value, json};
+use time::OffsetDateTime;
+use url::Url;
+use uuid::Uuid;
+
+use crate::http::map_reqwest_error;
+
+#[derive(Debug, Clone)]
+pub enum BedrockAuthConfig {
+    DefaultChain,
+    Bearer {
+        token: String,
+    },
+    StaticCredentials {
+        access_key_id: String,
+        secret_access_key: String,
+        session_token: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct BedrockProviderConfig {
+    pub provider_key: String,
+    pub region: String,
+    pub endpoint_url: String,
+    pub auth: BedrockAuthConfig,
+    pub default_headers: BTreeMap<String, String>,
+    pub request_timeout_ms: u64,
+}
+
+impl BedrockProviderConfig {
+    #[must_use]
+    pub fn default_endpoint_url(region: &str) -> String {
+        format!("https://bedrock-runtime.{region}.amazonaws.com")
+    }
+
+    pub fn resolved_endpoint_url(
+        region: &str,
+        endpoint_url: Option<&str>,
+    ) -> Result<String, url::ParseError> {
+        let url = match endpoint_url {
+            Some(endpoint_url) => Url::parse(endpoint_url)?,
+            None => Url::parse(&Self::default_endpoint_url(region))?,
+        };
+
+        Ok(url.to_string().trim_end_matches('/').to_string())
+    }
+}
+
+#[derive(Clone)]
+pub struct BedrockProvider {
+    config: BedrockProviderConfig,
+    client: reqwest::Client,
+}
+
+impl BedrockProvider {
+    pub fn new(config: BedrockProviderConfig) -> Result<Self, ProviderError> {
+        let _ = Url::parse(&config.endpoint_url).map_err(|error| {
+            ProviderError::InvalidRequest(format!(
+                "aws_bedrock provider `{}` endpoint_url is invalid: {error}",
+                config.provider_key
+            ))
+        })?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(config.request_timeout_ms))
+            .build()
+            .map_err(map_reqwest_error)?;
+
+        Ok(Self { config, client })
+    }
+
+    fn unsupported(method: &str) -> ProviderError {
+        ProviderError::NotImplemented(format!(
+            "aws_bedrock {method} execution is not implemented yet"
+        ))
+    }
+
+    fn converse_endpoint(&self, upstream_model: &str) -> String {
+        let encoded_model_id: String =
+            url::form_urlencoded::byte_serialize(upstream_model.as_bytes()).collect();
+        format!(
+            "{}/model/{encoded_model_id}/converse",
+            self.config.endpoint_url
+        )
+    }
+
+    fn build_converse_request(
+        &self,
+        request: &CoreChatRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<reqwest::Request, ProviderError> {
+        let body = map_chat_request_to_converse(request, context)?;
+        let url = self.converse_endpoint(&context.upstream_model);
+
+        let mut request = self.client.post(url).json(&body);
+        request = request.header("content-type", "application/json");
+        request = request.header("x-request-id", &context.request_id);
+
+        for (name, value) in &self.config.default_headers {
+            request = request.header(name, value);
+        }
+
+        for (name, value) in &context.extra_headers {
+            if let Some(value) = value.as_str() {
+                request = request.header(name, value);
+            }
+        }
+
+        match &self.config.auth {
+            BedrockAuthConfig::Bearer { token } => {
+                request = request.bearer_auth(token);
+            }
+            BedrockAuthConfig::DefaultChain | BedrockAuthConfig::StaticCredentials { .. } => {
+                return Err(ProviderError::NotImplemented(
+                    "aws_bedrock IAM SigV4 request signing is owned by the provider auth foundation"
+                        .to_string(),
+                ));
+            }
+        }
+
+        request.build().map_err(map_reqwest_error)
+    }
+}
+
+#[async_trait]
+impl ProviderClient for BedrockProvider {
+    fn provider_key(&self) -> &str {
+        &self.config.provider_key
+    }
+
+    fn provider_type(&self) -> &str {
+        "aws_bedrock"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities::with_dimensions(true, false, false, true, false, false, true)
+    }
+
+    async fn chat_completions(
+        &self,
+        request: &CoreChatRequest,
+        context: &ProviderRequestContext,
+    ) -> Result<Value, ProviderError> {
+        let request = self.build_converse_request(request, context)?;
+        let response = self
+            .client
+            .execute(request)
+            .await
+            .map_err(map_reqwest_error)?;
+        let status = response.status();
+        let text = response.text().await.map_err(map_reqwest_error)?;
+
+        if !status.is_success() {
+            return Err(ProviderError::UpstreamHttp {
+                status: status.as_u16(),
+                body: text,
+            });
+        }
+
+        let value: Value = serde_json::from_str(&text).map_err(|error| {
+            ProviderError::Transport(format!("invalid JSON from aws_bedrock converse: {error}"))
+        })?;
+        Ok(normalize_converse_response(&value, context))
+    }
+
+    async fn chat_completions_stream(
+        &self,
+        _request: &CoreChatRequest,
+        _context: &ProviderRequestContext,
+    ) -> Result<ProviderStream, ProviderError> {
+        Err(Self::unsupported("chat completions streaming"))
+    }
+
+    async fn embeddings(
+        &self,
+        _request: &CoreEmbeddingsRequest,
+        _context: &ProviderRequestContext,
+    ) -> Result<Value, ProviderError> {
+        Err(Self::unsupported("embeddings"))
+    }
+
+    async fn responses(
+        &self,
+        _request: &CoreResponsesRequest,
+        _context: &ProviderRequestContext,
+    ) -> Result<Value, ProviderError> {
+        Err(Self::unsupported("responses"))
+    }
+
+    async fn responses_stream(
+        &self,
+        _request: &CoreResponsesRequest,
+        _context: &ProviderRequestContext,
+    ) -> Result<ProviderStream, ProviderError> {
+        Err(Self::unsupported("responses streaming"))
+    }
+}
+
+fn map_chat_request_to_converse(
+    request: &CoreChatRequest,
+    context: &ProviderRequestContext,
+) -> Result<Value, ProviderError> {
+    if request.stream {
+        return Err(ProviderError::InvalidRequest(
+            "aws_bedrock Converse streaming is not supported in this slice".to_string(),
+        ));
+    }
+
+    let mut body = Map::new();
+    let mut system = Vec::new();
+    let mut messages = Vec::new();
+
+    for message in &request.messages {
+        match message.role.as_str() {
+            "system" | "developer" => {
+                system.push(json!({ "text": message_content_as_text(&message.content)? }));
+            }
+            "user" => {
+                messages.push(json!({
+                    "role": "user",
+                    "content": map_bedrock_content_blocks(&message.content)?
+                }));
+            }
+            "assistant" => {
+                let mut content = map_bedrock_content_blocks(&message.content)?;
+                content.extend(map_assistant_tool_uses(message)?);
+                messages.push(json!({
+                    "role": "assistant",
+                    "content": content
+                }));
+            }
+            "tool" => {
+                messages.push(json!({
+                    "role": "user",
+                    "content": [map_tool_result(message)?]
+                }));
+            }
+            other => {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "unsupported message role `{other}` for aws_bedrock Converse mapping"
+                )));
+            }
+        }
+    }
+
+    if messages.is_empty() {
+        return Err(ProviderError::InvalidRequest(
+            "aws_bedrock Converse requires at least one user, assistant, or tool message"
+                .to_string(),
+        ));
+    }
+
+    if !system.is_empty() {
+        body.insert("system".to_string(), Value::Array(system));
+    }
+    body.insert("messages".to_string(), Value::Array(messages));
+
+    let mut passthrough = request.extra.clone();
+    passthrough.remove("model");
+    passthrough.remove("messages");
+    passthrough.remove("stream");
+
+    let inference_config = extract_inference_config(&mut passthrough)?;
+    if !inference_config.is_empty() {
+        body.insert(
+            "inferenceConfig".to_string(),
+            Value::Object(inference_config),
+        );
+    }
+
+    if let Some(tool_config) = extract_tool_config(&mut passthrough)? {
+        body.insert("toolConfig".to_string(), tool_config);
+    }
+
+    if let Some(additional) = passthrough.remove("additionalModelRequestFields") {
+        body.insert("additionalModelRequestFields".to_string(), additional);
+    }
+    if let Some(additional) = passthrough.remove("additional_model_request_fields") {
+        body.insert("additionalModelRequestFields".to_string(), additional);
+    }
+
+    reject_openai_only_fields(&passthrough)?;
+    merge_object_overrides(&mut body, &context.extra_body);
+    Ok(Value::Object(body))
+}
+
+fn message_content_as_text(content: &Value) -> Result<String, ProviderError> {
+    match content {
+        Value::Null => Ok(String::new()),
+        Value::String(value) => Ok(value.clone()),
+        Value::Array(items) => {
+            let mut lines = Vec::new();
+            for item in items {
+                let object = item.as_object().ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "content array entries must be objects".to_string(),
+                    )
+                })?;
+                let kind = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "content array entries must include `type`".to_string(),
+                    )
+                })?;
+                match kind {
+                    "text" | "input_text" => {
+                        let text = object.get("text").and_then(Value::as_str).ok_or_else(|| {
+                            ProviderError::InvalidRequest(
+                                "text content entries must include a string `text`".to_string(),
+                            )
+                        })?;
+                        lines.push(text.to_string());
+                    }
+                    other => {
+                        return Err(ProviderError::InvalidRequest(format!(
+                            "unsupported content type `{other}` for aws_bedrock instruction text"
+                        )));
+                    }
+                }
+            }
+            Ok(lines.join("\n"))
+        }
+        _ => Err(ProviderError::InvalidRequest(
+            "message content must be a string or typed content array".to_string(),
+        )),
+    }
+}
+
+fn map_bedrock_content_blocks(content: &Value) -> Result<Vec<Value>, ProviderError> {
+    match content {
+        Value::Null => Ok(Vec::new()),
+        Value::String(text) => Ok(vec![json!({ "text": text })]),
+        Value::Array(items) => {
+            let mut blocks = Vec::new();
+            for item in items {
+                let object = item.as_object().ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "content array entries must be objects".to_string(),
+                    )
+                })?;
+                let kind = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "content array entries must include `type`".to_string(),
+                    )
+                })?;
+                match kind {
+                    "text" | "input_text" => {
+                        let text = object.get("text").and_then(Value::as_str).ok_or_else(|| {
+                            ProviderError::InvalidRequest(
+                                "text content entries must include a string `text`".to_string(),
+                            )
+                        })?;
+                        blocks.push(json!({ "text": text }));
+                    }
+                    "tool_result" => {
+                        blocks.push(map_tool_result_content_block(object)?);
+                    }
+                    other => {
+                        return Err(ProviderError::InvalidRequest(format!(
+                            "unsupported content type `{other}` for aws_bedrock Converse mapping"
+                        )));
+                    }
+                }
+            }
+            Ok(blocks)
+        }
+        _ => Err(ProviderError::InvalidRequest(
+            "message content must be a string or typed content array".to_string(),
+        )),
+    }
+}
+
+fn map_assistant_tool_uses(
+    message: &gateway_core::CoreChatMessage,
+) -> Result<Vec<Value>, ProviderError> {
+    let Some(tool_calls) = message.extra.get("tool_calls") else {
+        return Ok(Vec::new());
+    };
+    let calls = tool_calls.as_array().ok_or_else(|| {
+        ProviderError::InvalidRequest("assistant tool_calls must be an array".to_string())
+    })?;
+
+    calls
+        .iter()
+        .map(|call| {
+            let object = call.as_object().ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "assistant tool_calls entries must be objects".to_string(),
+                )
+            })?;
+            if object.get("type").and_then(Value::as_str) != Some("function") {
+                return Err(ProviderError::InvalidRequest(
+                    "only function tool_calls are supported for aws_bedrock Converse".to_string(),
+                ));
+            }
+            let tool_use_id = object.get("id").and_then(Value::as_str).ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "assistant tool_calls entries must include `id`".to_string(),
+                )
+            })?;
+            let function = object
+                .get("function")
+                .and_then(Value::as_object)
+                .ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "assistant function tool_calls must include `function`".to_string(),
+                    )
+                })?;
+            let name = function
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "assistant function tool_calls must include function.name".to_string(),
+                    )
+                })?;
+            let input = match function.get("arguments") {
+                Some(Value::String(arguments)) => {
+                    serde_json::from_str(arguments).map_err(|error| {
+                        ProviderError::InvalidRequest(format!(
+                            "assistant function tool_call arguments must be JSON: {error}"
+                        ))
+                    })?
+                }
+                Some(value) => value.clone(),
+                None => Value::Object(Map::new()),
+            };
+
+            Ok(json!({
+                "toolUse": {
+                    "toolUseId": tool_use_id,
+                    "name": name,
+                    "input": input
+                }
+            }))
+        })
+        .collect()
+}
+
+fn map_tool_result(message: &gateway_core::CoreChatMessage) -> Result<Value, ProviderError> {
+    let tool_call_id = message
+        .extra
+        .get("tool_call_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest("tool messages must include `tool_call_id`".to_string())
+        })?;
+    let content = match &message.content {
+        Value::String(text) => vec![json!({ "text": text })],
+        Value::Array(items) => items
+            .iter()
+            .map(|item| {
+                let object = item.as_object().ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "tool message content array entries must be objects".to_string(),
+                    )
+                })?;
+                let text = object.get("text").and_then(Value::as_str).ok_or_else(|| {
+                    ProviderError::InvalidRequest(
+                        "tool message content entries must include string `text`".to_string(),
+                    )
+                })?;
+                Ok(json!({ "text": text }))
+            })
+            .collect::<Result<Vec<_>, ProviderError>>()?,
+        _ => {
+            return Err(ProviderError::InvalidRequest(
+                "tool message content must be a string or text content array".to_string(),
+            ));
+        }
+    };
+
+    Ok(json!({
+        "toolResult": {
+            "toolUseId": tool_call_id,
+            "content": content
+        }
+    }))
+}
+
+fn map_tool_result_content_block(object: &Map<String, Value>) -> Result<Value, ProviderError> {
+    let tool_use_id = object
+        .get("tool_use_id")
+        .or_else(|| object.get("toolUseId"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "tool_result content must include tool_use_id".to_string(),
+            )
+        })?;
+    let text = object.get("text").and_then(Value::as_str).ok_or_else(|| {
+        ProviderError::InvalidRequest("tool_result content must include string `text`".to_string())
+    })?;
+
+    Ok(json!({
+        "toolResult": {
+            "toolUseId": tool_use_id,
+            "content": [{ "text": text }]
+        }
+    }))
+}
+
+fn extract_inference_config(
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<Map<String, Value>, ProviderError> {
+    let mut config = Map::new();
+    if let Some(value) = extra
+        .remove("max_completion_tokens")
+        .or_else(|| extra.remove("max_tokens"))
+    {
+        config.insert("maxTokens".to_string(), value);
+    }
+    if let Some(value) = extra.remove("temperature") {
+        config.insert("temperature".to_string(), value);
+    }
+    if let Some(value) = extra.remove("top_p") {
+        config.insert("topP".to_string(), value);
+    }
+    if let Some(value) = extra.remove("stop") {
+        config.insert(
+            "stopSequences".to_string(),
+            normalize_stop_sequences(value)?,
+        );
+    }
+    Ok(config)
+}
+
+fn normalize_stop_sequences(value: Value) -> Result<Value, ProviderError> {
+    match value {
+        Value::String(sequence) => Ok(Value::Array(vec![Value::String(sequence)])),
+        Value::Array(values) if values.iter().all(Value::is_string) => Ok(Value::Array(values)),
+        Value::Null => Ok(Value::Array(Vec::new())),
+        _ => Err(ProviderError::InvalidRequest(
+            "`stop` must be a string or array of strings for aws_bedrock Converse".to_string(),
+        )),
+    }
+}
+
+fn extract_tool_config(
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<Option<Value>, ProviderError> {
+    let Some(tools) = extra.remove("tools") else {
+        if let Some(tool_choice) = extra.remove("tool_choice")
+            && !tool_choice_is_none_or_auto(&tool_choice)
+        {
+            return Err(ProviderError::InvalidRequest(
+                "tool_choice requires non-empty tools for aws_bedrock Converse".to_string(),
+            ));
+        }
+        return Ok(None);
+    };
+
+    let tools_array = tools.as_array().ok_or_else(|| {
+        ProviderError::InvalidRequest("tools must be an array for aws_bedrock Converse".to_string())
+    })?;
+    if tools_array.is_empty() {
+        return Ok(None);
+    }
+
+    let mut bedrock_tools = Vec::new();
+    for tool in tools_array {
+        let object = tool.as_object().ok_or_else(|| {
+            ProviderError::InvalidRequest("tool entries must be objects".to_string())
+        })?;
+        if object.get("type").and_then(Value::as_str) != Some("function") {
+            return Err(ProviderError::InvalidRequest(
+                "only OpenAI function tools are supported for aws_bedrock Converse".to_string(),
+            ));
+        }
+        let function = object
+            .get("function")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                ProviderError::InvalidRequest("function tools must include `function`".to_string())
+            })?;
+        let name = function
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                ProviderError::InvalidRequest(
+                    "function tools must include function.name".to_string(),
+                )
+            })?;
+        let schema = function
+            .get("parameters")
+            .cloned()
+            .unwrap_or_else(|| json!({ "type": "object", "properties": {} }));
+        let mut spec = Map::new();
+        spec.insert("name".to_string(), Value::String(name.to_string()));
+        if let Some(description) = function
+            .get("description")
+            .and_then(Value::as_str)
+            .filter(|description| !description.trim().is_empty())
+        {
+            spec.insert(
+                "description".to_string(),
+                Value::String(description.to_string()),
+            );
+        }
+        spec.insert("inputSchema".to_string(), json!({ "json": schema }));
+        if let Some(strict) = function.get("strict").and_then(Value::as_bool) {
+            spec.insert("strict".to_string(), Value::Bool(strict));
+        }
+        bedrock_tools.push(json!({ "toolSpec": spec }));
+    }
+
+    let mut tool_config = Map::new();
+    tool_config.insert("tools".to_string(), Value::Array(bedrock_tools));
+    if let Some(tool_choice) = extra.remove("tool_choice")
+        && let Some(mapped) = map_tool_choice(&tool_choice)?
+    {
+        tool_config.insert("toolChoice".to_string(), mapped);
+    }
+
+    Ok(Some(Value::Object(tool_config)))
+}
+
+fn tool_choice_is_none_or_auto(value: &Value) -> bool {
+    matches!(value.as_str(), Some("none" | "auto"))
+        || value
+            .as_object()
+            .and_then(|object| object.get("type"))
+            .and_then(Value::as_str)
+            .is_some_and(|kind| matches!(kind, "none" | "auto"))
+}
+
+fn map_tool_choice(value: &Value) -> Result<Option<Value>, ProviderError> {
+    match value {
+        Value::String(choice) => match choice.as_str() {
+            "auto" => Ok(Some(json!({ "auto": {} }))),
+            "required" => Ok(Some(json!({ "any": {} }))),
+            "none" => Ok(None),
+            other => Err(ProviderError::InvalidRequest(format!(
+                "unsupported tool_choice `{other}` for aws_bedrock Converse"
+            ))),
+        },
+        Value::Object(object) => match object.get("type").and_then(Value::as_str) {
+            Some("auto") => Ok(Some(json!({ "auto": {} }))),
+            Some("required") => Ok(Some(json!({ "any": {} }))),
+            Some("none") => Ok(None),
+            Some("function") => {
+                let function = object
+                    .get("function")
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(
+                            "function tool_choice must include `function`".to_string(),
+                        )
+                    })?;
+                let name = function
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(
+                            "function tool_choice must include function.name".to_string(),
+                        )
+                    })?;
+                Ok(Some(json!({ "tool": { "name": name } })))
+            }
+            Some(other) => Err(ProviderError::InvalidRequest(format!(
+                "unsupported tool_choice type `{other}` for aws_bedrock Converse"
+            ))),
+            None => Err(ProviderError::InvalidRequest(
+                "tool_choice object must include `type`".to_string(),
+            )),
+        },
+        Value::Null => Ok(None),
+        _ => Err(ProviderError::InvalidRequest(
+            "tool_choice must be a string or object for aws_bedrock Converse".to_string(),
+        )),
+    }
+}
+
+fn reject_openai_only_fields(extra: &BTreeMap<String, Value>) -> Result<(), ProviderError> {
+    const UNSUPPORTED: &[&str] = &[
+        "frequency_penalty",
+        "presence_penalty",
+        "logit_bias",
+        "logprobs",
+        "top_logprobs",
+        "n",
+        "response_format",
+        "seed",
+        "store",
+        "metadata",
+        "parallel_tool_calls",
+        "user",
+    ];
+
+    if let Some(field) = UNSUPPORTED.iter().find(|field| extra.contains_key(**field)) {
+        return Err(ProviderError::InvalidRequest(format!(
+            "`{field}` is not supported for aws_bedrock Converse in this slice"
+        )));
+    }
+
+    Ok(())
+}
+
+fn normalize_converse_response(value: &Value, context: &ProviderRequestContext) -> Value {
+    let id = value
+        .get("responseId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("chatcmpl-{}", Uuid::new_v4().simple()));
+    let created = OffsetDateTime::now_utc().unix_timestamp();
+    let blocks = value
+        .get("output")
+        .and_then(|output| output.get("message"))
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let content = blocks
+        .iter()
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("");
+    let tool_calls = extract_tool_calls(blocks);
+    let finish_reason = value
+        .get("stopReason")
+        .and_then(Value::as_str)
+        .map(map_stop_reason)
+        .unwrap_or("stop");
+
+    let mut message = Map::new();
+    message.insert("role".to_string(), Value::String("assistant".to_string()));
+    message.insert("content".to_string(), Value::String(content));
+    if !tool_calls.is_empty() {
+        message.insert("tool_calls".to_string(), Value::Array(tool_calls));
+    }
+
+    let mut completion = Map::new();
+    completion.insert("id".to_string(), Value::String(id));
+    completion.insert(
+        "object".to_string(),
+        Value::String("chat.completion".to_string()),
+    );
+    completion.insert("created".to_string(), Value::Number(created.into()));
+    completion.insert(
+        "model".to_string(),
+        Value::String(context.model_key.clone()),
+    );
+    completion.insert(
+        "provider_model".to_string(),
+        Value::String(context.upstream_model.clone()),
+    );
+    completion.insert(
+        "choices".to_string(),
+        Value::Array(vec![json!({
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason
+        })]),
+    );
+
+    if let Some(usage) = map_usage(value) {
+        completion.insert("usage".to_string(), usage);
+    }
+
+    Value::Object(completion)
+}
+
+fn extract_tool_calls(blocks: &[Value]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| {
+            let tool_use = block.get("toolUse")?;
+            let id = tool_use.get("toolUseId").and_then(Value::as_str)?;
+            let name = tool_use.get("name").and_then(Value::as_str)?;
+            let arguments = tool_use
+                .get("input")
+                .cloned()
+                .unwrap_or_else(|| Value::Object(Map::new()));
+            Some(json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": arguments.to_string()
+                }
+            }))
+        })
+        .collect()
+}
+
+fn map_stop_reason(reason: &str) -> &'static str {
+    match reason {
+        "end_turn" | "stop_sequence" => "stop",
+        "max_tokens" | "model_context_window_exceeded" => "length",
+        "tool_use" => "tool_calls",
+        "guardrail_intervened" | "content_filtered" => "content_filter",
+        "malformed_model_output" | "malformed_tool_use" => "stop",
+        _ => "stop",
+    }
+}
+
+fn map_usage(value: &Value) -> Option<Value> {
+    let usage = value.get("usage")?.as_object()?;
+    let prompt = usage
+        .get("inputTokens")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let completion = usage
+        .get("outputTokens")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let total = usage
+        .get("totalTokens")
+        .and_then(Value::as_i64)
+        .unwrap_or(prompt + completion);
+
+    let mut mapped = Map::new();
+    mapped.insert("prompt_tokens".to_string(), Value::Number(prompt.into()));
+    mapped.insert(
+        "completion_tokens".to_string(),
+        Value::Number(completion.into()),
+    );
+    mapped.insert("total_tokens".to_string(), Value::Number(total.into()));
+    mapped.insert("provider_usage".to_string(), Value::Object(usage.clone()));
+    Some(Value::Object(mapped))
+}
+
+fn merge_object_overrides(base: &mut Map<String, Value>, overrides: &Map<String, Value>) {
+    for (key, value) in overrides {
+        match (base.get_mut(key), value) {
+            (Some(base_value), Value::Object(override_object)) => {
+                if let Some(base_object) = base_value.as_object_mut() {
+                    merge_object_overrides(base_object, override_object);
+                } else {
+                    *base_value = Value::Object(override_object.clone());
+                }
+            }
+            (Some(base_value), override_value) => {
+                *base_value = override_value.clone();
+            }
+            (None, override_value) => {
+                base.insert(key.clone(), override_value.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use gateway_core::{CoreChatMessage, CoreChatRequest, ProviderRequestContext};
+    use serde_json::{Map, Value, json};
+
+    use super::{
+        BedrockAuthConfig, BedrockProvider, BedrockProviderConfig, map_chat_request_to_converse,
+        normalize_converse_response,
+    };
+
+    #[test]
+    fn resolves_default_endpoint_from_region() {
+        let endpoint =
+            BedrockProviderConfig::resolved_endpoint_url("us-east-1", None).expect("endpoint");
+        assert_eq!(endpoint, "https://bedrock-runtime.us-east-1.amazonaws.com");
+    }
+
+    #[test]
+    fn normalizes_custom_endpoint_trailing_slash() {
+        let endpoint = BedrockProviderConfig::resolved_endpoint_url(
+            "us-east-1",
+            Some("https://bedrock-runtime.us-west-2.amazonaws.com/"),
+        )
+        .expect("endpoint");
+        assert_eq!(endpoint, "https://bedrock-runtime.us-west-2.amazonaws.com");
+    }
+
+    #[test]
+    fn maps_text_chat_request_to_converse_body() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![
+                message("system", "Be terse."),
+                message("developer", "Prefer SI units."),
+                message("user", "Hello"),
+            ],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_completion_tokens".to_string(), json!(128)),
+                ("temperature".to_string(), json!(0.2)),
+                ("top_p".to_string(), json!(0.9)),
+                ("stop".to_string(), json!(["END"])),
+            ]),
+        };
+
+        let body = map_chat_request_to_converse(
+            &request,
+            &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            body,
+            json!({
+                "system": [{"text":"Be terse."},{"text":"Prefer SI units."}],
+                "messages": [{
+                    "role": "user",
+                    "content": [{"text": "Hello"}]
+                }],
+                "inferenceConfig": {
+                    "maxTokens": 128,
+                    "temperature": 0.2,
+                    "topP": 0.9,
+                    "stopSequences": ["END"]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn builds_bearer_converse_request_with_encoded_model_path_and_headers() {
+        let provider = BedrockProvider::new(BedrockProviderConfig {
+            provider_key: "bedrock".to_string(),
+            region: "us-east-1".to_string(),
+            endpoint_url: "https://bedrock-runtime.us-east-1.amazonaws.com".to_string(),
+            auth: BedrockAuthConfig::Bearer {
+                token: "test-token".to_string(),
+            },
+            default_headers: BTreeMap::from([(
+                "x-amzn-bedrock-trace".to_string(),
+                "ENABLED".to_string(),
+            )]),
+            request_timeout_ms: 1_000,
+        })
+        .expect("provider");
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::new(),
+        };
+
+        let built = provider
+            .build_converse_request(
+                &request,
+                &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            )
+            .expect("request");
+        let body: Value =
+            serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+
+        assert_eq!(
+            built.url().as_str(),
+            "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-3-5-sonnet-20241022-v2%3A0/converse"
+        );
+        assert_eq!(
+            built.headers().get("authorization").unwrap(),
+            "Bearer test-token"
+        );
+        assert_eq!(built.headers().get("x-request-id").unwrap(), "req-test");
+        assert_eq!(
+            built.headers().get("x-amzn-bedrock-trace").unwrap(),
+            "ENABLED"
+        );
+        assert_eq!(
+            body,
+            json!({
+                "messages": [{
+                    "role": "user",
+                    "content": [{"text": "Hello"}]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn maps_function_tools_and_tool_choice() {
+        let request = CoreChatRequest {
+            model: "nova".to_string(),
+            messages: vec![message("user", "Check weather")],
+            stream: false,
+            extra: BTreeMap::from([
+                (
+                    "tools".to_string(),
+                    json!([{
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"]
+                            }
+                        }
+                    }]),
+                ),
+                (
+                    "tool_choice".to_string(),
+                    json!({"type":"function","function":{"name":"get_weather"}}),
+                ),
+            ]),
+        };
+
+        let body = map_chat_request_to_converse(&request, &context("amazon.nova-pro-v1:0"))
+            .expect("mapped");
+
+        assert_eq!(
+            body["toolConfig"],
+            json!({
+                "tools": [{
+                    "toolSpec": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "inputSchema": {
+                            "json": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"]
+                            }
+                        }
+                    }
+                }],
+                "toolChoice": {"tool": {"name": "get_weather"}}
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_role_deterministically() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("critic", "Nope")],
+            stream: false,
+            extra: BTreeMap::new(),
+        };
+
+        let error = map_chat_request_to_converse(
+            &request,
+            &context("anthropic.claude-3-haiku-20240307-v1:0"),
+        )
+        .expect_err("role rejected")
+        .to_string();
+        assert!(error.contains("unsupported message role `critic`"));
+    }
+
+    #[test]
+    fn normalizes_text_response_with_usage() {
+        let response = json!({
+            "responseId": "bedrock-response-id",
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "Hello from Bedrock."}]
+                }
+            },
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 12,
+                "outputTokens": 5,
+                "totalTokens": 17,
+                "cacheReadInputTokens": 2
+            }
+        });
+
+        let normalized = normalize_converse_response(
+            &response,
+            &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        );
+
+        assert_eq!(normalized["id"], "bedrock-response-id");
+        assert_eq!(normalized["object"], "chat.completion");
+        assert_eq!(normalized["model"], "gateway-model");
+        assert_eq!(normalized["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(
+            normalized["choices"][0]["message"]["content"],
+            "Hello from Bedrock."
+        );
+        assert_eq!(normalized["choices"][0]["finish_reason"], "stop");
+        assert_eq!(normalized["usage"]["prompt_tokens"], 12);
+        assert_eq!(normalized["usage"]["completion_tokens"], 5);
+        assert_eq!(normalized["usage"]["total_tokens"], 17);
+        assert_eq!(
+            normalized["usage"]["provider_usage"]["cacheReadInputTokens"],
+            2
+        );
+    }
+
+    #[test]
+    fn normalizes_tool_use_response() {
+        let response = json!({
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{
+                        "toolUse": {
+                            "toolUseId": "tooluse_123",
+                            "name": "get_weather",
+                            "input": {"city": "London"}
+                        }
+                    }]
+                }
+            },
+            "stopReason": "tool_use",
+            "usage": {
+                "inputTokens": 30,
+                "outputTokens": 8,
+                "totalTokens": 38
+            }
+        });
+
+        let normalized = normalize_converse_response(&response, &context("amazon.nova-pro-v1:0"));
+
+        assert_eq!(normalized["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            normalized["choices"][0]["message"]["tool_calls"][0],
+            json!({
+                "id": "tooluse_123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": "{\"city\":\"London\"}"
+                }
+            })
+        );
+    }
+
+    fn message(role: &str, content: &str) -> CoreChatMessage {
+        CoreChatMessage {
+            role: role.to_string(),
+            content: Value::String(content.to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    fn context(upstream_model: &str) -> ProviderRequestContext {
+        ProviderRequestContext {
+            request_id: "req-test".to_string(),
+            model_key: "gateway-model".to_string(),
+            provider_key: "bedrock".to_string(),
+            upstream_model: upstream_model.to_string(),
+            extra_headers: Map::new(),
+            extra_body: Map::new(),
+            request_headers: BTreeMap::new(),
+            compatibility: Default::default(),
+        }
+    }
+}

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1322,6 +1322,11 @@ fn extract_tool_config(
         return Ok(None);
     }
 
+    let tool_choice = extra.remove("tool_choice");
+    if tool_choice.as_ref().is_some_and(tool_choice_is_none) {
+        return Ok(None);
+    }
+
     let mut bedrock_tools = Vec::new();
     for tool in tools_array {
         let object = tool.as_object().ok_or_else(|| {
@@ -1371,7 +1376,7 @@ fn extract_tool_config(
 
     let mut tool_config = Map::new();
     tool_config.insert("tools".to_string(), Value::Array(bedrock_tools));
-    if let Some(tool_choice) = extra.remove("tool_choice")
+    if let Some(tool_choice) = tool_choice
         && let Some(mapped) = map_tool_choice(&tool_choice)?
     {
         tool_config.insert("toolChoice".to_string(), mapped);
@@ -2861,6 +2866,36 @@ mod tests {
                 "toolChoice": {"tool": {"name": "get_weather"}}
             })
         );
+    }
+
+    #[test]
+    fn omits_converse_tool_config_when_tool_choice_is_none() {
+        let request = CoreChatRequest {
+            model: "nova".to_string(),
+            messages: vec![message("user", "Do not call tools")],
+            stream: false,
+            extra: BTreeMap::from([
+                (
+                    "tools".to_string(),
+                    json!([{
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}}
+                            }
+                        }
+                    }]),
+                ),
+                ("tool_choice".to_string(), json!("none")),
+            ]),
+        };
+
+        let body = map_chat_request_to_converse(&request, &context("amazon.nova-pro-v1:0"))
+            .expect("mapped");
+
+        assert!(body.get("toolConfig").is_none());
     }
 
     #[test]

--- a/crates/gateway-providers/src/lib.rs
+++ b/crates/gateway-providers/src/lib.rs
@@ -1,8 +1,10 @@
+mod bedrock;
 mod http;
 mod openai_compat;
 mod streaming;
 mod token;
 mod vertex;
 
+pub use bedrock::{BedrockAuthConfig, BedrockProvider, BedrockProviderConfig};
 pub use openai_compat::{OpenAiCompatConfig, OpenAiCompatProvider};
 pub use vertex::{VertexAuthConfig, VertexProvider, VertexProviderConfig};

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -6,7 +6,7 @@
     "license": {
       "name": ""
     },
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "paths": {
     "/api/v1/admin/api-keys": {

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -167,6 +167,16 @@ impl GatewayConfig {
                     if let Some(endpoint_url) = provider.endpoint_url.as_deref() {
                         validate_bedrock_endpoint_url(&provider.id, endpoint_url)?;
                     }
+                    let _ = BedrockProviderConfig::resolved_endpoint_url(
+                        provider.region.trim(),
+                        provider.endpoint_url.as_deref(),
+                    )
+                    .with_context(|| {
+                        format!(
+                            "aws_bedrock provider `{}` endpoint_url is invalid",
+                            provider.id
+                        )
+                    })?;
                     match &provider.auth {
                         AwsBedrockAuthConfig::DefaultChain => {}
                         AwsBedrockAuthConfig::Bearer { token } => {
@@ -472,7 +482,7 @@ impl GatewayConfig {
                     })?;
 
                     let config = json!({
-                        "region": provider.region,
+                        "region": provider.region.trim(),
                         "endpoint_url": endpoint_url,
                         "default_headers": provider.default_headers,
                         "timeouts": provider.timeouts,
@@ -1783,7 +1793,7 @@ models:
 providers:
   - id: bedrock-bearer
     type: aws_bedrock
-    region: us-west-2
+    region: " us-west-2 "
     endpoint_url: "https://bedrock-runtime.us-west-2.amazonaws.com/"
     auth:
       mode: bearer
@@ -1807,6 +1817,7 @@ providers:
             providers[0].config["endpoint_url"],
             "https://bedrock-runtime.us-west-2.amazonaws.com"
         );
+        assert_eq!(providers[0].config["region"], "us-west-2");
         assert!(providers[0].config.get("token").is_none());
         assert_eq!(providers[0].secrets.as_ref().unwrap()["mode"], "bearer");
 
@@ -1867,6 +1878,22 @@ providers:
         let error_text = format!("{error:#}");
         assert!(
             error_text.contains("endpoint_url `not a url` is invalid"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: "us east 1"
+"#,
+        );
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("aws_bedrock provider `bedrock` endpoint_url is invalid"),
             "unexpected error: {error_text}"
         );
 

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -8,7 +8,10 @@ use gateway_core::{
     SeedModel, SeedModelRoute, SeedProvider, SeedTeam, SeedUser, SeedUserMembership,
     parse_gateway_api_key,
 };
-use gateway_providers::{OpenAiCompatConfig, VertexAuthConfig, VertexProviderConfig};
+use gateway_providers::{
+    BedrockAuthConfig, BedrockProviderConfig, OpenAiCompatConfig, VertexAuthConfig,
+    VertexProviderConfig,
+};
 use gateway_service::{
     PayloadPath, ProviderIconKey, RequestLogPayloadCaptureMode, RequestLogPayloadPolicy,
     hash_gateway_key_secret, is_supported_pricing_provider_id, parse_payload_path,
@@ -146,6 +149,61 @@ impl GatewayConfig {
                         }
                     }
 
+                    validate_provider_display_config(
+                        provider.id.as_str(),
+                        provider.display.as_ref(),
+                    )?;
+                }
+                ProviderConfig::AwsBedrock(provider) => {
+                    if provider.id.trim().is_empty() {
+                        bail!("aws_bedrock provider id cannot be empty");
+                    }
+                    if provider.region.trim().is_empty() {
+                        bail!(
+                            "aws_bedrock provider `{}` region cannot be empty",
+                            provider.id
+                        );
+                    }
+                    if let Some(endpoint_url) = provider.endpoint_url.as_deref() {
+                        validate_bedrock_endpoint_url(&provider.id, endpoint_url)?;
+                    }
+                    match &provider.auth {
+                        AwsBedrockAuthConfig::DefaultChain => {}
+                        AwsBedrockAuthConfig::Bearer { token } => {
+                            if token.trim().is_empty() {
+                                bail!(
+                                    "aws_bedrock provider `{}` bearer.token cannot be empty",
+                                    provider.id
+                                );
+                            }
+                        }
+                        AwsBedrockAuthConfig::StaticCredentials {
+                            access_key_id,
+                            secret_access_key,
+                            session_token,
+                        } => {
+                            if access_key_id.trim().is_empty() {
+                                bail!(
+                                    "aws_bedrock provider `{}` static_credentials.access_key_id cannot be empty",
+                                    provider.id
+                                );
+                            }
+                            if secret_access_key.trim().is_empty() {
+                                bail!(
+                                    "aws_bedrock provider `{}` static_credentials.secret_access_key cannot be empty",
+                                    provider.id
+                                );
+                            }
+                            if let Some(session_token) = session_token
+                                && session_token.trim().is_empty()
+                            {
+                                bail!(
+                                    "aws_bedrock provider `{}` static_credentials.session_token cannot be empty when set",
+                                    provider.id
+                                );
+                            }
+                        }
+                    }
                     validate_provider_display_config(
                         provider.id.as_str(),
                         provider.display.as_ref(),
@@ -359,6 +417,68 @@ impl GatewayConfig {
                         secrets,
                     });
                 }
+                ProviderConfig::AwsBedrock(provider) => {
+                    match &provider.auth {
+                        AwsBedrockAuthConfig::DefaultChain => {}
+                        AwsBedrockAuthConfig::Bearer { token } => {
+                            validate_env_reference_if_needed(token)?;
+                        }
+                        AwsBedrockAuthConfig::StaticCredentials {
+                            access_key_id,
+                            secret_access_key,
+                            session_token,
+                        } => {
+                            validate_env_reference_if_needed(access_key_id)?;
+                            validate_env_reference_if_needed(secret_access_key)?;
+                            if let Some(session_token) = session_token {
+                                validate_env_reference_if_needed(session_token)?;
+                            }
+                        }
+                    }
+
+                    let endpoint_url = BedrockProviderConfig::resolved_endpoint_url(
+                        provider.region.trim(),
+                        provider.endpoint_url.as_deref(),
+                    )
+                    .with_context(|| {
+                        format!(
+                            "aws_bedrock provider `{}` endpoint_url is invalid",
+                            provider.id
+                        )
+                    })?;
+
+                    let config = json!({
+                        "region": provider.region,
+                        "endpoint_url": endpoint_url,
+                        "default_headers": provider.default_headers,
+                        "timeouts": provider.timeouts,
+                        "display": provider.display,
+                    });
+
+                    let secrets = Some(match &provider.auth {
+                        AwsBedrockAuthConfig::DefaultChain => json!({"mode": "default_chain"}),
+                        AwsBedrockAuthConfig::Bearer { token } => {
+                            json!({"mode": "bearer", "token": token})
+                        }
+                        AwsBedrockAuthConfig::StaticCredentials {
+                            access_key_id,
+                            secret_access_key,
+                            session_token,
+                        } => json!({
+                            "mode": "static_credentials",
+                            "access_key_id": access_key_id,
+                            "secret_access_key": secret_access_key,
+                            "session_token": session_token,
+                        }),
+                    });
+
+                    providers.push(SeedProvider {
+                        provider_key: provider.id.clone(),
+                        provider_type: "aws_bedrock".to_string(),
+                        config,
+                        secrets,
+                    });
+                }
             }
         }
 
@@ -531,6 +651,61 @@ impl GatewayConfig {
                 project_id: provider.project_id.clone(),
                 location: provider.location.clone(),
                 api_host: provider.api_host.clone(),
+                auth,
+                default_headers: provider.default_headers.clone(),
+                request_timeout_ms: provider
+                    .timeouts
+                    .as_ref()
+                    .map(|timeouts| timeouts.total_ms)
+                    .unwrap_or(120_000),
+            });
+        }
+
+        Ok(configs)
+    }
+
+    pub fn bedrock_provider_configs(&self) -> anyhow::Result<Vec<BedrockProviderConfig>> {
+        let mut configs = Vec::new();
+
+        for provider in &self.providers {
+            let ProviderConfig::AwsBedrock(provider) = provider else {
+                continue;
+            };
+
+            let endpoint_url = BedrockProviderConfig::resolved_endpoint_url(
+                provider.region.trim(),
+                provider.endpoint_url.as_deref(),
+            )
+            .with_context(|| {
+                format!(
+                    "aws_bedrock provider `{}` endpoint_url is invalid",
+                    provider.id
+                )
+            })?;
+
+            let auth = match &provider.auth {
+                AwsBedrockAuthConfig::DefaultChain => BedrockAuthConfig::DefaultChain,
+                AwsBedrockAuthConfig::Bearer { token } => BedrockAuthConfig::Bearer {
+                    token: resolve_secret_reference(token)?,
+                },
+                AwsBedrockAuthConfig::StaticCredentials {
+                    access_key_id,
+                    secret_access_key,
+                    session_token,
+                } => BedrockAuthConfig::StaticCredentials {
+                    access_key_id: resolve_secret_reference(access_key_id)?,
+                    secret_access_key: resolve_secret_reference(secret_access_key)?,
+                    session_token: session_token
+                        .as_deref()
+                        .map(resolve_secret_reference)
+                        .transpose()?,
+                },
+            };
+
+            configs.push(BedrockProviderConfig {
+                provider_key: provider.id.clone(),
+                region: provider.region.trim().to_string(),
+                endpoint_url,
                 auth,
                 default_headers: provider.default_headers.clone(),
                 request_timeout_ms: provider
@@ -945,6 +1120,7 @@ pub enum ProviderConfig {
     #[serde(rename = "openai_compat")]
     OpenAiCompat(OpenAiCompatProviderConfig),
     GcpVertex(GcpVertexProviderConfig),
+    AwsBedrock(AwsBedrockProviderConfig),
 }
 
 impl ProviderConfig {
@@ -953,6 +1129,7 @@ impl ProviderConfig {
         match self {
             Self::OpenAiCompat(provider) => &provider.id,
             Self::GcpVertex(provider) => &provider.id,
+            Self::AwsBedrock(provider) => &provider.id,
         }
     }
 }
@@ -1011,6 +1188,38 @@ pub enum GcpVertexAuthConfig {
     Adc,
     ServiceAccount { credentials_path: String },
     Bearer { token: String },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AwsBedrockProviderConfig {
+    pub id: String,
+    pub region: String,
+    #[serde(default)]
+    pub endpoint_url: Option<String>,
+    #[serde(default)]
+    pub auth: AwsBedrockAuthConfig,
+    #[serde(default)]
+    pub default_headers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub timeouts: Option<ProviderTimeouts>,
+    #[serde(default)]
+    pub display: Option<ProviderDisplayConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AwsBedrockAuthConfig {
+    #[default]
+    DefaultChain,
+    Bearer {
+        token: String,
+    },
+    StaticCredentials {
+        access_key_id: String,
+        secret_access_key: String,
+        #[serde(default)]
+        session_token: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1193,6 +1402,30 @@ fn validate_vertex_upstream_model_format(value: &str) -> anyhow::Result<()> {
             "gcp_vertex routes require upstream_model in <publisher>/<model_id> format, got `{value}`"
         );
     }
+    Ok(())
+}
+
+fn validate_bedrock_endpoint_url(provider_id: &str, endpoint_url: &str) -> anyhow::Result<()> {
+    if endpoint_url.trim().is_empty() {
+        bail!("aws_bedrock provider `{provider_id}` endpoint_url cannot be empty");
+    }
+
+    let parsed = url::Url::parse(endpoint_url).map_err(|error| {
+        anyhow::anyhow!(
+            "aws_bedrock provider `{provider_id}` endpoint_url `{endpoint_url}` is invalid: {error}"
+        )
+    })?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => bail!(
+            "aws_bedrock provider `{provider_id}` endpoint_url scheme `{scheme}` is not supported"
+        ),
+    }
+    if parsed.host().is_none() {
+        bail!("aws_bedrock provider `{provider_id}` endpoint_url must include a host");
+    }
+
     Ok(())
 }
 
@@ -1513,6 +1746,159 @@ models:
         );
 
         GatewayConfig::from_path(&config_path).expect("config should parse");
+    }
+
+    #[test]
+    fn accepts_valid_bedrock_auth_modes_and_seeds_config() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock-chain
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: default_chain
+  - id: bedrock-bearer
+    type: aws_bedrock
+    region: us-west-2
+    endpoint_url: "https://bedrock-runtime.us-west-2.amazonaws.com/"
+    auth:
+      mode: bearer
+      token: literal.test-token
+  - id: bedrock-static
+    type: aws_bedrock
+    region: eu-west-1
+    auth:
+      mode: static_credentials
+      access_key_id: literal.test-access-key
+      secret_access_key: literal.test-secret-key
+      session_token: literal.test-session-token
+    default_headers:
+      x-test: configured
+    timeouts:
+      total_ms: 30000
+    display:
+      label: Bedrock
+      icon_key: aws
+"#,
+        );
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let providers = config.seed_providers().expect("seed providers");
+
+        assert_eq!(providers.len(), 3);
+        assert_eq!(providers[0].provider_type, "aws_bedrock");
+        assert_eq!(
+            providers[0].config["endpoint_url"],
+            "https://bedrock-runtime.us-east-1.amazonaws.com"
+        );
+        assert_eq!(
+            providers[0].secrets.as_ref().unwrap()["mode"],
+            "default_chain"
+        );
+        assert_eq!(
+            providers[1].config["endpoint_url"],
+            "https://bedrock-runtime.us-west-2.amazonaws.com"
+        );
+        assert!(providers[1].config.get("token").is_none());
+        assert_eq!(providers[1].secrets.as_ref().unwrap()["mode"], "bearer");
+        assert_eq!(
+            providers[2].secrets.as_ref().unwrap()["mode"],
+            "static_credentials"
+        );
+
+        let runtime_configs = config
+            .bedrock_provider_configs()
+            .expect("runtime provider configs");
+        assert_eq!(runtime_configs[2].request_timeout_ms, 30_000);
+    }
+
+    #[test]
+    fn rejects_invalid_bedrock_provider_config() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: ""
+    type: aws_bedrock
+    region: us-east-1
+"#,
+        );
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("aws_bedrock provider id cannot be empty"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: ""
+"#,
+        );
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("region cannot be empty"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    endpoint_url: "not a url"
+"#,
+        );
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("endpoint_url `not a url` is invalid"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: static_credentials
+      access_key_id: literal.test-access-key
+"#,
+        );
+        GatewayConfig::from_path(&config_path).expect_err("config should fail");
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: bearer
+      token: literal.test-token
+      access_key_id: literal.test-access-key
+"#,
+        );
+        GatewayConfig::from_path(&config_path).expect_err("config should fail");
     }
 
     #[test]

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -168,12 +168,7 @@ impl GatewayConfig {
                         validate_bedrock_endpoint_url(&provider.id, endpoint_url)?;
                     }
                     match &provider.auth {
-                        AwsBedrockAuthConfig::DefaultChain => {
-                            bail!(
-                                "aws_bedrock provider `{}` auth.mode default_chain requires IAM SigV4 signing, which is not implemented yet; use bearer auth for executable Bedrock routes",
-                                provider.id
-                            );
-                        }
+                        AwsBedrockAuthConfig::DefaultChain => {}
                         AwsBedrockAuthConfig::Bearer { token } => {
                             if token.trim().is_empty() {
                                 bail!(
@@ -185,11 +180,52 @@ impl GatewayConfig {
                                 format!("aws_bedrock provider `{}` bearer.token", provider.id)
                             })?;
                         }
-                        AwsBedrockAuthConfig::StaticCredentials { .. } => {
-                            bail!(
-                                "aws_bedrock provider `{}` auth.mode static_credentials requires IAM SigV4 signing, which is not implemented yet; use bearer auth for executable Bedrock routes",
-                                provider.id
-                            );
+                        AwsBedrockAuthConfig::StaticCredentials {
+                            access_key_id,
+                            secret_access_key,
+                            session_token,
+                        } => {
+                            let access_key_id =
+                                resolve_secret_reference(access_key_id).with_context(|| {
+                                    format!(
+                                        "aws_bedrock provider `{}` static_credentials.access_key_id",
+                                        provider.id
+                                    )
+                                })?;
+                            if access_key_id.trim().is_empty() {
+                                bail!(
+                                    "aws_bedrock provider `{}` static_credentials.access_key_id cannot be empty",
+                                    provider.id
+                                );
+                            }
+                            let secret_access_key =
+                                resolve_secret_reference(secret_access_key).with_context(|| {
+                                    format!(
+                                        "aws_bedrock provider `{}` static_credentials.secret_access_key",
+                                        provider.id
+                                    )
+                                })?;
+                            if secret_access_key.trim().is_empty() {
+                                bail!(
+                                    "aws_bedrock provider `{}` static_credentials.secret_access_key cannot be empty",
+                                    provider.id
+                                );
+                            }
+                            if let Some(session_token) = session_token {
+                                let session_token = resolve_secret_reference(session_token)
+                                    .with_context(|| {
+                                        format!(
+                                            "aws_bedrock provider `{}` static_credentials.session_token",
+                                            provider.id
+                                        )
+                                    })?;
+                                if session_token.trim().is_empty() {
+                                    bail!(
+                                        "aws_bedrock provider `{}` static_credentials.session_token cannot be empty",
+                                        provider.id
+                                    );
+                                }
+                            }
                         }
                     }
                     validate_provider_display_config(
@@ -1587,7 +1623,7 @@ mod tests {
     use gateway_service::RequestLogPayloadCaptureMode;
     use tempfile::tempdir;
 
-    use super::GatewayConfig;
+    use super::{BedrockAuthConfig, GatewayConfig};
 
     fn write_config(path: &Path, yaml: &str) {
         std::fs::write(path, yaml).expect("write config");
@@ -1871,13 +1907,109 @@ providers:
     type: aws_bedrock
     region: us-east-1
     auth:
-      mode: default_chain
+      mode: bearer
+      token: raw-token
 "#,
         );
         let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
         let error_text = format!("{error:#}");
         assert!(
-            error_text.contains("default_chain requires IAM SigV4 signing"),
+            error_text.contains("unsupported secret reference `raw-token`"),
+            "unexpected error: {error_text}"
+        );
+    }
+
+    #[test]
+    fn accepts_bedrock_default_chain_and_static_credentials_auth() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock-default
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: default_chain
+  - id: bedrock-static
+    type: aws_bedrock
+    region: us-west-2
+    auth:
+      mode: static_credentials
+      access_key_id: literal.test-access-key
+      secret_access_key: literal.test-secret-key
+      session_token: literal.test-session-token
+"#,
+        );
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let runtime_configs = config
+            .bedrock_provider_configs()
+            .expect("runtime provider configs");
+
+        assert_eq!(runtime_configs.len(), 2);
+        assert!(matches!(
+            runtime_configs[0].auth,
+            BedrockAuthConfig::DefaultChain
+        ));
+        match &runtime_configs[1].auth {
+            BedrockAuthConfig::StaticCredentials {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => {
+                assert_eq!(access_key_id, "test-access-key");
+                assert_eq!(secret_access_key, "test-secret-key");
+                assert_eq!(session_token.as_deref(), Some("test-session-token"));
+            }
+            other => panic!("unexpected auth config: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_empty_bedrock_static_credential_fields() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: static_credentials
+      access_key_id: literal.
+      secret_access_key: literal.test-secret-key
+"#,
+        );
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("static_credentials.access_key_id cannot be empty"),
+            "unexpected error: {error_text}"
+        );
+
+        write_config(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: static_credentials
+      access_key_id: literal.test-access-key
+      secret_access_key: literal.
+"#,
+        );
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("static_credentials.secret_access_key cannot be empty"),
             "unexpected error: {error_text}"
         );
 
@@ -1892,31 +2024,13 @@ providers:
       mode: static_credentials
       access_key_id: literal.test-access-key
       secret_access_key: literal.test-secret-key
+      session_token: literal.
 "#,
         );
         let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
         let error_text = format!("{error:#}");
         assert!(
-            error_text.contains("static_credentials requires IAM SigV4 signing"),
-            "unexpected error: {error_text}"
-        );
-
-        write_config(
-            &config_path,
-            r#"
-providers:
-  - id: bedrock
-    type: aws_bedrock
-    region: us-east-1
-    auth:
-      mode: bearer
-      token: raw-token
-"#,
-        );
-        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
-        let error_text = format!("{error:#}");
-        assert!(
-            error_text.contains("unsupported secret reference `raw-token`"),
+            error_text.contains("static_credentials.session_token cannot be empty"),
             "unexpected error: {error_text}"
         );
     }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -16,7 +16,7 @@ use gateway_core::{
     RequestLogPayloadRecord, RequestLogRecord, RequestLogRepository, RequestTag, RequestTags,
     UsageLedgerRecord, UsagePricingStatus, UserStatus,
 };
-use gateway_providers::{OpenAiCompatProvider, VertexProvider};
+use gateway_providers::{BedrockProvider, OpenAiCompatProvider, VertexProvider};
 use gateway_service::{
     DEFAULT_PRICING_CATALOG_REFRESH_INTERVAL, GatewayService, WeightedRoutePlanner,
     hash_gateway_key_secret,
@@ -1119,6 +1119,12 @@ fn build_provider_registry(config: &GatewayConfig) -> anyhow::Result<ProviderReg
         providers.register(Arc::new(provider));
     }
 
+    for provider_config in config.bedrock_provider_configs()? {
+        let provider = BedrockProvider::new(provider_config)
+            .map_err(|error| anyhow::anyhow!("failed building aws_bedrock provider: {error}"))?;
+        providers.register(Arc::new(provider));
+    }
+
     Ok(providers)
 }
 
@@ -1235,7 +1241,10 @@ mod tests {
     use url::Url;
     use uuid::Uuid;
 
-    use crate::{ensure_bootstrap_admin, ensure_seed_local_demo_targets_local_database};
+    use crate::{
+        build_provider_registry, ensure_bootstrap_admin,
+        ensure_seed_local_demo_targets_local_database,
+    };
     use gateway::{
         config::{BootstrapAdminConfig, GatewayConfig},
         http::{build_router, state::AppState},
@@ -1245,6 +1254,32 @@ mod tests {
     enum MockChatResult {
         Value(Value),
         Error(MockError),
+    }
+
+    #[test]
+    fn build_provider_registry_registers_bedrock_stub() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: default_chain
+"#,
+        )
+        .expect("write config");
+
+        let config = GatewayConfig::from_path(&config_path).expect("config");
+        let registry = build_provider_registry(&config).expect("registry");
+        let provider = registry.get("bedrock").expect("bedrock provider");
+
+        assert_eq!(provider.provider_type(), "aws_bedrock");
+        assert!(!provider.capabilities().responses);
+        assert!(!provider.capabilities().embeddings);
     }
 
     #[derive(Clone)]

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1279,6 +1279,8 @@ providers:
         let provider = registry.get("bedrock").expect("bedrock provider");
 
         assert_eq!(provider.provider_type(), "aws_bedrock");
+        assert!(provider.capabilities().chat_completions);
+        assert!(provider.capabilities().stream);
         assert!(!provider.capabilities().responses);
         assert!(!provider.capabilities().embeddings);
     }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -44,6 +44,10 @@ export default defineConfig({
         ],
       },
       {
+        text: "Providers",
+        items: [{ text: "AWS Bedrock", link: "/providers/aws-bedrock" }],
+      },
+      {
         text: "Operations",
         items: [
           { text: "Budgets and Spending", link: "/operations/budgets-and-spending" },

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -332,6 +332,7 @@ Supported provider types in the checked-in configs:
 
 - `openai_compat`
 - `gcp_vertex`
+- `aws_bedrock`
 
 ### Provider Auth Modes
 
@@ -340,6 +341,9 @@ Supported provider types in the checked-in configs:
 | `openai_compat` | `auth.token` | bearer-style token |
 | `gcp_vertex` | `auth.mode: adc` | ADC available in the runtime environment |
 | `gcp_vertex` | `auth.mode: service_account` | `credentials_path` pointing at service-account JSON or an equivalent mounted secret path |
+| `aws_bedrock` | `auth.mode: default_chain` | AWS SDK/default credential chain in the runtime environment |
+| `aws_bedrock` | `auth.mode: bearer` | Bedrock bearer token, often `env.AWS_BEARER_TOKEN_BEDROCK` |
+| `aws_bedrock` | `auth.mode: static_credentials` | AWS access key ID, secret access key, and optional session token |
 
 ### `openai_compat`
 
@@ -383,6 +387,63 @@ Routing and pricing caveats:
 - `upstream_model` must use `<publisher>/<model_id>`
 - pricing identity is inferred from the publisher prefix
 - Anthropic-on-Vertex pricing is only supported for `location=global`
+
+### `aws_bedrock`
+
+Important fields:
+
+- `id`
+- `region`
+- `endpoint_url`
+  - optional
+  - defaults to `https://bedrock-runtime.{region}.amazonaws.com`
+- `auth.mode`
+- `default_headers`
+- `timeouts.total_ms`
+- optional `display.label`
+- optional `display.icon_key`
+
+Supported auth modes:
+
+```yaml
+providers:
+  - id: bedrock
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: default_chain
+```
+
+```yaml
+providers:
+  - id: bedrock-api-key
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: bearer
+      token: env.AWS_BEARER_TOKEN_BEDROCK
+```
+
+```yaml
+providers:
+  - id: bedrock-static
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: static_credentials
+      access_key_id: env.AWS_ACCESS_KEY_ID
+      secret_access_key: env.AWS_SECRET_ACCESS_KEY
+      session_token: env.AWS_SESSION_TOKEN
+```
+
+`default_chain` leaves credential discovery to the AWS runtime environment. The standard environment variables are `AWS_REGION` or `AWS_DEFAULT_REGION` for region-aware AWS tooling, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optional `AWS_SESSION_TOKEN`; shared AWS config, profiles, ECS/EKS credentials, and IMDS are also part of the AWS SDK credential-chain model.
+
+Routing caveats:
+
+- `upstream_model` should be the Bedrock Runtime model identity passed to Bedrock APIs: a base model ID such as `anthropic.claude-3-5-sonnet-20240620-v1:0`, an inference profile ID such as `us.anthropic.claude-3-5-sonnet-20240620-v1:0`, or a supported Bedrock ARN.
+- Non-streaming `/v1/chat/completions` uses Bedrock Converse in this slice.
+- Keep route `stream`, `responses`, and `embeddings` capability flags `false`.
+- IAM/SigV4 request signing, streaming, `/v1/responses`, and `/v1/embeddings` are not implemented for `aws_bedrock`.
 
 ## Model Config
 
@@ -494,6 +555,21 @@ models:
           chat_completions: true
           responses: false
           embeddings: false
+```
+
+Bedrock routes can execute non-streaming Chat Completions through Converse. Keep streaming, Responses, and embeddings disabled:
+
+```yaml
+models:
+  - id: claude-bedrock
+    routes:
+      - provider: bedrock
+        upstream_model: us.anthropic.claude-3-5-sonnet-20240620-v1:0
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: false
 ```
 
 OpenAI-compatible embeddings-only routes should narrow route capability so chat and Responses requests fail early:

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -413,14 +413,14 @@ providers:
       token: env.AWS_BEARER_TOKEN_BEDROCK
 ```
 
-`default_chain` and `static_credentials` require IAM SigV4 signing, which is not implemented yet. They are rejected during config validation until provider auth supports signed Bedrock Runtime requests.
+`default_chain` and `static_credentials` use IAM SigV4 signing for Bedrock Runtime requests. `bearer` remains available for bearer-token based Bedrock access where applicable.
 
 Routing caveats:
 
 - `upstream_model` should be the Bedrock Runtime model identity passed to Bedrock APIs: a base model ID such as `anthropic.claude-3-5-sonnet-20240620-v1:0`, an inference profile ID such as `us.anthropic.claude-3-5-sonnet-20240620-v1:0`, or a supported Bedrock ARN.
 - `/v1/chat/completions` routing is provider/model-specific in this slice: Claude non-streaming requests use `InvokeModel` with Anthropic Messages, while Bedrock Converse and ConverseStream are used for supported Bedrock-native chat flows.
 - Route `stream` may be enabled for Bedrock models that support streaming through `ConverseStream`; keep `responses` and `embeddings` capability flags `false`.
-- IAM/SigV4 request signing, `/v1/responses`, and `/v1/embeddings` are not implemented for `aws_bedrock`.
+- `/v1/responses` and `/v1/embeddings` are not implemented for `aws_bedrock`.
 - Validate documentation-only updates with `mise run docs-check`.
 
 ## Model Config

--- a/docs/configuration/pricing-catalog-and-accounting.md
+++ b/docs/configuration/pricing-catalog-and-accounting.md
@@ -119,6 +119,8 @@ The pricing catalog can preserve more rate metadata than the runtime charges tod
 
 That distinction keeps the ledger conservative. The gateway should not infer spend for provider-specific counters until the pricing and request semantics are explicit. Richer token and cache accounting is tracked in [issue #92](https://github.com/ahstn/oceans-llm/issues/92).
 
+AWS Bedrock Anthropic Claude responses preserve the raw Anthropic usage object under `usage.provider_usage`, including cache counters such as `cache_read_input_tokens` and `cache_creation_input_tokens` when Bedrock returns them. Durable accounting still uses only normalized `prompt_tokens`, `completion_tokens`, and `total_tokens`; cache read/write discounts or surcharges are not priced in this slice.
+
 ## Relationship to Request Flow
 
 Route choice affects accounting, not only provider execution.

--- a/docs/providers/aws-bedrock.md
+++ b/docs/providers/aws-bedrock.md
@@ -1,0 +1,151 @@
+# AWS Bedrock
+
+`See also`: [Configuration Reference](../configuration/configuration-reference.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Provider API Compatibility](../reference/provider-api-compatibility.md), [Pricing Catalog and Accounting](../configuration/pricing-catalog-and-accounting.md)
+
+This page owns provider-specific configuration examples for Amazon Bedrock routes.
+
+## Current Runtime Boundary
+
+The gateway uses the Bedrock Runtime endpoint shape:
+
+- non-Anthropic chat models use Bedrock `Converse`
+- Anthropic Claude chat models use Bedrock `InvokeModel` with the native Anthropic Messages body for non-streaming requests
+- streaming chat uses Bedrock `ConverseStream` and is normalized into OpenAI-compatible chat-completion chunks
+- `/v1/responses` and `/v1/embeddings` are not implemented for `aws_bedrock` routes
+
+The runnable auth mode in the current provider adapter is bearer-token auth. AWS documents `AWS_BEARER_TOKEN_BEDROCK` as the environment variable recognized by Bedrock API-key auth and direct HTTP calls can pass the same value as `Authorization: Bearer ...`: [Use an Amazon Bedrock API key](https://docs.aws.amazon.com/en_us/bedrock/latest/userguide/api-keys-use.html). The config parser accepts `default_chain` and `static_credentials`, but IAM/SigV4 request signing is still provider-auth follow-up work. Use bearer auth for working local and development examples.
+
+## Provider
+
+```yaml
+providers:
+  - id: bedrock-us-east-1
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: bearer
+      token: env.AWS_BEARER_TOKEN_BEDROCK
+    display:
+      label: Amazon Bedrock
+      icon_key: aws
+```
+
+`endpoint_url` is optional. When omitted, the gateway uses `https://bedrock-runtime.{region}.amazonaws.com`.
+
+## Model Identity
+
+Use Bedrock Runtime model identities as `upstream_model` values. The value can be a base model ID, a geo or global inference profile ID, or a Bedrock ARN accepted by the Bedrock Runtime operation.
+
+AWS now publishes model IDs on the Bedrock model cards. The [models at a glance](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html) page links to each model card and says those cards include programmatic model IDs, endpoint support, service tiers, regional availability, quotas, and sample code.
+
+Examples verified against AWS model cards on 2026-04-30:
+
+| Use case | Gateway model id | Bedrock `upstream_model` | Notes |
+| --- | --- | --- | --- |
+| Latest high-capability Claude | `claude-opus-bedrock` | `global.anthropic.claude-opus-4-7` | [Claude Opus 4.7](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html) launched on 2026-04-16. AWS lists `anthropic.claude-opus-4-7` plus US, EU, JP, and global inference IDs. |
+| Claude regional profile | `claude-sonnet-bedrock` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | [Claude Sonnet 4.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-5.html) supports base, geo, and global IDs on Bedrock Runtime. |
+| Amazon low-cost multimodal | `nova-lite-bedrock` | `global.amazon.nova-2-lite-v1:0` | [Nova 2 Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html) supports `amazon.nova-2-lite-v1:0`, US/EU geo IDs, and a global inference ID. |
+| Amazon reasoning and distillation | `nova-premier-bedrock` | `us.amazon.nova-premier-v1:0` | [Nova Premier](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-premier.html) supports `amazon.nova-premier-v1:0` and a US geo inference ID; AWS does not list a global inference ID for this model. |
+
+Prefer geo or global inference profile IDs when your AWS account and residency policy allow them. They let Bedrock route within the selected geography or globally for higher throughput. Use in-region base model IDs when data residency requires one specific Region.
+
+## Claude Example
+
+Claude routes are detected by `upstream_model` values containing `anthropic.claude`. Non-streaming Chat Completions requests are sent to Bedrock Runtime `InvokeModel` with Anthropic Messages fields, including `anthropic_version: bedrock-2023-05-31`.
+
+```yaml
+models:
+  - id: claude-opus-bedrock
+    description: Claude Opus on AWS Bedrock
+    tags: [bedrock, claude, reasoning]
+    routes:
+      - provider: bedrock-us-east-1
+        upstream_model: global.anthropic.claude-opus-4-7
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: true
+          vision: true
+          json_schema: false
+```
+
+Native Claude invocation requires callers to set `max_tokens` or `max_completion_tokens`. Bedrock-hosted Claude vision is limited to base64 image payloads in this gateway slice; remote image URLs are rejected before the provider call.
+
+## Amazon Nova Example
+
+Amazon Nova routes use the generic Bedrock Converse request shape.
+
+```yaml
+models:
+  - id: nova-lite-bedrock
+    description: Amazon Nova 2 Lite on AWS Bedrock
+    tags: [bedrock, nova, multimodal]
+    routes:
+      - provider: bedrock-us-east-1
+        upstream_model: global.amazon.nova-2-lite-v1:0
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: true
+          vision: false
+          json_schema: false
+
+  - id: nova-premier-bedrock
+    description: Amazon Nova Premier on AWS Bedrock
+    tags: [bedrock, nova, reasoning]
+    routes:
+      - provider: bedrock-us-east-1
+        upstream_model: us.amazon.nova-premier-v1:0
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: true
+          vision: false
+          json_schema: false
+```
+
+Keep `vision: false` unless the route has been tested with the exact public request shape you plan to support. Bedrock model cards can list multimodal support even when the gateway adapter has not normalized that modality for the public OpenAI-shaped request.
+
+## Fallback Across Providers
+
+Route priority and weight can put Bedrock behind another provider while keeping a stable gateway model id.
+
+```yaml
+models:
+  - id: coding-default
+    description: Stable model alias for coding workloads
+    tags: [coding]
+    routes:
+      - provider: openai-prod
+        upstream_model: gpt-5
+        priority: 10
+        weight: 1.0
+      - provider: bedrock-us-east-1
+        upstream_model: global.anthropic.claude-opus-4-7
+        priority: 20
+        weight: 1.0
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: true
+          vision: true
+          json_schema: false
+```
+
+The current runtime executes one selected route. Priority and weight affect route planning, not live retry after an upstream error.
+
+## Operational Notes
+
+- Set `responses: false` and `embeddings: false` on Bedrock routes until those API families exist in the provider adapter.
+- Keep `json_schema: false` unless a specific Bedrock route has explicit provider-specific overrides and tests.
+- Use `extra_body` only for additive Bedrock or Anthropic fields you have tested for the exact model family.
+- Check the model card before adding a new `upstream_model`; Bedrock model IDs and inference profile support differ by model and Region.
+- Production IAM role or temporary credential support should wait for SigV4 request signing in the provider adapter.

--- a/docs/providers/aws-bedrock.md
+++ b/docs/providers/aws-bedrock.md
@@ -13,7 +13,9 @@ The gateway uses the Bedrock Runtime endpoint shape:
 - streaming chat uses Bedrock `ConverseStream` and is normalized into OpenAI-compatible chat-completion chunks
 - `/v1/responses` and `/v1/embeddings` are not implemented for `aws_bedrock` routes
 
-The runnable auth mode in the current provider adapter is bearer-token auth. AWS documents `AWS_BEARER_TOKEN_BEDROCK` as the environment variable recognized by Bedrock API-key auth and direct HTTP calls can pass the same value as `Authorization: Bearer ...`: [Use an Amazon Bedrock API key](https://docs.aws.amazon.com/en_us/bedrock/latest/userguide/api-keys-use.html). The config validator rejects `default_chain` and `static_credentials` until IAM/SigV4 request signing exists. Use bearer auth for working local and development examples.
+The provider adapter supports bearer-token auth and IAM SigV4 request signing. AWS documents `AWS_BEARER_TOKEN_BEDROCK` as the environment variable recognized by Bedrock API-key auth and direct HTTP calls can pass the same value as `Authorization: Bearer ...`: [Use an Amazon Bedrock API key](https://docs.aws.amazon.com/en_us/bedrock/latest/userguide/api-keys-use.html).
+
+For IAM auth, `auth.mode: default_chain` uses the AWS SDK default credential provider chain. In EKS, IRSA works through that chain when the pod environment includes `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and optional `AWS_ROLE_SESSION_NAME`; earlier sources in the default chain can still win, matching AWS SDK behavior. `auth.mode: static_credentials` signs with the configured access key, secret key, and optional session token.
 
 ## Provider
 
@@ -31,6 +33,26 @@ providers:
 ```
 
 `endpoint_url` is optional. When omitted, the gateway uses `https://bedrock-runtime.{region}.amazonaws.com`.
+
+IAM examples:
+
+```yaml
+providers:
+  - id: bedrock-irsa
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: default_chain
+
+  - id: bedrock-static
+    type: aws_bedrock
+    region: us-east-1
+    auth:
+      mode: static_credentials
+      access_key_id: env.AWS_ACCESS_KEY_ID
+      secret_access_key: env.AWS_SECRET_ACCESS_KEY
+      session_token: env.AWS_SESSION_TOKEN
+```
 
 ## Model Identity
 
@@ -148,7 +170,7 @@ The current runtime executes one selected route. Priority and weight affect rout
 - Keep `json_schema: false` unless a specific Bedrock route has explicit provider-specific overrides and tests.
 - Use `extra_body` only for additive Bedrock or Anthropic fields you have tested for the exact model family.
 - Check the model card before adding a new `upstream_model`; Bedrock model IDs and inference profile support differ by model and Region.
-- Production IAM role or temporary credential support should wait for SigV4 request signing in the provider adapter.
+- Prefer `default_chain` for production IAM roles and IRSA. Use `static_credentials` only for constrained local or controlled deployment cases where credential rotation is handled outside the gateway.
 
 ## Validation
 

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -35,7 +35,7 @@ This matrix is about current execution support, not provider marketing claims.
 | `openai_compat` | Supported. Chat Completions route profiles can rewrite known request-shape quirks. | Supported through the distinct Responses request/provider path. Chat Completions profile transforms do not apply. | Supported. No route compatibility transforms apply in this slice. |
 | `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Not implemented in this slice; keep route `embeddings: false`. |
 | `gcp_vertex` with `anthropic/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Not applicable. |
-| `aws_bedrock` | Supported for non-streaming Bedrock Converse when route capabilities allow it. Keep route `stream: false` until EventStream support lands. | Not implemented; keep route `responses: false`. | Not implemented; keep route `embeddings: false`. |
+| `aws_bedrock` | Supported for Bedrock Converse chat. Anthropic Claude upstream model IDs use Bedrock `InvokeModel` with the native Anthropic Messages payload for non-streaming Chat Completions. Streaming chat uses ConverseStream and normalizes AWS Smithy/EventStream frames into OpenAI-compatible SSE; it is not native Anthropic Messages streaming. | Not implemented; keep route `responses: false`. | Not implemented; keep route `embeddings: false`. |
 
 Route capability flags are still useful when a provider implementation does not support a public API family. They make failures happen at the gateway edge instead of later inside the provider adapter.
 
@@ -76,7 +76,27 @@ Effective capability is the intersection of configured route metadata and provid
 
 For example, a Vertex Google chat route should normally set `responses: false` and `embeddings: false` until those provider paths are implemented. Otherwise the route may look viable from config alone and still fail when the provider adapter rejects the unsupported API family.
 
-For Bedrock, this foundation guarantees config load, validation, seeding, registration, deterministic region, endpoint, timeout, display, auth metadata, and non-streaming Converse chat execution for bearer-token auth. Bedrock `upstream_model` values should match Bedrock Runtime model identity: base model IDs, inference profile IDs, or Bedrock ARNs accepted by the target Bedrock Runtime operation. AWS documents `InvokeModel` as requiring `bedrock:InvokeModel`; streamed invocation and Converse access require the corresponding Bedrock runtime permissions. IAM/SigV4 signing and EventStream chat streaming remain follow-up work.
+For Bedrock, this foundation guarantees config load, validation, seeding, registration, deterministic region, endpoint, timeout, display, auth metadata, Converse chat execution, Claude Messages invocation, and ConverseStream chat streaming for bearer-token auth. Bedrock `upstream_model` values should match Bedrock Runtime model identity: base model IDs, inference profile IDs, or Bedrock ARNs accepted by the target Bedrock Runtime operation. AWS documents `InvokeModel` as requiring `bedrock:InvokeModel`; streamed invocation and Converse access require the corresponding Bedrock runtime permissions. IAM/SigV4 signing remains follow-up work.
+
+## AWS Bedrock Anthropic Claude
+
+Bedrock-hosted Claude models are selected when the Bedrock `upstream_model` contains `anthropic.claude`, including regional inference profile IDs such as `us.anthropic.claude-3-5-sonnet-20241022-v2:0`. Non-streaming Chat Completions for those routes use Bedrock Runtime `InvokeModel` (`/model/{modelId}/invoke`) with Anthropic's native Messages body instead of the generic Converse body.
+
+The native Bedrock Anthropic body always includes:
+
+- `anthropic_version: bedrock-2023-05-31`
+- combined `system` and `developer` text as Anthropic `system`
+- `messages` with Anthropic `text`, `image`, `tool_use`, and `tool_result` content blocks
+- `max_tokens` from `max_tokens` or `max_completion_tokens`
+- `temperature`, `top_p`, `top_k`, and `stop_sequences`
+- function tools as Anthropic custom tools with `input_schema`
+- `tool_choice` mapped from OpenAI `auto`, `required`, and named function choices
+
+The implementation rejects missing `max_tokens` for native Claude invocation because Bedrock marks it required. It also rejects OpenAI-only controls such as penalties, `n`, `seed`, `parallel_tool_calls`, and `response_format`. JSON schema mode should stay disabled in route capabilities unless a route explicitly uses Bedrock/Anthropic-specific `output_config` through provider overrides and accepts the non-OpenAI contract. Thinking and beta features are pass-through provider fields (`thinking`, `output_config`, `anthropic_beta`, `context_management`) rather than normalized OpenAI fields in this slice.
+
+Vision is supported only for Bedrock-compatible base64 image payloads. Remote image URLs are rejected because Bedrock Anthropic Messages requires base64 image sources. Tools and tool-result turns are supported for Claude 3+ models, subject to the model's Bedrock feature availability.
+
+Streaming boundary: native Anthropic Messages streaming over `InvokeModelWithResponseStream` is not part of this issue. If a Bedrock route enables streaming, it is using the generic Bedrock Converse stream adapter from [issue #128](https://github.com/ahstn/oceans-llm/issues/128), not the native Anthropic Messages stream event contract.
 
 ## OpenAI-Compatible Profile Fields
 
@@ -122,6 +142,10 @@ This is intentionally narrower than full tool-call streaming normalization. Tool
 
 The Responses stream adapter is separate. It parses SSE frames for transport safety, preserves `event: response.*` names and JSON payloads, surfaces malformed or incomplete streams as structured SSE error chunks, and appends one final `data: [DONE]` only after a successful upstream stream that omitted it.
 
+Bedrock chat streaming is a separate transport adapter because Bedrock Runtime does not return SSE for ConverseStream. It decodes AWS Smithy/EventStream frames, reads string headers such as `:message-type`, `:event-type`, and `:exception-type`, and normalizes ConverseStream events into Chat Completions SSE chunks. `messageStart` emits the assistant role, `contentBlockDelta` emits text or function-tool argument deltas, `messageStop` emits the terminal finish reason, and `metadata.usage` emits an OpenAI-shaped usage chunk when present. EventStream exception frames and malformed or incomplete frames emit structured SSE error chunks and do not receive a final `[DONE]`.
+
+The current Bedrock frame parser validates frame lengths, header boundaries, supported header encodings, JSON payload shape, and clean finalization. It recognizes the prelude CRC and message CRC fields but does not validate CRC checksums in this slice. Provider-native `InvokeModelWithResponseStream` mappings, including Anthropic-specific native streaming payloads, remain separate provider-family work.
+
 ## Accounting Boundary
 
 Compatibility profiles can make usage more likely to appear in a standard place, but they do not change accounting semantics.
@@ -155,5 +179,5 @@ These items are intentionally outside this first slice:
 - cache, reasoning, and modality token accounting: [issue #92](https://github.com/ahstn/oceans-llm/issues/92)
 - multimodal image/file compatibility across provider families: [issue #93](https://github.com/ahstn/oceans-llm/issues/93)
 - Vertex embeddings provider support: [issue #103](https://github.com/ahstn/oceans-llm/issues/103)
-- Bedrock EventStream chat streaming: [issue #128](https://github.com/ahstn/oceans-llm/issues/128)
+- Bedrock native InvokeModel provider-family streaming mappings: [issue #129](https://github.com/ahstn/oceans-llm/issues/129)
 - route readiness diagnostics: [issue #98](https://github.com/ahstn/oceans-llm/issues/98)

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -35,6 +35,7 @@ This matrix is about current execution support, not provider marketing claims.
 | `openai_compat` | Supported. Chat Completions route profiles can rewrite known request-shape quirks. | Supported through the distinct Responses request/provider path. Chat Completions profile transforms do not apply. | Supported. No route compatibility transforms apply in this slice. |
 | `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Not implemented in this slice; keep route `embeddings: false`. |
 | `gcp_vertex` with `anthropic/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Not applicable. |
+| `aws_bedrock` | Supported for non-streaming Bedrock Converse when route capabilities allow it. Keep route `stream: false` until EventStream support lands. | Not implemented; keep route `responses: false`. | Not implemented; keep route `embeddings: false`. |
 
 Route capability flags are still useful when a provider implementation does not support a public API family. They make failures happen at the gateway edge instead of later inside the provider adapter.
 
@@ -74,6 +75,8 @@ Effective capability is the intersection of configured route metadata and provid
 - Capability defaults are permissive, so routes for partial providers should set unsupported API families to `false`.
 
 For example, a Vertex Google chat route should normally set `responses: false` and `embeddings: false` until those provider paths are implemented. Otherwise the route may look viable from config alone and still fail when the provider adapter rejects the unsupported API family.
+
+For Bedrock, this foundation guarantees config load, validation, seeding, registration, deterministic region, endpoint, timeout, display, auth metadata, and non-streaming Converse chat execution for bearer-token auth. Bedrock `upstream_model` values should match Bedrock Runtime model identity: base model IDs, inference profile IDs, or Bedrock ARNs accepted by the target Bedrock Runtime operation. AWS documents `InvokeModel` as requiring `bedrock:InvokeModel`; streamed invocation and Converse access require the corresponding Bedrock runtime permissions. IAM/SigV4 signing and EventStream chat streaming remain follow-up work.
 
 ## OpenAI-Compatible Profile Fields
 
@@ -152,4 +155,5 @@ These items are intentionally outside this first slice:
 - cache, reasoning, and modality token accounting: [issue #92](https://github.com/ahstn/oceans-llm/issues/92)
 - multimodal image/file compatibility across provider families: [issue #93](https://github.com/ahstn/oceans-llm/issues/93)
 - Vertex embeddings provider support: [issue #103](https://github.com/ahstn/oceans-llm/issues/103)
+- Bedrock EventStream chat streaming: [issue #128](https://github.com/ahstn/oceans-llm/issues/128)
 - route readiness diagnostics: [issue #98](https://github.com/ahstn/oceans-llm/issues/98)

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -76,7 +76,7 @@ Effective capability is the intersection of configured route metadata and provid
 
 For example, a Vertex Google chat route should normally set `responses: false` and `embeddings: false` until those provider paths are implemented. Otherwise the route may look viable from config alone and still fail when the provider adapter rejects the unsupported API family.
 
-For Bedrock, this foundation guarantees config load, validation, seeding, registration, deterministic region, endpoint, timeout, display, auth metadata, Converse chat execution, Claude Messages invocation, and ConverseStream chat streaming for bearer-token auth. Bedrock `upstream_model` values should match Bedrock Runtime model identity: base model IDs, inference profile IDs, or Bedrock ARNs accepted by the target Bedrock Runtime operation. AWS documents `InvokeModel` as requiring `bedrock:InvokeModel`; streamed invocation and Converse access require the corresponding Bedrock runtime permissions. IAM/SigV4 signing remains follow-up work.
+For Bedrock, this foundation guarantees config load, validation, seeding, registration, deterministic region, endpoint, timeout, display, auth metadata, Converse chat execution, Claude Messages invocation, and ConverseStream chat streaming for bearer-token auth. It also supports IAM/SigV4 signing for the `default_chain` and `static_credentials` auth modes. Bedrock `upstream_model` values should match Bedrock Runtime model identity: base model IDs, inference profile IDs, or Bedrock ARNs accepted by the target Bedrock Runtime operation. AWS documents `InvokeModel` as requiring `bedrock:InvokeModel`; streamed invocation and Converse access require the corresponding Bedrock runtime permissions.
 
 ## AWS Bedrock Anthropic Claude
 

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -159,7 +159,7 @@ That separation matters in two common cases:
 - a request can be logged even when it becomes `unpriced`
 - a request can be logged even when a later accounting step hits a rough edge
 
-For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure. Chat Completions streams usually expose usage at top level. Responses streams expose usage on completed response events as `response.usage`. Stored stream events can be capped by payload policy without weakening usage or provider-error parsing.
+For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure. Chat Completions streams usually expose usage at top level. Responses streams expose usage on completed response events as `response.usage`. Bedrock ConverseStream is normalized before it reaches this logging path: the provider adapter decodes AWS EventStream frames, emits OpenAI-compatible SSE chunks, maps metadata usage into a usage chunk, and turns EventStream exceptions or malformed frames into structured SSE error chunks. Stored stream events can be capped by payload policy without weakening usage or provider-error parsing.
 
 ## Known Rough Edges
 


### PR DESCRIPTION
## Description

Adds AWS Bedrock chat support beyond the initial provider foundation.

- Summary of changes
  - Add Bedrock ConverseStream decoding and OpenAI-compatible streaming normalization.
  - Add native Anthropic Claude Messages invocation through Bedrock InvokeModel for non-streaming chat completions.
  - Add Bedrock-focused provider documentation with current model configuration examples.
- Why this approach was chosen
  - Bedrock ConverseStream returns AWS Smithy/EventStream frames rather than SSE, so the provider adapter owns transport normalization before gateway logging sees the stream.
  - Bedrock-hosted Claude models have a native Anthropic Messages request/response contract, so non-streaming Claude routes use InvokeModel instead of forcing the generic Converse shape.
- How it works
  - Bedrock chat streaming posts to `/converse-stream`, decodes EventStream frames, maps Converse events into chat-completion chunks, and emits structured SSE errors for malformed frames or upstream exceptions.
  - Claude routes are detected from `anthropic.claude` upstream model IDs and mapped to Anthropic Messages payloads with `anthropic_version: bedrock-2023-05-31`.
  - Provider docs live under `docs/providers/aws-bedrock.md` and are linked from the VitePress sidebar.
- Risks, tradeoffs, and alternatives considered
  - EventStream CRC fields are recognized but not validated in this slice.
  - IAM/SigV4 auth remains follow-up work; bearer token auth is the runnable path.
  - Native Anthropic InvokeModelWithResponseStream is still distinct follow-up work; streaming currently uses the generic ConverseStream adapter.
- Additional context for reviewers
  - This PR covers issues #126, #127, #128, and #129 scoped to Bedrock chat, streaming, Claude Messages, and provider docs.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Postgres-specific checks were not run because this change does not touch store, migration, or release behavior.
