### PR TITLE
feat(providers): add claude thinking compatibility

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -2,8 +2,12 @@ name: helm-ci
 
 on:
   pull_request:
+    paths:
+      - "deploy/helm/oceans-llm/**"
   push:
     branches: ["main"]
+    paths:
+      - "deploy/helm/oceans-llm/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -530,6 +530,16 @@ fn map_chat_request_to_converse(
     if let Some(additional) = passthrough.remove("additional_model_request_fields") {
         body.insert("additionalModelRequestFields".to_string(), additional);
     }
+    apply_converse_anthropic_thinking_compatibility(
+        &mut body,
+        &mut passthrough,
+        &context.upstream_model,
+    )?;
+    validate_converse_anthropic_sampling_fields(
+        &mut body,
+        &mut passthrough,
+        &context.upstream_model,
+    )?;
 
     reject_openai_only_fields(&passthrough)?;
     reject_unknown_converse_fields(&passthrough)?;
@@ -621,8 +631,10 @@ fn map_chat_request_to_anthropic_messages(
         body.extend(tools);
     }
     extract_anthropic_passthrough_fields(&mut body, &mut passthrough);
+    apply_anthropic_thinking_compatibility(&mut body, &mut passthrough, &context.upstream_model)?;
     reject_openai_only_fields(&passthrough)?;
     reject_unknown_anthropic_messages_fields(&passthrough)?;
+    validate_anthropic_sampling_fields(&mut body, &context.upstream_model)?;
 
     merge_object_overrides(&mut body, &context.extra_body);
     if !body.contains_key("max_tokens") {
@@ -1487,6 +1499,595 @@ fn extract_anthropic_passthrough_fields(
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudeThinkingPolicy {
+    AdaptiveOnly,
+    AdaptivePreferred,
+    ManualWithEffortBeta,
+    ManualOnly,
+    MythosPreview,
+}
+
+fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPolicy {
+    let model = upstream_model.to_ascii_lowercase();
+    if model.contains("claude-mythos-preview") {
+        ClaudeThinkingPolicy::MythosPreview
+    } else if is_opus_4_7_or_later(&model) {
+        ClaudeThinkingPolicy::AdaptiveOnly
+    } else if model.contains("claude-opus-4-6") || model.contains("claude-sonnet-4-6") {
+        ClaudeThinkingPolicy::AdaptivePreferred
+    } else if model.contains("claude-opus-4-5") {
+        ClaudeThinkingPolicy::ManualWithEffortBeta
+    } else {
+        ClaudeThinkingPolicy::ManualOnly
+    }
+}
+
+fn is_opus_4_7_or_later(model: &str) -> bool {
+    let Some(rest) = model.split("claude-opus-4-").nth(1) else {
+        return false;
+    };
+    rest.split(|ch: char| !ch.is_ascii_digit())
+        .next()
+        .and_then(|minor| minor.parse::<u16>().ok())
+        .is_some_and(|minor| minor >= 7)
+}
+
+fn apply_anthropic_thinking_compatibility(
+    body: &mut Map<String, Value>,
+    extra: &mut BTreeMap<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    let effort = extract_anthropic_reasoning_effort(extra)?;
+    let budget_tokens = extract_anthropic_reasoning_budget_tokens(extra);
+    let policy = claude_thinking_policy(upstream_model);
+
+    validate_caller_thinking_for_policy(body, policy, upstream_model)?;
+
+    if let Some(effort) = effort {
+        match policy {
+            ClaudeThinkingPolicy::AdaptiveOnly
+            | ClaudeThinkingPolicy::AdaptivePreferred
+            | ClaudeThinkingPolicy::MythosPreview => {
+                ensure_anthropic_adaptive_thinking(body, upstream_model)?;
+                merge_anthropic_output_effort(body, effort, upstream_model)?;
+            }
+            ClaudeThinkingPolicy::ManualWithEffortBeta => {
+                if let Some(budget_tokens) =
+                    budget_tokens.or_else(|| existing_manual_thinking_budget(body))
+                {
+                    ensure_anthropic_manual_thinking(body, budget_tokens, upstream_model)?;
+                }
+                merge_anthropic_output_effort(body, effort, upstream_model)?;
+                ensure_anthropic_beta(body, "effort-2025-11-24")?;
+            }
+            ClaudeThinkingPolicy::ManualOnly => {
+                let budget_tokens = budget_tokens
+                    .or_else(|| existing_manual_thinking_budget(body))
+                    .ok_or_else(|| {
+                    ProviderError::InvalidRequest(format!(
+                        "`reasoning_effort` requires an explicit manual thinking budget for `{upstream_model}` because this Claude model does not support adaptive thinking"
+                    ))
+                })?;
+                ensure_anthropic_manual_thinking(body, budget_tokens, upstream_model)?;
+            }
+        }
+    } else if let Some(budget_tokens) = budget_tokens {
+        match policy {
+            ClaudeThinkingPolicy::AdaptiveOnly => {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`reasoning.budget_tokens` is not supported for `{upstream_model}`; use adaptive thinking with `reasoning_effort` or `output_config.effort`"
+                )));
+            }
+            ClaudeThinkingPolicy::AdaptivePreferred
+            | ClaudeThinkingPolicy::ManualWithEffortBeta
+            | ClaudeThinkingPolicy::ManualOnly
+            | ClaudeThinkingPolicy::MythosPreview => {
+                ensure_anthropic_manual_thinking(body, budget_tokens, upstream_model)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_anthropic_reasoning_effort(
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<Option<Value>, ProviderError> {
+    let reasoning_effort = extra.remove("reasoning_effort");
+    let reasoning = extra.remove("reasoning");
+
+    match (reasoning_effort, reasoning) {
+        (Some(effort), None) => Ok(Some(effort)),
+        (None, Some(Value::Object(mut reasoning))) => {
+            if let Some(budget_tokens) = reasoning.remove("budget_tokens") {
+                extra.insert("reasoning_budget_tokens".to_string(), budget_tokens);
+            }
+            Ok(reasoning.remove("effort"))
+        }
+        (Some(effort), Some(Value::Object(mut reasoning))) => {
+            if let Some(reasoning_effort) = reasoning.remove("effort")
+                && reasoning_effort != effort
+            {
+                return Err(ProviderError::InvalidRequest(
+                    "`reasoning_effort` conflicts with `reasoning.effort` for Anthropic Claude mapping"
+                        .to_string(),
+                ));
+            }
+            if let Some(budget_tokens) = reasoning.remove("budget_tokens") {
+                extra.insert("reasoning_budget_tokens".to_string(), budget_tokens);
+            }
+            Ok(Some(effort))
+        }
+        (None, Some(Value::Null)) => Ok(None),
+        (Some(effort), Some(Value::Null)) => Ok(Some(effort)),
+        (_, Some(_)) => Err(ProviderError::InvalidRequest(
+            "`reasoning` must be an object for Anthropic Claude mapping".to_string(),
+        )),
+        (None, None) => Ok(None),
+    }
+}
+
+fn extract_anthropic_reasoning_budget_tokens(extra: &mut BTreeMap<String, Value>) -> Option<Value> {
+    if let Some(value) = extra.remove("thinking_budget_tokens") {
+        return Some(value);
+    }
+    if let Some(value) = extra.remove("reasoning_budget_tokens") {
+        return Some(value);
+    }
+    None
+}
+
+fn validate_caller_thinking_for_policy(
+    body: &Map<String, Value>,
+    policy: ClaudeThinkingPolicy,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    let Some(thinking) = body.get("thinking") else {
+        return Ok(());
+    };
+    let thinking_type = thinking
+        .as_object()
+        .and_then(|object| object.get("type"))
+        .and_then(Value::as_str);
+
+    match policy {
+        ClaudeThinkingPolicy::AdaptiveOnly => {
+            if thinking_type == Some("enabled") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: enabled` with manual `budget_tokens` is not supported for `{upstream_model}`; use `thinking.type: adaptive` and `output_config.effort`"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::ManualOnly => {
+            if thinking_type == Some("adaptive") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: adaptive` is not supported for `{upstream_model}`; use `thinking.type: enabled` with `budget_tokens`"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::ManualWithEffortBeta => {
+            if thinking_type == Some("adaptive") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: adaptive` is not supported for `{upstream_model}`; use `thinking.type: enabled` with `budget_tokens`"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::MythosPreview => {
+            if thinking_type == Some("disabled") {
+                return Err(ProviderError::InvalidRequest(
+                    "`thinking.type: disabled` is not supported for Claude Mythos Preview"
+                        .to_string(),
+                ));
+            }
+        }
+        ClaudeThinkingPolicy::AdaptivePreferred => {}
+    }
+
+    Ok(())
+}
+
+fn ensure_anthropic_adaptive_thinking(
+    body: &mut Map<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    match body.get("thinking") {
+        None => {
+            body.insert("thinking".to_string(), json!({ "type": "adaptive" }));
+            Ok(())
+        }
+        Some(Value::Object(object))
+            if object.get("type").and_then(Value::as_str) == Some("adaptive") =>
+        {
+            Ok(())
+        }
+        Some(_) => Err(ProviderError::InvalidRequest(format!(
+            "`reasoning_effort` requires `thinking.type: adaptive` for `{upstream_model}` and conflicts with caller-supplied `thinking`"
+        ))),
+    }
+}
+
+fn ensure_anthropic_manual_thinking(
+    body: &mut Map<String, Value>,
+    budget_tokens: Value,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    match body.get("thinking") {
+        None => {
+            body.insert(
+                "thinking".to_string(),
+                json!({ "type": "enabled", "budget_tokens": budget_tokens }),
+            );
+            Ok(())
+        }
+        Some(Value::Object(object))
+            if object.get("type").and_then(Value::as_str) == Some("enabled") =>
+        {
+            match object.get("budget_tokens") {
+                Some(existing) if existing == &budget_tokens => Ok(()),
+                Some(_) => Err(ProviderError::InvalidRequest(format!(
+                    "manual Anthropic thinking budget for `{upstream_model}` conflicts with caller-supplied `thinking.budget_tokens`"
+                ))),
+                None => Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: enabled` for `{upstream_model}` must include `budget_tokens`"
+                ))),
+            }
+        }
+        Some(_) => Err(ProviderError::InvalidRequest(format!(
+            "manual Anthropic thinking budget for `{upstream_model}` conflicts with caller-supplied `thinking`"
+        ))),
+    }
+}
+
+fn existing_manual_thinking_budget(body: &Map<String, Value>) -> Option<Value> {
+    let thinking = body.get("thinking")?.as_object()?;
+    if thinking.get("type").and_then(Value::as_str) == Some("enabled") {
+        thinking.get("budget_tokens").cloned()
+    } else {
+        None
+    }
+}
+
+fn merge_anthropic_output_effort(
+    body: &mut Map<String, Value>,
+    effort: Value,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    match body.get_mut("output_config") {
+        None => {
+            body.insert("output_config".to_string(), json!({ "effort": effort }));
+            Ok(())
+        }
+        Some(Value::Object(output_config)) => match output_config.get("effort") {
+            Some(existing) if existing != &effort => Err(ProviderError::InvalidRequest(format!(
+                "`reasoning_effort` conflicts with `output_config.effort` for `{upstream_model}`"
+            ))),
+            Some(_) => Ok(()),
+            None => {
+                output_config.insert("effort".to_string(), effort);
+                Ok(())
+            }
+        },
+        Some(_) => Err(ProviderError::InvalidRequest(
+            "`output_config` must be an object for Anthropic Claude mapping".to_string(),
+        )),
+    }
+}
+
+fn validate_anthropic_sampling_fields(
+    body: &mut Map<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    if claude_thinking_policy(upstream_model) != ClaudeThinkingPolicy::AdaptiveOnly {
+        return Ok(());
+    }
+
+    for field in ["temperature", "top_p", "top_k"] {
+        let Some(value) = body.get(field) else {
+            continue;
+        };
+        if value.is_null() || is_default_anthropic_sampling_value(field, value) {
+            body.remove(field);
+            continue;
+        }
+        return Err(ProviderError::InvalidRequest(format!(
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+        )));
+    }
+
+    Ok(())
+}
+
+fn is_default_anthropic_sampling_value(field: &str, value: &Value) -> bool {
+    match field {
+        "temperature" | "top_p" => value
+            .as_f64()
+            .is_some_and(|number| (number - 1.0).abs() < f64::EPSILON),
+        "top_k" => false,
+        _ => false,
+    }
+}
+
+fn apply_converse_anthropic_thinking_compatibility(
+    body: &mut Map<String, Value>,
+    extra: &mut BTreeMap<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    if !is_anthropic_claude_model(upstream_model) {
+        return Ok(());
+    }
+
+    let effort = extract_anthropic_reasoning_effort(extra)?;
+    let budget_tokens = extract_anthropic_reasoning_budget_tokens(extra);
+    let policy = claude_thinking_policy(upstream_model);
+
+    if effort.is_none() && budget_tokens.is_none() {
+        validate_converse_caller_thinking_for_policy(body, policy, upstream_model)?;
+        return Ok(());
+    }
+
+    let additional = ensure_additional_model_request_fields(body)?;
+    validate_converse_caller_thinking_for_policy_object(additional, policy, upstream_model)?;
+
+    if let Some(effort) = effort {
+        match policy {
+            ClaudeThinkingPolicy::AdaptiveOnly
+            | ClaudeThinkingPolicy::AdaptivePreferred
+            | ClaudeThinkingPolicy::MythosPreview => {
+                merge_converse_thinking_field(
+                    additional,
+                    "type",
+                    json!("adaptive"),
+                    upstream_model,
+                )?;
+                merge_converse_thinking_field(additional, "effort", effort, upstream_model)?;
+            }
+            ClaudeThinkingPolicy::ManualWithEffortBeta => {
+                if let Some(budget_tokens) = budget_tokens {
+                    merge_converse_thinking_field(
+                        additional,
+                        "type",
+                        json!("enabled"),
+                        upstream_model,
+                    )?;
+                    merge_converse_thinking_field(
+                        additional,
+                        "budget_tokens",
+                        budget_tokens,
+                        upstream_model,
+                    )?;
+                }
+                merge_converse_thinking_field(additional, "effort", effort, upstream_model)?;
+            }
+            ClaudeThinkingPolicy::ManualOnly => {
+                let budget_tokens = budget_tokens
+                    .or_else(|| existing_converse_manual_thinking_budget(additional))
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(format!(
+                            "`reasoning_effort` requires an explicit manual thinking budget for `{upstream_model}` because this Claude model does not support adaptive thinking or Bedrock effort"
+                        ))
+                    })?;
+                merge_converse_thinking_field(
+                    additional,
+                    "type",
+                    json!("enabled"),
+                    upstream_model,
+                )?;
+                merge_converse_thinking_field(
+                    additional,
+                    "budget_tokens",
+                    budget_tokens,
+                    upstream_model,
+                )?;
+            }
+        }
+    } else if let Some(budget_tokens) = budget_tokens {
+        match policy {
+            ClaudeThinkingPolicy::AdaptiveOnly => {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`reasoning.budget_tokens` is not supported for `{upstream_model}`; use adaptive thinking with `reasoning_effort`"
+                )));
+            }
+            ClaudeThinkingPolicy::AdaptivePreferred
+            | ClaudeThinkingPolicy::ManualWithEffortBeta
+            | ClaudeThinkingPolicy::ManualOnly
+            | ClaudeThinkingPolicy::MythosPreview => {
+                merge_converse_thinking_field(
+                    additional,
+                    "type",
+                    json!("enabled"),
+                    upstream_model,
+                )?;
+                merge_converse_thinking_field(
+                    additional,
+                    "budget_tokens",
+                    budget_tokens,
+                    upstream_model,
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_additional_model_request_fields(
+    body: &mut Map<String, Value>,
+) -> Result<&mut Map<String, Value>, ProviderError> {
+    if !body.contains_key("additionalModelRequestFields") {
+        body.insert(
+            "additionalModelRequestFields".to_string(),
+            Value::Object(Map::new()),
+        );
+    }
+    body.get_mut("additionalModelRequestFields")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "`additionalModelRequestFields` must be an object for aws_bedrock Converse"
+                    .to_string(),
+            )
+        })
+}
+
+fn validate_converse_caller_thinking_for_policy(
+    body: &Map<String, Value>,
+    policy: ClaudeThinkingPolicy,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    let Some(additional) = body
+        .get("additionalModelRequestFields")
+        .and_then(Value::as_object)
+    else {
+        return Ok(());
+    };
+    validate_converse_caller_thinking_for_policy_object(additional, policy, upstream_model)
+}
+
+fn validate_converse_caller_thinking_for_policy_object(
+    additional: &Map<String, Value>,
+    policy: ClaudeThinkingPolicy,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    let Some(thinking) = additional.get("thinking") else {
+        return Ok(());
+    };
+    let thinking_type = thinking
+        .as_object()
+        .and_then(|object| object.get("type"))
+        .and_then(Value::as_str);
+
+    match policy {
+        ClaudeThinkingPolicy::AdaptiveOnly => {
+            if thinking_type == Some("enabled") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`additionalModelRequestFields.thinking.type: enabled` is not supported for `{upstream_model}`; use adaptive thinking"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::ManualOnly | ClaudeThinkingPolicy::ManualWithEffortBeta => {
+            if thinking_type == Some("adaptive") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`additionalModelRequestFields.thinking.type: adaptive` is not supported for `{upstream_model}`; use manual `budget_tokens`"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::MythosPreview => {
+            if thinking_type == Some("disabled") {
+                return Err(ProviderError::InvalidRequest(
+                    "`additionalModelRequestFields.thinking.type: disabled` is not supported for Claude Mythos Preview"
+                        .to_string(),
+                ));
+            }
+        }
+        ClaudeThinkingPolicy::AdaptivePreferred => {}
+    }
+    Ok(())
+}
+
+fn merge_converse_thinking_field(
+    additional: &mut Map<String, Value>,
+    field: &str,
+    value: Value,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    if !additional.contains_key("thinking") {
+        additional.insert("thinking".to_string(), Value::Object(Map::new()));
+    }
+    let thinking = additional
+        .get_mut("thinking")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "`additionalModelRequestFields.thinking` must be an object for aws_bedrock Converse"
+                    .to_string(),
+            )
+        })?;
+
+    match thinking.get(field) {
+        Some(existing) if existing != &value => Err(ProviderError::InvalidRequest(format!(
+            "`reasoning_effort` conflicts with `additionalModelRequestFields.thinking.{field}` for `{upstream_model}`"
+        ))),
+        Some(_) => Ok(()),
+        None => {
+            thinking.insert(field.to_string(), value);
+            Ok(())
+        }
+    }
+}
+
+fn existing_converse_manual_thinking_budget(additional: &Map<String, Value>) -> Option<Value> {
+    let thinking = additional.get("thinking")?.as_object()?;
+    if thinking.get("type").and_then(Value::as_str) == Some("enabled") {
+        thinking.get("budget_tokens").cloned()
+    } else {
+        None
+    }
+}
+
+fn validate_converse_anthropic_sampling_fields(
+    body: &mut Map<String, Value>,
+    extra: &mut BTreeMap<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    if !is_anthropic_claude_model(upstream_model)
+        || claude_thinking_policy(upstream_model) != ClaudeThinkingPolicy::AdaptiveOnly
+    {
+        return Ok(());
+    }
+
+    let Some(inference_config) = body
+        .get_mut("inferenceConfig")
+        .and_then(Value::as_object_mut)
+    else {
+        return Ok(());
+    };
+    for (field, bedrock_field) in [("temperature", "temperature"), ("top_p", "topP")] {
+        let Some(value) = inference_config.get(bedrock_field) else {
+            continue;
+        };
+        if value.is_null() || is_default_anthropic_sampling_value(field, value) {
+            inference_config.remove(bedrock_field);
+            continue;
+        }
+        return Err(ProviderError::InvalidRequest(format!(
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+        )));
+    }
+    if inference_config.is_empty() {
+        body.remove("inferenceConfig");
+    }
+    if let Some(value) = extra.remove("top_k")
+        && !value.is_null()
+    {
+        return Err(ProviderError::InvalidRequest(format!(
+            "`top_k` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_anthropic_beta(body: &mut Map<String, Value>, beta: &str) -> Result<(), ProviderError> {
+    match body.get_mut("anthropic_beta") {
+        None => {
+            body.insert(
+                "anthropic_beta".to_string(),
+                Value::Array(vec![Value::String(beta.to_string())]),
+            );
+            Ok(())
+        }
+        Some(Value::Array(values)) => {
+            if !values.iter().any(|value| value.as_str() == Some(beta)) {
+                values.push(Value::String(beta.to_string()));
+            }
+            Ok(())
+        }
+        Some(_) => Err(ProviderError::InvalidRequest(
+            "`anthropic_beta` must be an array for Anthropic Claude mapping".to_string(),
+        )),
+    }
+}
+
 fn tool_choice_is_none_or_auto(value: &Value) -> bool {
     matches!(value.as_str(), Some("none" | "auto"))
         || value
@@ -1653,6 +2254,7 @@ fn normalize_converse_response(value: &Value, context: &ProviderRequestContext) 
         .collect::<Vec<_>>()
         .join("");
     let tool_calls = extract_tool_calls(blocks);
+    let reasoning_blocks = extract_bedrock_reasoning_blocks(blocks);
     let finish_reason = value
         .get("stopReason")
         .and_then(Value::as_str)
@@ -1664,6 +2266,12 @@ fn normalize_converse_response(value: &Value, context: &ProviderRequestContext) 
     message.insert("content".to_string(), Value::String(content));
     if !tool_calls.is_empty() {
         message.insert("tool_calls".to_string(), Value::Array(tool_calls));
+    }
+    if !reasoning_blocks.is_empty() {
+        message.insert(
+            "provider_metadata".to_string(),
+            bedrock_reasoning_metadata("bedrock_converse", reasoning_blocks),
+        );
     }
 
     let mut completion = Map::new();
@@ -1721,6 +2329,7 @@ fn normalize_anthropic_messages_response(value: &Value, context: &ProviderReques
         .collect::<Vec<_>>()
         .join("");
     let tool_calls = extract_anthropic_tool_calls(blocks);
+    let thinking_blocks = extract_anthropic_thinking_blocks(blocks);
     let finish_reason = value
         .get("stop_reason")
         .and_then(Value::as_str)
@@ -1732,6 +2341,12 @@ fn normalize_anthropic_messages_response(value: &Value, context: &ProviderReques
     message.insert("content".to_string(), Value::String(content));
     if !tool_calls.is_empty() {
         message.insert("tool_calls".to_string(), Value::Array(tool_calls));
+    }
+    if !thinking_blocks.is_empty() {
+        message.insert(
+            "provider_metadata".to_string(),
+            bedrock_reasoning_metadata("anthropic_messages", thinking_blocks),
+        );
     }
 
     let mut completion = Map::new();
@@ -1811,6 +2426,132 @@ fn extract_anthropic_tool_calls(blocks: &[Value]) -> Vec<Value> {
             }))
         })
         .collect()
+}
+
+fn extract_anthropic_thinking_blocks(blocks: &[Value]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| match block.get("type").and_then(Value::as_str) {
+            Some("thinking") => {
+                let mut normalized = Map::new();
+                normalized.insert("type".to_string(), Value::String("thinking".to_string()));
+                normalized.insert(
+                    "thinking".to_string(),
+                    block
+                        .get("thinking")
+                        .cloned()
+                        .unwrap_or_else(|| Value::String(String::new())),
+                );
+                if let Some(signature) = block.get("signature").cloned() {
+                    normalized.insert("signature".to_string(), signature);
+                }
+                Some(Value::Object(normalized))
+            }
+            Some("redacted_thinking") => {
+                let mut normalized = Map::new();
+                normalized.insert(
+                    "type".to_string(),
+                    Value::String("redacted_thinking".to_string()),
+                );
+                if let Some(data) = block.get("data").cloned() {
+                    normalized.insert("data".to_string(), data);
+                }
+                Some(Value::Object(normalized))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn extract_bedrock_reasoning_blocks(blocks: &[Value]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| block.get("reasoningContent"))
+        .filter_map(normalize_bedrock_reasoning_content)
+        .collect()
+}
+
+fn normalize_bedrock_reasoning_content(reasoning: &Value) -> Option<Value> {
+    if let Some(reasoning_text) = reasoning.get("reasoningText").and_then(Value::as_object) {
+        let mut normalized = Map::new();
+        normalized.insert(
+            "type".to_string(),
+            Value::String("reasoning_text".to_string()),
+        );
+        normalized.insert(
+            "text".to_string(),
+            reasoning_text
+                .get("text")
+                .cloned()
+                .unwrap_or_else(|| Value::String(String::new())),
+        );
+        if let Some(signature) = reasoning_text.get("signature").cloned() {
+            normalized.insert("signature".to_string(), signature);
+        }
+        return Some(Value::Object(normalized));
+    }
+
+    if let Some(text) = reasoning.get("text").cloned() {
+        let mut normalized = Map::new();
+        normalized.insert(
+            "type".to_string(),
+            Value::String("reasoning_text".to_string()),
+        );
+        normalized.insert("text".to_string(), text);
+        if let Some(signature) = reasoning.get("signature").cloned() {
+            normalized.insert("signature".to_string(), signature);
+        }
+        return Some(Value::Object(normalized));
+    }
+
+    if let Some(signature) = reasoning.get("signature").cloned() {
+        let mut normalized = Map::new();
+        normalized.insert(
+            "type".to_string(),
+            Value::String("reasoning_signature".to_string()),
+        );
+        normalized.insert("signature".to_string(), signature);
+        return Some(Value::Object(normalized));
+    }
+
+    if let Some(data) = reasoning
+        .get("redactedContent")
+        .or_else(|| reasoning.get("data"))
+        .cloned()
+    {
+        let mut normalized = Map::new();
+        normalized.insert(
+            "type".to_string(),
+            Value::String("redacted_reasoning".to_string()),
+        );
+        normalized.insert("data".to_string(), data);
+        return Some(Value::Object(normalized));
+    }
+
+    if let Some(redacted) = reasoning.get("redactedReasoning") {
+        let mut normalized = Map::new();
+        normalized.insert(
+            "type".to_string(),
+            Value::String("redacted_reasoning".to_string()),
+        );
+        if let Some(data) = redacted.get("data").cloned() {
+            normalized.insert("data".to_string(), data);
+        }
+        return Some(Value::Object(normalized));
+    }
+
+    None
+}
+
+fn bedrock_reasoning_metadata(source: &str, blocks: Vec<Value>) -> Value {
+    json!({
+        "aws_bedrock": {
+            "reasoning": {
+                "source": source,
+                "blocks": blocks
+            }
+        }
+    })
 }
 
 fn map_stop_reason(reason: &str) -> &'static str {
@@ -2141,6 +2882,18 @@ impl BedrockConverseStreamNormalizer {
                                     "arguments": input
                                 }
                             }]
+                        }),
+                        Value::Null,
+                    )));
+                } else if let Some(reasoning) = delta.get("reasoningContent")
+                    && let Some(block) = normalize_bedrock_reasoning_content(reasoning)
+                {
+                    actions.push(BedrockStreamAction::Chunk(self.delta_chunk(
+                        json!({
+                            "provider_metadata": bedrock_reasoning_metadata(
+                                "bedrock_converse_stream",
+                                vec![block],
+                            )
                         }),
                         Value::Null,
                     )));
@@ -2487,6 +3240,320 @@ mod tests {
                 "stop_sequences": ["END"]
             })
         );
+    }
+
+    #[test]
+    fn maps_opus_4_7_reasoning_effort_to_adaptive_thinking() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("xhigh")),
+                ("temperature".to_string(), json!(1.0)),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("global.anthropic.claude-opus-4-7"),
+        )
+        .expect("mapped");
+
+        assert_eq!(body["thinking"], json!({ "type": "adaptive" }));
+        assert_eq!(body["output_config"], json!({ "effort": "xhigh" }));
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("temperature").is_none());
+    }
+
+    #[test]
+    fn maps_opus_and_sonnet_4_6_reasoning_effort_to_adaptive_thinking() {
+        for upstream_model in [
+            "us.anthropic.claude-opus-4-6-v1:0",
+            "us.anthropic.claude-sonnet-4-6-v1:0",
+        ] {
+            let request = CoreChatRequest {
+                model: "claude".to_string(),
+                messages: vec![message("user", "Think carefully")],
+                stream: false,
+                extra: BTreeMap::from([
+                    ("max_tokens".to_string(), json!(4096)),
+                    ("reasoning_effort".to_string(), json!("medium")),
+                ]),
+            };
+
+            let body = map_chat_request_to_anthropic_messages(&request, &context(upstream_model))
+                .expect("mapped");
+
+            assert_eq!(body["thinking"], json!({ "type": "adaptive" }));
+            assert_eq!(body["output_config"], json!({ "effort": "medium" }));
+            assert!(body.get("reasoning_effort").is_none());
+        }
+    }
+
+    #[test]
+    fn maps_older_claude_reasoning_budget_to_manual_thinking() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                (
+                    "reasoning".to_string(),
+                    json!({ "effort": "high", "budget_tokens": 1024 }),
+                ),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-sonnet-4-5-v1:0"),
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            body["thinking"],
+            json!({ "type": "enabled", "budget_tokens": 1024 })
+        );
+        assert!(body.get("output_config").is_none());
+        assert!(body.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn maps_opus_4_5_reasoning_effort_to_bedrock_effort_beta() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("medium")),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-opus-4-5-v1:0"),
+        )
+        .expect("mapped");
+
+        assert!(body.get("thinking").is_none());
+        assert_eq!(body["output_config"], json!({ "effort": "medium" }));
+        assert_eq!(body["anthropic_beta"], json!(["effort-2025-11-24"]));
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn maps_claude_converse_reasoning_effort_to_additional_model_request_fields() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("high")),
+                (
+                    "additionalModelRequestFields".to_string(),
+                    json!({ "trace": "enabled" }),
+                ),
+            ]),
+        };
+
+        let body =
+            map_chat_request_to_converse(&request, &context("us.anthropic.claude-sonnet-4-6-v1:0"))
+                .expect("mapped");
+
+        assert_eq!(
+            body["additionalModelRequestFields"],
+            json!({
+                "trace": "enabled",
+                "thinking": {
+                    "type": "adaptive",
+                    "effort": "high"
+                }
+            })
+        );
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn maps_older_claude_converse_reasoning_budget_to_manual_thinking() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                (
+                    "reasoning".to_string(),
+                    json!({ "effort": "high", "budget_tokens": 1024 }),
+                ),
+            ]),
+        };
+
+        let body =
+            map_chat_request_to_converse(&request, &context("anthropic.claude-haiku-4-5-v1:0"))
+                .expect("mapped");
+
+        assert_eq!(
+            body["additionalModelRequestFields"],
+            json!({
+                "thinking": {
+                    "type": "enabled",
+                    "budget_tokens": 1024
+                }
+            })
+        );
+        assert!(body.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn rejects_conflicting_claude_converse_reasoning_effort() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("high")),
+                (
+                    "additionalModelRequestFields".to_string(),
+                    json!({
+                        "thinking": {
+                            "type": "adaptive",
+                            "effort": "low"
+                        }
+                    }),
+                ),
+            ]),
+        };
+
+        let error =
+            map_chat_request_to_converse(&request, &context("us.anthropic.claude-opus-4-6-v1:0"))
+                .expect_err("conflict rejected")
+                .to_string();
+
+        assert!(error.contains("additionalModelRequestFields.thinking.effort"));
+    }
+
+    #[test]
+    fn rejects_opus_4_7_converse_non_default_sampling_fields() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(64)),
+                ("temperature".to_string(), json!(0.2)),
+            ]),
+        };
+
+        let error =
+            map_chat_request_to_converse(&request, &context("global.anthropic.claude-opus-4-7"))
+                .expect_err("sampling rejected")
+                .to_string();
+
+        assert!(error.contains("temperature"));
+        assert!(error.contains("non-default"));
+    }
+
+    #[test]
+    fn rejects_opus_4_7_manual_thinking_budget() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                (
+                    "thinking".to_string(),
+                    json!({ "type": "enabled", "budget_tokens": 1024 }),
+                ),
+            ]),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("global.anthropic.claude-opus-4-7"),
+        )
+        .expect_err("manual thinking rejected")
+        .to_string();
+
+        assert!(error.contains("thinking.type: enabled"));
+        assert!(error.contains("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn rejects_older_claude_adaptive_thinking() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("thinking".to_string(), json!({ "type": "adaptive" })),
+            ]),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-haiku-4-5-v1:0"),
+        )
+        .expect_err("adaptive thinking rejected")
+        .to_string();
+
+        assert!(error.contains("thinking.type: adaptive"));
+        assert!(error.contains("is not supported"));
+    }
+
+    #[test]
+    fn rejects_opus_4_7_non_default_sampling_fields() {
+        for field in ["temperature", "top_p", "top_k"] {
+            let request = CoreChatRequest {
+                model: "claude".to_string(),
+                messages: vec![message("user", "Hello")],
+                stream: false,
+                extra: BTreeMap::from([
+                    ("max_tokens".to_string(), json!(64)),
+                    (field.to_string(), json!(0.2)),
+                ]),
+            };
+
+            let error = map_chat_request_to_anthropic_messages(
+                &request,
+                &context("global.anthropic.claude-opus-4-7"),
+            )
+            .expect_err("sampling rejected")
+            .to_string();
+
+            assert!(error.contains(field));
+            assert!(error.contains("non-default"));
+        }
+    }
+
+    #[test]
+    fn rejects_conflicting_reasoning_and_output_config_effort() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("medium")),
+                ("output_config".to_string(), json!({ "effort": "high" })),
+            ]),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("global.anthropic.claude-opus-4-7"),
+        )
+        .expect_err("conflict rejected")
+        .to_string();
+
+        assert!(error.contains("conflicts with `output_config.effort`"));
     }
 
     #[test]
@@ -3164,6 +4231,72 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_converse_reasoning_metadata_without_leaking_into_content() {
+        let response = json!({
+            "responseId": "bedrock-response-id",
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "reasoningContent": {
+                                "reasoningText": {
+                                    "text": "visible summarized reasoning",
+                                    "signature": "sig-reasoning"
+                                }
+                            }
+                        },
+                        {
+                            "reasoningContent": {
+                                "redactedContent": "cmVkYWN0ZWQ="
+                            }
+                        },
+                        {"text": "Final answer."}
+                    ]
+                }
+            },
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 12,
+                "outputTokens": 9,
+                "totalTokens": 21
+            }
+        });
+
+        let normalized = normalize_converse_response(
+            &response,
+            &context("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+        );
+        let message = &normalized["choices"][0]["message"];
+
+        assert_eq!(message["content"], "Final answer.");
+        assert!(
+            !message["content"]
+                .as_str()
+                .expect("content string")
+                .contains("visible summarized reasoning")
+        );
+        assert_eq!(
+            message["provider_metadata"]["aws_bedrock"]["reasoning"]["source"],
+            "bedrock_converse"
+        );
+        assert_eq!(
+            message["provider_metadata"]["aws_bedrock"]["reasoning"]["blocks"],
+            json!([
+                {
+                    "type": "reasoning_text",
+                    "text": "visible summarized reasoning",
+                    "signature": "sig-reasoning"
+                },
+                {
+                    "type": "redacted_reasoning",
+                    "data": "cmVkYWN0ZWQ="
+                }
+            ])
+        );
+    }
+
+    #[test]
     fn normalizes_tool_use_response() {
         let response = json!({
             "output": {
@@ -3240,6 +4373,76 @@ mod tests {
         assert_eq!(
             normalized["usage"]["provider_usage"]["cache_creation_input_tokens"],
             3
+        );
+    }
+
+    #[test]
+    fn normalizes_anthropic_thinking_metadata_without_leaking_into_content() {
+        let response = json!({
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "summarized hidden reasoning",
+                    "signature": "sig-thinking"
+                },
+                {
+                    "type": "redacted_thinking",
+                    "data": "ZW5jcnlwdGVk"
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_123",
+                    "name": "get_weather",
+                    "input": {"city": "London"}
+                },
+                {
+                    "type": "text",
+                    "text": "I will check."
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": {
+                "input_tokens": 30,
+                "output_tokens": 12
+            }
+        });
+
+        let normalized =
+            normalize_anthropic_messages_response(&response, &context("anthropic.claude-opus-4-7"));
+        let message = &normalized["choices"][0]["message"];
+
+        assert_eq!(message["content"], "I will check.");
+        assert!(
+            !message["content"]
+                .as_str()
+                .expect("content string")
+                .contains("summarized hidden reasoning")
+        );
+        assert_eq!(normalized["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            message["tool_calls"][0]["function"]["arguments"],
+            "{\"city\":\"London\"}"
+        );
+        assert_eq!(
+            message["provider_metadata"]["aws_bedrock"]["reasoning"]["source"],
+            "anthropic_messages"
+        );
+        assert_eq!(
+            message["provider_metadata"]["aws_bedrock"]["reasoning"]["blocks"],
+            json!([
+                {
+                    "type": "thinking",
+                    "thinking": "summarized hidden reasoning",
+                    "signature": "sig-thinking"
+                },
+                {
+                    "type": "redacted_thinking",
+                    "data": "ZW5jcnlwdGVk"
+                }
+            ])
         );
     }
 
@@ -3393,6 +4596,112 @@ mod tests {
                 .contains(r#""tool_calls":[{"function":{"arguments":"{\"city\":"},"index":1}]"#)
         );
         assert!(transcript.contains(r#""finish_reason":"tool_calls""#));
+        assert!(transcript.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn normalizes_reasoning_signature_redaction_text_and_tool_deltas_from_converse_stream() {
+        let frames = vec![
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStart")],
+                br#"{"role":"assistant"}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":0,"delta":{"reasoningContent":{"text":"summarized stream reasoning"}}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":0,"delta":{"reasoningContent":{"signature":"sig-stream"}}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":0,"delta":{"reasoningContent":{"data":"cmVkYWN0ZWQ="}}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":1,"delta":{"text":"Final "}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockStart"),
+                ],
+                br#"{"contentBlockIndex":2,"start":{"toolUse":{"toolUseId":"tool_123","name":"get_weather"}}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":2,"delta":{"toolUse":{"input":"{\"city\":\"London\"}"}}}"#,
+            ),
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStop")],
+                br#"{"stopReason":"tool_use"}"#,
+            ),
+        ];
+
+        let transcript = collect_bedrock_stream(frames).await;
+
+        assert!(transcript.contains(r#""source":"bedrock_converse_stream""#));
+        assert!(transcript.contains(r#""type":"reasoning_text""#));
+        assert!(transcript.contains(r#""text":"summarized stream reasoning""#));
+        assert!(transcript.contains(r#""type":"reasoning_signature""#));
+        assert!(transcript.contains(r#""signature":"sig-stream""#));
+        assert!(transcript.contains(r#""type":"redacted_reasoning""#));
+        assert!(transcript.contains(r#""data":"cmVkYWN0ZWQ=""#));
+        assert!(transcript.contains(r#""delta":{"content":"Final "}"#));
+        assert!(transcript.contains(r#""name":"get_weather""#));
+        assert!(transcript.contains(r#""finish_reason":"tool_calls""#));
+        assert!(!transcript.contains(r#""content":"summarized stream reasoning""#));
+        assert!(transcript.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[tokio::test]
+    async fn normalizes_omitted_thinking_signature_before_text_from_converse_stream() {
+        let frames = vec![
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStart")],
+                br#"{"role":"assistant"}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":0,"delta":{"reasoningContent":{"signature":"sig-omitted"}}}"#,
+            ),
+            eventstream_frame(
+                &[
+                    (":message-type", "event"),
+                    (":event-type", "contentBlockDelta"),
+                ],
+                br#"{"contentBlockIndex":1,"delta":{"text":"The answer is 42."}}"#,
+            ),
+            eventstream_frame(
+                &[(":message-type", "event"), (":event-type", "messageStop")],
+                br#"{"stopReason":"end_turn"}"#,
+            ),
+        ];
+
+        let transcript = collect_bedrock_stream(frames).await;
+
+        assert!(transcript.contains(r#""type":"reasoning_signature""#));
+        assert!(transcript.contains(r#""signature":"sig-omitted""#));
+        assert!(transcript.contains(r#""delta":{"content":"The answer is 42."}"#));
         assert!(transcript.ends_with("data: [DONE]\n\n"));
     }
 

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1538,7 +1538,10 @@ fn apply_anthropic_thinking_compatibility(
     extra: &mut BTreeMap<String, Value>,
     upstream_model: &str,
 ) -> Result<(), ProviderError> {
-    let effort = extract_anthropic_reasoning_effort(extra)?;
+    let reasoning_effort = extract_anthropic_reasoning_effort(extra)?;
+    let native_effort = extract_existing_anthropic_output_effort(body)?;
+    let has_native_effort = native_effort.is_some();
+    let effort = merge_optional_efforts(reasoning_effort, native_effort, upstream_model)?;
     let budget_tokens = extract_anthropic_reasoning_budget_tokens(extra);
     let policy = claude_thinking_policy(upstream_model);
 
@@ -1562,6 +1565,11 @@ fn apply_anthropic_thinking_compatibility(
                 ensure_anthropic_beta(body, "effort-2025-11-24")?;
             }
             ClaudeThinkingPolicy::ManualOnly => {
+                if has_native_effort {
+                    return Err(ProviderError::InvalidRequest(format!(
+                        "`output_config.effort` is not supported for `{upstream_model}`"
+                    )));
+                }
                 let budget_tokens = budget_tokens
                     .or_else(|| existing_manual_thinking_budget(body))
                     .ok_or_else(|| {
@@ -1594,7 +1602,9 @@ fn apply_anthropic_thinking_compatibility(
 fn extract_anthropic_reasoning_effort(
     extra: &mut BTreeMap<String, Value>,
 ) -> Result<Option<Value>, ProviderError> {
-    let reasoning_effort = extra.remove("reasoning_effort");
+    let reasoning_effort = extra
+        .remove("reasoning_effort")
+        .filter(|value| !value.is_null());
     let reasoning = extra.remove("reasoning");
 
     match (reasoning_effort, reasoning) {
@@ -1603,10 +1613,11 @@ fn extract_anthropic_reasoning_effort(
             if let Some(budget_tokens) = reasoning.remove("budget_tokens") {
                 extra.insert("reasoning_budget_tokens".to_string(), budget_tokens);
             }
-            Ok(reasoning.remove("effort"))
+            Ok(reasoning.remove("effort").filter(|value| !value.is_null()))
         }
         (Some(effort), Some(Value::Object(mut reasoning))) => {
-            if let Some(reasoning_effort) = reasoning.remove("effort")
+            if let Some(reasoning_effort) =
+                reasoning.remove("effort").filter(|value| !value.is_null())
                 && reasoning_effort != effort
             {
                 return Err(ProviderError::InvalidRequest(
@@ -1624,6 +1635,51 @@ fn extract_anthropic_reasoning_effort(
         (_, Some(_)) => Err(ProviderError::InvalidRequest(
             "`reasoning` must be an object for Anthropic Claude mapping".to_string(),
         )),
+        (None, None) => Ok(None),
+    }
+}
+
+fn extract_existing_anthropic_output_effort(
+    body: &mut Map<String, Value>,
+) -> Result<Option<Value>, ProviderError> {
+    let (effort, remove_output_config) = {
+        let Some(output_config) = body.get_mut("output_config") else {
+            return Ok(None);
+        };
+        let output_config = output_config.as_object_mut().ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "`output_config` must be an object for Anthropic Claude mapping".to_string(),
+            )
+        })?;
+
+        let effort = output_config.get("effort").cloned();
+        if effort.as_ref().is_some_and(Value::is_null) {
+            output_config.remove("effort");
+            (None, output_config.is_empty())
+        } else {
+            (effort, false)
+        }
+    };
+    if remove_output_config {
+        body.remove("output_config");
+    }
+
+    Ok(effort)
+}
+
+fn merge_optional_efforts(
+    reasoning_effort: Option<Value>,
+    native_effort: Option<Value>,
+    upstream_model: &str,
+) -> Result<Option<Value>, ProviderError> {
+    match (reasoning_effort, native_effort) {
+        (Some(reasoning_effort), Some(native_effort)) if reasoning_effort != native_effort => {
+            Err(ProviderError::InvalidRequest(format!(
+                "`reasoning_effort` conflicts with `output_config.effort` for `{upstream_model}`"
+            )))
+        }
+        (Some(reasoning_effort), _) => Ok(Some(reasoning_effort)),
+        (None, Some(native_effort)) => Ok(Some(native_effort)),
         (None, None) => Ok(None),
     }
 }
@@ -2063,6 +2119,29 @@ fn validate_converse_anthropic_sampling_fields(
         return Err(ProviderError::InvalidRequest(format!(
             "`top_k` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
         )));
+    }
+    let remove_additional = if let Some(additional) = body
+        .get_mut("additionalModelRequestFields")
+        .and_then(Value::as_object_mut)
+    {
+        for field in ["top_k", "topK"] {
+            let Some(value) = additional.get(field) else {
+                continue;
+            };
+            if value.is_null() {
+                additional.remove(field);
+                continue;
+            }
+            return Err(ProviderError::InvalidRequest(format!(
+                "`{field}` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+            )));
+        }
+        additional.is_empty()
+    } else {
+        false
+    };
+    if remove_additional {
+        body.remove("additionalModelRequestFields");
     }
     Ok(())
 }
@@ -3346,6 +3425,77 @@ mod tests {
     }
 
     #[test]
+    fn ignores_null_reasoning_effort_for_anthropic_mapping() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), Value::Null),
+                ("reasoning".to_string(), json!({ "effort": null })),
+                ("output_config".to_string(), json!({ "effort": null })),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("global.anthropic.claude-opus-4-7"),
+        )
+        .expect("mapped");
+
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("output_config").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn validates_native_output_config_effort_for_anthropic_mapping() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("output_config".to_string(), json!({ "effort": "medium" })),
+                ("reasoning_budget_tokens".to_string(), json!(1024)),
+            ]),
+        };
+
+        let body = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-opus-4-5-v1:0"),
+        )
+        .expect("mapped");
+
+        assert_eq!(body["output_config"], json!({ "effort": "medium" }));
+        assert_eq!(body["anthropic_beta"], json!(["effort-2025-11-24"]));
+    }
+
+    #[test]
+    fn rejects_native_output_config_effort_for_manual_only_anthropic_mapping() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("output_config".to_string(), json!({ "effort": "medium" })),
+            ]),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-sonnet-4-5-v1:0"),
+        )
+        .expect_err("manual-only effort rejected")
+        .to_string();
+
+        assert!(error.contains("output_config.effort"));
+    }
+
+    #[test]
     fn maps_claude_converse_reasoning_effort_to_additional_model_request_fields() {
         let request = CoreChatRequest {
             model: "claude".to_string(),
@@ -3457,6 +3607,30 @@ mod tests {
 
         assert!(error.contains("temperature"));
         assert!(error.contains("non-default"));
+    }
+
+    #[test]
+    fn rejects_opus_4_7_converse_additional_model_top_k() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(64)),
+                (
+                    "additionalModelRequestFields".to_string(),
+                    json!({ "top_k": 50 }),
+                ),
+            ]),
+        };
+
+        let error =
+            map_chat_request_to_converse(&request, &context("global.anthropic.claude-opus-4-7"))
+                .expect_err("top_k rejected")
+                .to_string();
+
+        assert!(error.contains("top_k"));
+        assert!(error.contains("Claude Opus 4.7+"));
     }
 
     #[test]

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1702,10 +1702,12 @@ fn validate_caller_thinking_for_policy(
     let Some(thinking) = body.get("thinking") else {
         return Ok(());
     };
-    let thinking_type = thinking
-        .as_object()
-        .and_then(|object| object.get("type"))
-        .and_then(Value::as_str);
+    let thinking = thinking.as_object().ok_or_else(|| {
+        ProviderError::InvalidRequest(
+            "`thinking` must be an object for aws_bedrock Anthropic Claude mapping".to_string(),
+        )
+    })?;
+    let thinking_type = thinking.get("type").and_then(Value::as_str);
 
     match policy {
         ClaudeThinkingPolicy::AdaptiveOnly => {
@@ -1738,6 +1740,16 @@ fn validate_caller_thinking_for_policy(
             }
         }
         ClaudeThinkingPolicy::AdaptivePreferred => {}
+    }
+
+    if thinking_type == Some("enabled")
+        && thinking
+            .get("budget_tokens")
+            .is_none_or(|value| value.is_null())
+    {
+        return Err(ProviderError::InvalidRequest(format!(
+            "`thinking.type: enabled` for `{upstream_model}` must include `budget_tokens`"
+        )));
     }
 
     Ok(())
@@ -2013,10 +2025,13 @@ fn validate_converse_caller_thinking_for_policy_object(
     let Some(thinking) = additional.get("thinking") else {
         return Ok(());
     };
-    let thinking_type = thinking
-        .as_object()
-        .and_then(|object| object.get("type"))
-        .and_then(Value::as_str);
+    let thinking = thinking.as_object().ok_or_else(|| {
+        ProviderError::InvalidRequest(
+            "`additionalModelRequestFields.thinking` must be an object for aws_bedrock Converse"
+                .to_string(),
+        )
+    })?;
+    let thinking_type = thinking.get("type").and_then(Value::as_str);
 
     match policy {
         ClaudeThinkingPolicy::AdaptiveOnly => {
@@ -2042,6 +2057,15 @@ fn validate_converse_caller_thinking_for_policy_object(
             }
         }
         ClaudeThinkingPolicy::AdaptivePreferred => {}
+    }
+    if thinking_type == Some("enabled")
+        && thinking
+            .get("budget_tokens")
+            .is_none_or(|value| value.is_null())
+    {
+        return Err(ProviderError::InvalidRequest(format!(
+            "`additionalModelRequestFields.thinking.type: enabled` for `{upstream_model}` must include `budget_tokens`"
+        )));
     }
     Ok(())
 }
@@ -2097,10 +2121,19 @@ fn validate_converse_anthropic_sampling_fields(
         return Ok(());
     }
 
+    if let Some(value) = extra.remove("top_k")
+        && !value.is_null()
+    {
+        return Err(ProviderError::InvalidRequest(format!(
+            "`top_k` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+        )));
+    }
+
     let Some(inference_config) = body
         .get_mut("inferenceConfig")
         .and_then(Value::as_object_mut)
     else {
+        validate_converse_additional_top_k(body, upstream_model)?;
         return Ok(());
     };
     for (field, bedrock_field) in [("temperature", "temperature"), ("top_p", "topP")] {
@@ -2118,13 +2151,13 @@ fn validate_converse_anthropic_sampling_fields(
     if inference_config.is_empty() {
         body.remove("inferenceConfig");
     }
-    if let Some(value) = extra.remove("top_k")
-        && !value.is_null()
-    {
-        return Err(ProviderError::InvalidRequest(format!(
-            "`top_k` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
-        )));
-    }
+    validate_converse_additional_top_k(body, upstream_model)
+}
+
+fn validate_converse_additional_top_k(
+    body: &mut Map<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
     let remove_additional = if let Some(additional) = body
         .get_mut("additionalModelRequestFields")
         .and_then(Value::as_object_mut)
@@ -3690,6 +3723,30 @@ mod tests {
     }
 
     #[test]
+    fn rejects_opus_4_7_converse_additional_model_top_k_without_inference_config() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Hello")],
+            stream: true,
+            extra: BTreeMap::from([(
+                "additionalModelRequestFields".to_string(),
+                json!({
+                    "thinking": {"type": "adaptive"},
+                    "top_k": 50
+                }),
+            )]),
+        };
+
+        let error =
+            map_chat_request_to_converse(&request, &context("global.anthropic.claude-opus-4-7"))
+                .expect_err("top_k rejected without inferenceConfig")
+                .to_string();
+
+        assert!(error.contains("top_k"));
+        assert!(error.contains("Claude Opus 4.7+"));
+    }
+
+    #[test]
     fn rejects_opus_4_7_manual_thinking_budget() {
         let request = CoreChatRequest {
             model: "claude".to_string(),
@@ -3713,6 +3770,53 @@ mod tests {
 
         assert!(error.contains("thinking.type: enabled"));
         assert!(error.contains("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn rejects_native_manual_thinking_without_budget() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("thinking".to_string(), json!({ "type": "enabled" })),
+            ]),
+        };
+
+        let error = map_chat_request_to_anthropic_messages(
+            &request,
+            &context("anthropic.claude-haiku-4-5-v1:0"),
+        )
+        .expect_err("manual thinking requires budget")
+        .to_string();
+
+        assert!(error.contains("thinking.type: enabled"));
+        assert!(error.contains("budget_tokens"));
+    }
+
+    #[test]
+    fn rejects_converse_manual_thinking_without_budget() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                (
+                    "additionalModelRequestFields".to_string(),
+                    json!({ "thinking": { "type": "enabled" } }),
+                ),
+            ]),
+        };
+
+        let error =
+            map_chat_request_to_converse(&request, &context("anthropic.claude-haiku-4-5-v1:0"))
+                .expect_err("manual thinking requires budget")
+                .to_string();
+
+        assert!(error.contains("additionalModelRequestFields.thinking.type: enabled"));
+        assert!(error.contains("budget_tokens"));
     }
 
     #[test]

--- a/crates/gateway-providers/src/bedrock.rs
+++ b/crates/gateway-providers/src/bedrock.rs
@@ -1899,20 +1899,25 @@ fn apply_converse_anthropic_thinking_compatibility(
                 merge_converse_thinking_field(additional, "effort", effort, upstream_model)?;
             }
             ClaudeThinkingPolicy::ManualWithEffortBeta => {
-                if let Some(budget_tokens) = budget_tokens {
-                    merge_converse_thinking_field(
-                        additional,
-                        "type",
-                        json!("enabled"),
-                        upstream_model,
-                    )?;
-                    merge_converse_thinking_field(
-                        additional,
-                        "budget_tokens",
-                        budget_tokens,
-                        upstream_model,
-                    )?;
-                }
+                let budget_tokens = budget_tokens
+                    .or_else(|| existing_converse_manual_thinking_budget(additional))
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(format!(
+                            "`reasoning_effort` requires an explicit manual thinking budget for `{upstream_model}` because this Claude model requires manual thinking when Bedrock effort is used"
+                        ))
+                    })?;
+                merge_converse_thinking_field(
+                    additional,
+                    "type",
+                    json!("enabled"),
+                    upstream_model,
+                )?;
+                merge_converse_thinking_field(
+                    additional,
+                    "budget_tokens",
+                    budget_tokens,
+                    upstream_model,
+                )?;
                 merge_converse_thinking_field(additional, "effort", effort, upstream_model)?;
             }
             ClaudeThinkingPolicy::ManualOnly => {
@@ -3557,6 +3562,57 @@ mod tests {
             })
         );
         assert!(body.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn maps_opus_4_5_converse_reasoning_effort_with_manual_budget() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                (
+                    "reasoning".to_string(),
+                    json!({ "effort": "medium", "budget_tokens": 1024 }),
+                ),
+            ]),
+        };
+
+        let body =
+            map_chat_request_to_converse(&request, &context("anthropic.claude-opus-4-5-v1:0"))
+                .expect("mapped");
+
+        assert_eq!(
+            body["additionalModelRequestFields"],
+            json!({
+                "thinking": {
+                    "type": "enabled",
+                    "budget_tokens": 1024,
+                    "effort": "medium"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_opus_4_5_converse_reasoning_effort_without_manual_budget() {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("medium")),
+            ]),
+        };
+
+        let error =
+            map_chat_request_to_converse(&request, &context("anthropic.claude-opus-4-5-v1:0"))
+                .expect_err("budget required")
+                .to_string();
+
+        assert!(error.contains("manual thinking budget"));
     }
 
     #[test]

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -478,7 +478,7 @@ fn apply_vertex_anthropic_thinking_compatibility(
     let native_effort = extract_existing_anthropic_output_effort(body)?;
     let has_native_effort = native_effort.is_some();
     let effort = merge_optional_efforts(reasoning_effort, native_effort, upstream_model)?;
-    let budget_tokens = extract_anthropic_reasoning_budget_tokens(body);
+    let budget_tokens = extract_anthropic_reasoning_budget_tokens(body)?;
     let policy = claude_thinking_policy(upstream_model);
 
     validate_caller_thinking_for_policy(body, policy, upstream_model)?;
@@ -622,14 +622,24 @@ fn merge_optional_efforts(
     }
 }
 
-fn extract_anthropic_reasoning_budget_tokens(body: &mut Map<String, Value>) -> Option<Value> {
-    if let Some(value) = body.remove("thinking_budget_tokens") {
-        return Some(value);
+fn extract_anthropic_reasoning_budget_tokens(
+    body: &mut Map<String, Value>,
+) -> Result<Option<Value>, ProviderError> {
+    let thinking_budget = body
+        .remove("thinking_budget_tokens")
+        .filter(|value| !value.is_null());
+    let reasoning_budget = body
+        .remove("reasoning_budget_tokens")
+        .filter(|value| !value.is_null());
+
+    match (thinking_budget, reasoning_budget) {
+        (Some(left), Some(right)) if left != right => Err(ProviderError::InvalidRequest(
+            "`thinking_budget_tokens` conflicts with `reasoning_budget_tokens` for Anthropic Vertex mapping"
+                .to_string(),
+        )),
+        (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
+        (None, None) => Ok(None),
     }
-    if let Some(value) = body.remove("reasoning_budget_tokens") {
-        return Some(value);
-    }
-    None
 }
 
 fn validate_caller_thinking_for_policy(
@@ -1267,6 +1277,23 @@ fn normalize_anthropic_thinking_delta(delta: &Map<String, Value>) -> Option<Valu
     }
 }
 
+fn normalize_anthropic_thinking_start(block: &Map<String, Value>) -> Option<Value> {
+    match block.get("type").and_then(Value::as_str) {
+        Some("redacted_thinking") => {
+            let mut normalized = Map::new();
+            normalized.insert(
+                "type".to_string(),
+                Value::String("redacted_thinking".to_string()),
+            );
+            if let Some(data) = block.get("data").cloned() {
+                normalized.insert("data".to_string(), data);
+            }
+            Some(Value::Object(normalized))
+        }
+        _ => None,
+    }
+}
+
 fn vertex_reasoning_metadata(source: &str, blocks: Vec<Value>) -> Value {
     json!({
         "gcp_vertex": {
@@ -1564,6 +1591,37 @@ where
                             role_emitted = true;
                         } else if let Some(delta) = delta
                             && let Some(block) = normalize_anthropic_thinking_delta(delta)
+                        {
+                            let mut outbound_delta = Map::new();
+                            if !role_emitted {
+                                outbound_delta.insert(
+                                    "role".to_string(),
+                                    Value::String("assistant".to_string()),
+                                );
+                            }
+                            outbound_delta.insert(
+                                "provider_metadata".to_string(),
+                                vertex_reasoning_metadata(
+                                    "anthropic_messages_stream",
+                                    vec![block],
+                                ),
+                            );
+                            let chunk = openai_delta_chunk(
+                                &stream_id,
+                                created,
+                                &model,
+                                Value::Object(outbound_delta),
+                                None,
+                            );
+                            yield Ok(openai_sse_chunk(&chunk));
+                            role_emitted = true;
+                        }
+                    }
+                    "content_block_start" => {
+                        if let Some(block) = payload
+                            .get("content_block")
+                            .and_then(Value::as_object)
+                            .and_then(normalize_anthropic_thinking_start)
                         {
                             let mut outbound_delta = Map::new();
                             if !role_emitted {
@@ -2077,6 +2135,63 @@ mod tests {
     }
 
     #[test]
+    fn ignores_null_vertex_thinking_budget_alias_before_reasoning_budget() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("thinking_budget_tokens".to_string(), Value::Null);
+        request
+            .extra
+            .insert("reasoning_budget_tokens".to_string(), json!(1024));
+
+        let mapped = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-sonnet-4-5@20250929"),
+            false,
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            mapped["thinking"],
+            json!({ "type": "enabled", "budget_tokens": 1024 })
+        );
+        assert!(mapped.get("thinking_budget_tokens").is_none());
+        assert!(mapped.get("reasoning_budget_tokens").is_none());
+    }
+
+    #[test]
+    fn rejects_conflicting_vertex_thinking_budget_aliases() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("thinking_budget_tokens".to_string(), json!(2048));
+        request
+            .extra
+            .insert("reasoning_budget_tokens".to_string(), json!(1024));
+
+        let error = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-sonnet-4-5@20250929"),
+            false,
+        )
+        .expect_err("conflicting budgets rejected")
+        .to_string();
+
+        assert!(error.contains("thinking_budget_tokens"));
+        assert!(error.contains("reasoning_budget_tokens"));
+    }
+
+    #[test]
     fn maps_vertex_opus_and_sonnet_4_6_reasoning_effort_to_adaptive_thinking() {
         for model in ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"] {
             let mut request = chat_request(vec![CoreChatMessage {
@@ -2497,6 +2612,38 @@ data: {"type":"vertex_event"}
         assert!(rendered.contains("\"thinking_delta\""));
         assert!(rendered.contains("\"signature_delta\""));
         assert!(rendered.contains("\"sig-stream\""));
+        assert_eq!(rendered.matches("\"role\":\"assistant\"").count(), 1);
+        assert!(rendered.contains("data: [DONE]"));
+    }
+
+    #[tokio::test]
+    async fn anthropic_stream_preserves_redacted_thinking_start_metadata() {
+        let upstream = stream::iter(vec![Ok(Bytes::from(concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\"}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"encrypted-redacted\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"visible\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
+        )))]);
+        let stream = super::normalize_anthropic_stream(
+            upstream,
+            "chatcmpl-test".to_string(),
+            1,
+            "fast".to_string(),
+        );
+        let bytes: Vec<_> = stream.collect().await;
+        let rendered = bytes
+            .into_iter()
+            .map(|item| String::from_utf8(item.expect("chunk").to_vec()).expect("utf8"))
+            .collect::<String>();
+
+        assert!(rendered.contains("\"content\":\"visible\""));
+        assert!(rendered.contains("\"provider_metadata\""));
+        assert!(rendered.contains("\"redacted_thinking\""));
+        assert!(rendered.contains("\"encrypted-redacted\""));
         assert_eq!(rendered.matches("\"role\":\"assistant\"").count(), 1);
         assert!(rendered.contains("data: [DONE]"));
     }

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -430,8 +430,313 @@ fn map_anthropic_request(
         );
     }
 
+    apply_vertex_anthropic_thinking_compatibility(&mut body, &context.upstream_model)?;
+    validate_vertex_anthropic_sampling_fields(&mut body, &context.upstream_model)?;
     merge_object_overrides(&mut body, &context.extra_body);
     Ok(Value::Object(body))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudeThinkingPolicy {
+    AdaptiveOnly,
+    AdaptivePreferred,
+    ManualWithEffort,
+    ManualOnly,
+    MythosPreview,
+}
+
+fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPolicy {
+    let model = upstream_model.to_ascii_lowercase();
+    if model.contains("claude-mythos-preview") {
+        ClaudeThinkingPolicy::MythosPreview
+    } else if is_opus_4_7_or_later(&model) {
+        ClaudeThinkingPolicy::AdaptiveOnly
+    } else if model.contains("claude-opus-4-6") || model.contains("claude-sonnet-4-6") {
+        ClaudeThinkingPolicy::AdaptivePreferred
+    } else if model.contains("claude-opus-4-5") {
+        ClaudeThinkingPolicy::ManualWithEffort
+    } else {
+        ClaudeThinkingPolicy::ManualOnly
+    }
+}
+
+fn is_opus_4_7_or_later(model: &str) -> bool {
+    let Some(rest) = model.split("claude-opus-4-").nth(1) else {
+        return false;
+    };
+    rest.split(|ch: char| !ch.is_ascii_digit())
+        .next()
+        .and_then(|minor| minor.parse::<u16>().ok())
+        .is_some_and(|minor| minor >= 7)
+}
+
+fn apply_vertex_anthropic_thinking_compatibility(
+    body: &mut Map<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    let effort = extract_anthropic_reasoning_effort(body)?;
+    let budget_tokens = extract_anthropic_reasoning_budget_tokens(body);
+    let policy = claude_thinking_policy(upstream_model);
+
+    validate_caller_thinking_for_policy(body, policy, upstream_model)?;
+
+    if let Some(effort) = effort {
+        match policy {
+            ClaudeThinkingPolicy::AdaptiveOnly
+            | ClaudeThinkingPolicy::AdaptivePreferred
+            | ClaudeThinkingPolicy::MythosPreview => {
+                ensure_anthropic_adaptive_thinking(body, upstream_model)?;
+                merge_anthropic_output_effort(body, effort, upstream_model)?;
+            }
+            ClaudeThinkingPolicy::ManualWithEffort => {
+                let budget_tokens = budget_tokens
+                    .or_else(|| existing_manual_thinking_budget(body))
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(format!(
+                            "`reasoning_effort` requires an explicit manual thinking budget for `{upstream_model}` because this Claude model does not support adaptive thinking"
+                        ))
+                    })?;
+                ensure_anthropic_manual_thinking(body, budget_tokens, upstream_model)?;
+                merge_anthropic_output_effort(body, effort, upstream_model)?;
+            }
+            ClaudeThinkingPolicy::ManualOnly => {
+                let budget_tokens = budget_tokens
+                    .or_else(|| existing_manual_thinking_budget(body))
+                    .ok_or_else(|| {
+                        ProviderError::InvalidRequest(format!(
+                            "`reasoning_effort` requires an explicit manual thinking budget for `{upstream_model}` because this Claude model does not support adaptive thinking or effort"
+                        ))
+                    })?;
+                ensure_anthropic_manual_thinking(body, budget_tokens, upstream_model)?;
+            }
+        }
+    } else if let Some(budget_tokens) = budget_tokens {
+        match policy {
+            ClaudeThinkingPolicy::AdaptiveOnly => {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`reasoning.budget_tokens` is not supported for `{upstream_model}`; use adaptive thinking with `reasoning_effort` or `output_config.effort`"
+                )));
+            }
+            ClaudeThinkingPolicy::AdaptivePreferred
+            | ClaudeThinkingPolicy::ManualWithEffort
+            | ClaudeThinkingPolicy::ManualOnly
+            | ClaudeThinkingPolicy::MythosPreview => {
+                ensure_anthropic_manual_thinking(body, budget_tokens, upstream_model)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_anthropic_reasoning_effort(
+    body: &mut Map<String, Value>,
+) -> Result<Option<Value>, ProviderError> {
+    let reasoning_effort = body.remove("reasoning_effort");
+    let reasoning = body.remove("reasoning");
+
+    match (reasoning_effort, reasoning) {
+        (Some(effort), None) => Ok(Some(effort)),
+        (None, Some(Value::Object(mut reasoning))) => {
+            if let Some(budget_tokens) = reasoning.remove("budget_tokens") {
+                body.insert("reasoning_budget_tokens".to_string(), budget_tokens);
+            }
+            Ok(reasoning.remove("effort"))
+        }
+        (Some(effort), Some(Value::Object(mut reasoning))) => {
+            if let Some(reasoning_effort) = reasoning.remove("effort")
+                && reasoning_effort != effort
+            {
+                return Err(ProviderError::InvalidRequest(
+                    "`reasoning_effort` conflicts with `reasoning.effort` for Anthropic Vertex mapping"
+                        .to_string(),
+                ));
+            }
+            if let Some(budget_tokens) = reasoning.remove("budget_tokens") {
+                body.insert("reasoning_budget_tokens".to_string(), budget_tokens);
+            }
+            Ok(Some(effort))
+        }
+        (None, Some(Value::Null)) => Ok(None),
+        (Some(effort), Some(Value::Null)) => Ok(Some(effort)),
+        (_, Some(_)) => Err(ProviderError::InvalidRequest(
+            "`reasoning` must be an object for Anthropic Vertex mapping".to_string(),
+        )),
+        (None, None) => Ok(None),
+    }
+}
+
+fn extract_anthropic_reasoning_budget_tokens(body: &mut Map<String, Value>) -> Option<Value> {
+    if let Some(value) = body.remove("thinking_budget_tokens") {
+        return Some(value);
+    }
+    if let Some(value) = body.remove("reasoning_budget_tokens") {
+        return Some(value);
+    }
+    None
+}
+
+fn validate_caller_thinking_for_policy(
+    body: &Map<String, Value>,
+    policy: ClaudeThinkingPolicy,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    let Some(thinking) = body.get("thinking") else {
+        return Ok(());
+    };
+    let thinking_type = thinking
+        .as_object()
+        .and_then(|object| object.get("type"))
+        .and_then(Value::as_str);
+
+    match policy {
+        ClaudeThinkingPolicy::AdaptiveOnly => {
+            if thinking_type == Some("enabled") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: enabled` with manual `budget_tokens` is not supported for `{upstream_model}`; use `thinking.type: adaptive` and `output_config.effort`"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::ManualOnly | ClaudeThinkingPolicy::ManualWithEffort => {
+            if thinking_type == Some("adaptive") {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: adaptive` is not supported for `{upstream_model}`; use `thinking.type: enabled` with `budget_tokens`"
+                )));
+            }
+        }
+        ClaudeThinkingPolicy::MythosPreview => {
+            if thinking_type == Some("disabled") {
+                return Err(ProviderError::InvalidRequest(
+                    "`thinking.type: disabled` is not supported for Claude Mythos Preview"
+                        .to_string(),
+                ));
+            }
+        }
+        ClaudeThinkingPolicy::AdaptivePreferred => {}
+    }
+
+    Ok(())
+}
+
+fn ensure_anthropic_adaptive_thinking(
+    body: &mut Map<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    match body.get("thinking") {
+        None => {
+            body.insert("thinking".to_string(), json!({ "type": "adaptive" }));
+            Ok(())
+        }
+        Some(Value::Object(object))
+            if object.get("type").and_then(Value::as_str) == Some("adaptive") =>
+        {
+            Ok(())
+        }
+        Some(_) => Err(ProviderError::InvalidRequest(format!(
+            "`reasoning_effort` requires `thinking.type: adaptive` for `{upstream_model}` and conflicts with caller-supplied `thinking`"
+        ))),
+    }
+}
+
+fn ensure_anthropic_manual_thinking(
+    body: &mut Map<String, Value>,
+    budget_tokens: Value,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    match body.get("thinking") {
+        None => {
+            body.insert(
+                "thinking".to_string(),
+                json!({ "type": "enabled", "budget_tokens": budget_tokens }),
+            );
+            Ok(())
+        }
+        Some(Value::Object(object))
+            if object.get("type").and_then(Value::as_str) == Some("enabled") =>
+        {
+            match object.get("budget_tokens") {
+                Some(existing) if existing == &budget_tokens => Ok(()),
+                Some(_) => Err(ProviderError::InvalidRequest(format!(
+                    "manual Anthropic thinking budget for `{upstream_model}` conflicts with caller-supplied `thinking.budget_tokens`"
+                ))),
+                None => Err(ProviderError::InvalidRequest(format!(
+                    "`thinking.type: enabled` for `{upstream_model}` must include `budget_tokens`"
+                ))),
+            }
+        }
+        Some(_) => Err(ProviderError::InvalidRequest(format!(
+            "manual Anthropic thinking budget for `{upstream_model}` conflicts with caller-supplied `thinking`"
+        ))),
+    }
+}
+
+fn existing_manual_thinking_budget(body: &Map<String, Value>) -> Option<Value> {
+    let thinking = body.get("thinking")?.as_object()?;
+    if thinking.get("type").and_then(Value::as_str) == Some("enabled") {
+        thinking.get("budget_tokens").cloned()
+    } else {
+        None
+    }
+}
+
+fn merge_anthropic_output_effort(
+    body: &mut Map<String, Value>,
+    effort: Value,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    match body.get_mut("output_config") {
+        None => {
+            body.insert("output_config".to_string(), json!({ "effort": effort }));
+            Ok(())
+        }
+        Some(Value::Object(output_config)) => match output_config.get("effort") {
+            Some(existing) if existing != &effort => Err(ProviderError::InvalidRequest(format!(
+                "`reasoning_effort` conflicts with `output_config.effort` for `{upstream_model}`"
+            ))),
+            Some(_) => Ok(()),
+            None => {
+                output_config.insert("effort".to_string(), effort);
+                Ok(())
+            }
+        },
+        Some(_) => Err(ProviderError::InvalidRequest(
+            "`output_config` must be an object for Anthropic Vertex mapping".to_string(),
+        )),
+    }
+}
+
+fn validate_vertex_anthropic_sampling_fields(
+    body: &mut Map<String, Value>,
+    upstream_model: &str,
+) -> Result<(), ProviderError> {
+    if claude_thinking_policy(upstream_model) != ClaudeThinkingPolicy::AdaptiveOnly {
+        return Ok(());
+    }
+
+    for field in ["temperature", "top_p", "top_k"] {
+        let Some(value) = body.get(field) else {
+            continue;
+        };
+        if value.is_null() || is_default_anthropic_sampling_value(field, value) {
+            body.remove(field);
+            continue;
+        }
+        return Err(ProviderError::InvalidRequest(format!(
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+        )));
+    }
+
+    Ok(())
+}
+
+fn is_default_anthropic_sampling_value(field: &str, value: &Value) -> bool {
+    match field {
+        "temperature" | "top_p" => value
+            .as_f64()
+            .is_some_and(|number| (number - 1.0).abs() < f64::EPSILON),
+        "top_k" => false,
+        _ => false,
+    }
 }
 
 fn message_content_as_text(content: &Value) -> Result<String, ProviderError> {
@@ -767,32 +1072,38 @@ fn normalize_anthropic_response(value: &Value, context: &ProviderRequestContext)
         .map(str::to_string)
         .unwrap_or_else(|| format!("chatcmpl-{}", Uuid::new_v4().simple()));
     let created = OffsetDateTime::now_utc().unix_timestamp();
-    let text = value
+    let blocks = value
         .get("content")
         .and_then(Value::as_array)
-        .map(|blocks| {
-            blocks
-                .iter()
-                .filter_map(|block| {
-                    let object = block.as_object()?;
-                    if object.get("type").and_then(Value::as_str) == Some("text") {
-                        object
-                            .get("text")
-                            .and_then(Value::as_str)
-                            .map(str::to_string)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join("")
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let text = blocks
+        .iter()
+        .filter_map(|block| {
+            if block.get("type").and_then(Value::as_str) == Some("text") {
+                block.get("text").and_then(Value::as_str)
+            } else {
+                None
+            }
         })
-        .unwrap_or_default();
+        .collect::<Vec<_>>()
+        .join("");
+    let thinking_blocks = extract_anthropic_thinking_blocks(blocks);
     let finish_reason = value
         .get("stop_reason")
         .and_then(Value::as_str)
         .map(map_anthropic_finish_reason)
         .unwrap_or("stop");
+
+    let mut message = Map::new();
+    message.insert("role".to_string(), Value::String("assistant".to_string()));
+    message.insert("content".to_string(), Value::String(text));
+    if !thinking_blocks.is_empty() {
+        message.insert(
+            "provider_metadata".to_string(),
+            vertex_reasoning_metadata("anthropic_messages", thinking_blocks),
+        );
+    }
 
     let mut completion = Map::new();
     completion.insert("id".to_string(), Value::String(id));
@@ -809,7 +1120,7 @@ fn normalize_anthropic_response(value: &Value, context: &ProviderRequestContext)
         "choices".to_string(),
         Value::Array(vec![json!({
             "index": 0,
-            "message": {"role":"assistant","content": text},
+            "message": message,
             "finish_reason": finish_reason
         })]),
     );
@@ -819,6 +1130,84 @@ fn normalize_anthropic_response(value: &Value, context: &ProviderRequestContext)
     }
 
     Value::Object(completion)
+}
+
+fn extract_anthropic_thinking_blocks(blocks: &[Value]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| match block.get("type").and_then(Value::as_str) {
+            Some("thinking") => {
+                let mut normalized = Map::new();
+                normalized.insert("type".to_string(), Value::String("thinking".to_string()));
+                normalized.insert(
+                    "thinking".to_string(),
+                    block
+                        .get("thinking")
+                        .cloned()
+                        .unwrap_or_else(|| Value::String(String::new())),
+                );
+                if let Some(signature) = block.get("signature").cloned() {
+                    normalized.insert("signature".to_string(), signature);
+                }
+                Some(Value::Object(normalized))
+            }
+            Some("redacted_thinking") => {
+                let mut normalized = Map::new();
+                normalized.insert(
+                    "type".to_string(),
+                    Value::String("redacted_thinking".to_string()),
+                );
+                if let Some(data) = block.get("data").cloned() {
+                    normalized.insert("data".to_string(), data);
+                }
+                Some(Value::Object(normalized))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn normalize_anthropic_thinking_delta(delta: &Map<String, Value>) -> Option<Value> {
+    match delta.get("type").and_then(Value::as_str) {
+        Some("thinking_delta") => {
+            let mut normalized = Map::new();
+            normalized.insert(
+                "type".to_string(),
+                Value::String("thinking_delta".to_string()),
+            );
+            normalized.insert(
+                "thinking".to_string(),
+                delta
+                    .get("thinking")
+                    .cloned()
+                    .unwrap_or_else(|| Value::String(String::new())),
+            );
+            Some(Value::Object(normalized))
+        }
+        Some("signature_delta") => {
+            let mut normalized = Map::new();
+            normalized.insert(
+                "type".to_string(),
+                Value::String("signature_delta".to_string()),
+            );
+            if let Some(signature) = delta.get("signature").cloned() {
+                normalized.insert("signature".to_string(), signature);
+            }
+            Some(Value::Object(normalized))
+        }
+        _ => None,
+    }
+}
+
+fn vertex_reasoning_metadata(source: &str, blocks: Vec<Value>) -> Value {
+    json!({
+        "gcp_vertex": {
+            "reasoning": {
+                "source": source,
+                "blocks": blocks
+            }
+        }
+    })
 }
 
 fn map_google_usage(value: &Value) -> Option<Value> {
@@ -1105,6 +1494,32 @@ where
                             );
                             yield Ok(openai_sse_chunk(&chunk));
                             role_emitted = true;
+                        } else if let Some(delta) = delta
+                            && let Some(block) = normalize_anthropic_thinking_delta(delta)
+                        {
+                            let mut outbound_delta = Map::new();
+                            if !role_emitted {
+                                outbound_delta.insert(
+                                    "role".to_string(),
+                                    Value::String("assistant".to_string()),
+                                );
+                            }
+                            outbound_delta.insert(
+                                "provider_metadata".to_string(),
+                                vertex_reasoning_metadata(
+                                    "anthropic_messages_stream",
+                                    vec![block],
+                                ),
+                            );
+                            let chunk = openai_delta_chunk(
+                                &stream_id,
+                                created,
+                                &model,
+                                Value::Object(outbound_delta),
+                                None,
+                            );
+                            yield Ok(openai_sse_chunk(&chunk));
+                            role_emitted = true;
                         }
                     }
                     "message_delta" => {
@@ -1275,6 +1690,26 @@ fn openai_chunk(
         "created": created,
         "model": model,
         "choices": [Value::Object(choice)]
+    })
+}
+
+fn openai_delta_chunk(
+    id: &str,
+    created: i64,
+    model: &str,
+    delta: Value,
+    finish_reason: Option<&str>,
+) -> Value {
+    json!({
+        "id": id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": delta,
+            "finish_reason": finish_reason
+        }]
     })
 }
 
@@ -1475,6 +1910,161 @@ mod tests {
     }
 
     #[test]
+    fn maps_vertex_opus_4_7_reasoning_effort_to_adaptive_thinking() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request.extra.insert("model".to_string(), json!("fast"));
+        request
+            .extra
+            .insert("reasoning_effort".to_string(), json!("xhigh"));
+        request.extra.insert("temperature".to_string(), json!(1.0));
+        request.extra.insert("top_p".to_string(), json!(1.0));
+
+        let mapped = map_anthropic_request(&request, &context("anthropic/claude-opus-4-7"), false)
+            .expect("mapped");
+
+        assert_eq!(mapped["anthropic_version"], "vertex-2023-10-16");
+        assert_eq!(mapped["thinking"], json!({ "type": "adaptive" }));
+        assert_eq!(mapped["output_config"], json!({ "effort": "xhigh" }));
+        assert!(mapped.get("reasoning_effort").is_none());
+        assert!(mapped.get("model").is_none());
+        assert!(mapped.get("temperature").is_none());
+        assert!(mapped.get("top_p").is_none());
+    }
+
+    #[test]
+    fn maps_vertex_opus_and_sonnet_4_6_reasoning_effort_to_adaptive_thinking() {
+        for model in ["anthropic/claude-opus-4-6", "anthropic/claude-sonnet-4-6"] {
+            let mut request = chat_request(vec![CoreChatMessage {
+                role: "user".to_string(),
+                content: Value::String("think carefully".to_string()),
+                name: None,
+                extra: BTreeMap::new(),
+            }]);
+            request
+                .extra
+                .insert("reasoning_effort".to_string(), json!("high"));
+
+            let mapped = map_anthropic_request(&request, &context(model), false).expect("mapped");
+
+            assert_eq!(mapped["thinking"], json!({ "type": "adaptive" }));
+            assert_eq!(mapped["output_config"], json!({ "effort": "high" }));
+            assert!(mapped.get("reasoning_effort").is_none());
+        }
+    }
+
+    #[test]
+    fn maps_vertex_opus_4_5_reasoning_effort_with_manual_budget() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request.extra.insert(
+            "reasoning".to_string(),
+            json!({ "effort": "medium", "budget_tokens": 2048 }),
+        );
+
+        let mapped = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-opus-4-5@20251101"),
+            false,
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            mapped["thinking"],
+            json!({ "type": "enabled", "budget_tokens": 2048 })
+        );
+        assert_eq!(mapped["output_config"], json!({ "effort": "medium" }));
+        assert!(mapped.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn maps_vertex_older_claude_reasoning_budget_to_manual_thinking() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request.extra.insert(
+            "reasoning".to_string(),
+            json!({ "effort": "medium", "budget_tokens": 1024 }),
+        );
+
+        let mapped = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-sonnet-4-5@20250929"),
+            false,
+        )
+        .expect("mapped");
+
+        assert_eq!(
+            mapped["thinking"],
+            json!({ "type": "enabled", "budget_tokens": 1024 })
+        );
+        assert!(mapped.get("output_config").is_none());
+        assert!(mapped.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn rejects_vertex_opus_4_7_manual_thinking_budget() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request.extra.insert(
+            "thinking".to_string(),
+            json!({ "type": "enabled", "budget_tokens": 4096 }),
+        );
+
+        let error = map_anthropic_request(&request, &context("anthropic/claude-opus-4-7"), false)
+            .expect_err("manual thinking should be rejected");
+
+        match error {
+            ProviderError::InvalidRequest(message) => {
+                assert!(message.contains("thinking.type: enabled"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn rejects_vertex_older_claude_adaptive_thinking() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("thinking".to_string(), json!({ "type": "adaptive" }));
+
+        let error = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-haiku-4-5@20251001"),
+            false,
+        )
+        .expect_err("adaptive thinking should be rejected");
+
+        match error {
+            ProviderError::InvalidRequest(message) => {
+                assert!(message.contains("thinking.type: adaptive"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
     fn normalizes_google_response_into_openai_shape() {
         let response = json!({
             "responseId": "resp-123",
@@ -1502,6 +2092,36 @@ mod tests {
         assert_eq!(normalized["choices"][0]["message"]["content"], "hello");
         assert_eq!(normalized["usage"]["prompt_tokens"], 5);
         assert_eq!(normalized["usage"]["completion_tokens"], 7);
+    }
+
+    #[test]
+    fn normalizes_anthropic_thinking_metadata_without_leaking_into_content() {
+        let response = json!({
+            "id":"msg_123",
+            "content":[
+                {"type":"thinking","thinking":"summarized hidden reasoning","signature":"sig-thinking"},
+                {"type":"redacted_thinking","data":"encrypted-redacted"},
+                {"type":"text","text":"visible answer"}
+            ],
+            "stop_reason":"end_turn",
+            "usage":{"input_tokens":5,"output_tokens":7}
+        });
+        let normalized =
+            normalize_anthropic_response(&response, &context("anthropic/claude-opus-4-7"));
+        let message = &normalized["choices"][0]["message"];
+
+        assert_eq!(message["content"], "visible answer");
+        assert_eq!(
+            message["provider_metadata"]["gcp_vertex"]["reasoning"]["source"],
+            "anthropic_messages"
+        );
+        assert_eq!(
+            message["provider_metadata"]["gcp_vertex"]["reasoning"]["blocks"],
+            json!([
+                {"type":"thinking","thinking":"summarized hidden reasoning","signature":"sig-thinking"},
+                {"type":"redacted_thinking","data":"encrypted-redacted"}
+            ])
+        );
     }
 
     #[test]
@@ -1652,6 +2272,42 @@ data: {"type":"vertex_event"}
         assert!(!rendered.contains("data: [DONE]"));
     }
 
+    #[tokio::test]
+    async fn anthropic_stream_preserves_thinking_and_signature_metadata() {
+        let upstream = stream::iter(vec![Ok(Bytes::from(concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\"}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"signature_delta\",\"signature\":\"sig-stream\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"visible\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
+        )))]);
+        let stream = super::normalize_anthropic_stream(
+            upstream,
+            "chatcmpl-test".to_string(),
+            1,
+            "fast".to_string(),
+        );
+        let bytes: Vec<_> = stream.collect().await;
+        let rendered = bytes
+            .into_iter()
+            .map(|item| String::from_utf8(item.expect("chunk").to_vec()).expect("utf8"))
+            .collect::<String>();
+
+        assert!(rendered.contains("\"content\":\"visible\""));
+        assert!(rendered.contains("\"provider_metadata\""));
+        assert!(rendered.contains("\"gcp_vertex\""));
+        assert!(rendered.contains("\"thinking_delta\""));
+        assert!(rendered.contains("\"signature_delta\""));
+        assert!(rendered.contains("\"sig-stream\""));
+        assert_eq!(rendered.matches("\"role\":\"assistant\"").count(), 1);
+        assert!(rendered.contains("data: [DONE]"));
+    }
+
     fn vertex_provider_for_test(api_host: String) -> VertexProvider {
         VertexProvider::new(VertexProviderConfig {
             provider_key: "vertex-prod".to_string(),
@@ -1756,7 +2412,9 @@ data: {"type":"vertex_event"}
                      State(captured): State<Arc<Mutex<Option<Value>>>>,
                      headers: HeaderMap,
                      Json(payload): Json<Value>| async move {
-                        assert!(path.ends_with(":streamRawPredict"));
+                        assert!(path.ends_with(
+                            "publishers/anthropic/models/claude-sonnet-4-6:streamRawPredict"
+                        ));
                         assert_eq!(
                             headers
                                 .get("authorization")
@@ -1823,6 +2481,7 @@ data: {"type":"vertex_event"}
             request_payload["anthropic_version"],
             Value::String("vertex-2023-10-16".to_string())
         );
+        assert!(request_payload.get("model").is_none());
         assert_eq!(request_payload["stream"], Value::Bool(true));
     }
 }

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -430,9 +430,9 @@ fn map_anthropic_request(
         );
     }
 
+    merge_object_overrides(&mut body, &context.extra_body);
     apply_vertex_anthropic_thinking_compatibility(&mut body, &context.upstream_model)?;
     validate_vertex_anthropic_sampling_fields(&mut body, &context.upstream_model)?;
-    merge_object_overrides(&mut body, &context.extra_body);
     Ok(Value::Object(body))
 }
 
@@ -640,10 +640,12 @@ fn validate_caller_thinking_for_policy(
     let Some(thinking) = body.get("thinking") else {
         return Ok(());
     };
-    let thinking_type = thinking
-        .as_object()
-        .and_then(|object| object.get("type"))
-        .and_then(Value::as_str);
+    let thinking = thinking.as_object().ok_or_else(|| {
+        ProviderError::InvalidRequest(
+            "`thinking` must be an object for Anthropic Vertex mapping".to_string(),
+        )
+    })?;
+    let thinking_type = thinking.get("type").and_then(Value::as_str);
 
     match policy {
         ClaudeThinkingPolicy::AdaptiveOnly => {
@@ -669,6 +671,16 @@ fn validate_caller_thinking_for_policy(
             }
         }
         ClaudeThinkingPolicy::AdaptivePreferred => {}
+    }
+
+    if thinking_type == Some("enabled")
+        && thinking
+            .get("budget_tokens")
+            .is_none_or(|value| value.is_null())
+    {
+        return Err(ProviderError::InvalidRequest(format!(
+            "`thinking.type: enabled` for `{upstream_model}` must include `budget_tokens`"
+        )));
     }
 
     Ok(())
@@ -2160,6 +2172,59 @@ mod tests {
         match error {
             ProviderError::InvalidRequest(message) => {
                 assert!(message.contains("thinking.type: enabled"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn rejects_vertex_extra_body_that_bypasses_anthropic_validation() {
+        let request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        let mut context = context("anthropic/claude-opus-4-7");
+        context
+            .extra_body
+            .insert("temperature".to_string(), json!(0.2));
+
+        let error = map_anthropic_request(&request, &context, false)
+            .expect_err("route extra_body should be validated after merge");
+
+        match error {
+            ProviderError::InvalidRequest(message) => {
+                assert!(message.contains("temperature"));
+                assert!(message.contains("Claude Opus 4.7+"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn rejects_vertex_native_manual_thinking_without_budget() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("thinking".to_string(), json!({ "type": "enabled" }));
+
+        let error = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-sonnet-4-5@20250929"),
+            false,
+        )
+        .expect_err("native manual thinking requires a budget");
+
+        match error {
+            ProviderError::InvalidRequest(message) => {
+                assert!(message.contains("thinking.type: enabled"));
+                assert!(message.contains("budget_tokens"));
             }
             other => panic!("unexpected error: {other}"),
         }

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -474,7 +474,10 @@ fn apply_vertex_anthropic_thinking_compatibility(
     body: &mut Map<String, Value>,
     upstream_model: &str,
 ) -> Result<(), ProviderError> {
-    let effort = extract_anthropic_reasoning_effort(body)?;
+    let reasoning_effort = extract_anthropic_reasoning_effort(body)?;
+    let native_effort = extract_existing_anthropic_output_effort(body)?;
+    let has_native_effort = native_effort.is_some();
+    let effort = merge_optional_efforts(reasoning_effort, native_effort, upstream_model)?;
     let budget_tokens = extract_anthropic_reasoning_budget_tokens(body);
     let policy = claude_thinking_policy(upstream_model);
 
@@ -500,6 +503,11 @@ fn apply_vertex_anthropic_thinking_compatibility(
                 merge_anthropic_output_effort(body, effort, upstream_model)?;
             }
             ClaudeThinkingPolicy::ManualOnly => {
+                if has_native_effort {
+                    return Err(ProviderError::InvalidRequest(format!(
+                        "`output_config.effort` is not supported for `{upstream_model}`"
+                    )));
+                }
                 let budget_tokens = budget_tokens
                     .or_else(|| existing_manual_thinking_budget(body))
                     .ok_or_else(|| {
@@ -532,7 +540,9 @@ fn apply_vertex_anthropic_thinking_compatibility(
 fn extract_anthropic_reasoning_effort(
     body: &mut Map<String, Value>,
 ) -> Result<Option<Value>, ProviderError> {
-    let reasoning_effort = body.remove("reasoning_effort");
+    let reasoning_effort = body
+        .remove("reasoning_effort")
+        .filter(|value| !value.is_null());
     let reasoning = body.remove("reasoning");
 
     match (reasoning_effort, reasoning) {
@@ -541,10 +551,11 @@ fn extract_anthropic_reasoning_effort(
             if let Some(budget_tokens) = reasoning.remove("budget_tokens") {
                 body.insert("reasoning_budget_tokens".to_string(), budget_tokens);
             }
-            Ok(reasoning.remove("effort"))
+            Ok(reasoning.remove("effort").filter(|value| !value.is_null()))
         }
         (Some(effort), Some(Value::Object(mut reasoning))) => {
-            if let Some(reasoning_effort) = reasoning.remove("effort")
+            if let Some(reasoning_effort) =
+                reasoning.remove("effort").filter(|value| !value.is_null())
                 && reasoning_effort != effort
             {
                 return Err(ProviderError::InvalidRequest(
@@ -562,6 +573,51 @@ fn extract_anthropic_reasoning_effort(
         (_, Some(_)) => Err(ProviderError::InvalidRequest(
             "`reasoning` must be an object for Anthropic Vertex mapping".to_string(),
         )),
+        (None, None) => Ok(None),
+    }
+}
+
+fn extract_existing_anthropic_output_effort(
+    body: &mut Map<String, Value>,
+) -> Result<Option<Value>, ProviderError> {
+    let (effort, remove_output_config) = {
+        let Some(output_config) = body.get_mut("output_config") else {
+            return Ok(None);
+        };
+        let output_config = output_config.as_object_mut().ok_or_else(|| {
+            ProviderError::InvalidRequest(
+                "`output_config` must be an object for Anthropic Vertex mapping".to_string(),
+            )
+        })?;
+
+        let effort = output_config.get("effort").cloned();
+        if effort.as_ref().is_some_and(Value::is_null) {
+            output_config.remove("effort");
+            (None, output_config.is_empty())
+        } else {
+            (effort, false)
+        }
+    };
+    if remove_output_config {
+        body.remove("output_config");
+    }
+
+    Ok(effort)
+}
+
+fn merge_optional_efforts(
+    reasoning_effort: Option<Value>,
+    native_effort: Option<Value>,
+    upstream_model: &str,
+) -> Result<Option<Value>, ProviderError> {
+    match (reasoning_effort, native_effort) {
+        (Some(reasoning_effort), Some(native_effort)) if reasoning_effort != native_effort => {
+            Err(ProviderError::InvalidRequest(format!(
+                "`reasoning_effort` conflicts with `output_config.effort` for `{upstream_model}`"
+            )))
+        }
+        (Some(reasoning_effort), _) => Ok(Some(reasoning_effort)),
+        (None, Some(native_effort)) => Ok(Some(native_effort)),
         (None, None) => Ok(None),
     }
 }
@@ -1934,6 +1990,78 @@ mod tests {
         assert!(mapped.get("model").is_none());
         assert!(mapped.get("temperature").is_none());
         assert!(mapped.get("top_p").is_none());
+    }
+
+    #[test]
+    fn ignores_null_reasoning_effort_for_vertex_anthropic_mapping() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("hello".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("reasoning_effort".to_string(), Value::Null);
+        request
+            .extra
+            .insert("reasoning".to_string(), json!({ "effort": null }));
+        request
+            .extra
+            .insert("output_config".to_string(), json!({ "effort": null }));
+
+        let mapped = map_anthropic_request(&request, &context("anthropic/claude-opus-4-7"), false)
+            .expect("mapped");
+
+        assert!(mapped.get("thinking").is_none());
+        assert!(mapped.get("output_config").is_none());
+        assert!(mapped.get("reasoning_effort").is_none());
+        assert!(mapped.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn validates_native_output_config_effort_for_vertex_anthropic_mapping() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("output_config".to_string(), json!({ "effort": "xhigh" }));
+
+        let mapped = map_anthropic_request(&request, &context("anthropic/claude-opus-4-7"), false)
+            .expect("mapped");
+
+        assert_eq!(mapped["thinking"], json!({ "type": "adaptive" }));
+        assert_eq!(mapped["output_config"], json!({ "effort": "xhigh" }));
+    }
+
+    #[test]
+    fn rejects_native_output_config_effort_for_vertex_manual_only_models() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("output_config".to_string(), json!({ "effort": "medium" }));
+        request
+            .extra
+            .insert("reasoning_budget_tokens".to_string(), json!(1024));
+
+        let error = map_anthropic_request(
+            &request,
+            &context("anthropic/claude-sonnet-4-5@20250929"),
+            false,
+        )
+        .expect_err("manual-only effort rejected")
+        .to_string();
+
+        assert!(error.contains("output_config.effort"));
     }
 
     #[test]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,7 +45,10 @@ export default defineConfig({
       },
       {
         text: "Providers",
-        items: [{ text: "AWS Bedrock", link: "/providers/aws-bedrock" }],
+        items: [
+          { text: "AWS Bedrock", link: "/providers/aws-bedrock" },
+          { text: "Google Vertex AI", link: "/providers/gcp-vertex" },
+        ],
       },
       {
         text: "Operations",

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -385,6 +385,7 @@ Routing and pricing caveats:
 - `upstream_model` must use `<publisher>/<model_id>`
 - pricing identity is inferred from the publisher prefix
 - Anthropic-on-Vertex pricing is only supported for `location=global`
+- provider-specific configuration examples live in [Google Vertex AI](../providers/gcp-vertex.md)
 
 ### `aws_bedrock`
 

--- a/docs/configuration/pricing-catalog-and-accounting.md
+++ b/docs/configuration/pricing-catalog-and-accounting.md
@@ -119,7 +119,7 @@ The pricing catalog can preserve more rate metadata than the runtime charges tod
 
 That distinction keeps the ledger conservative. The gateway should not infer spend for provider-specific counters until the pricing and request semantics are explicit. Richer token and cache accounting is tracked in [issue #92](https://github.com/ahstn/oceans-llm/issues/92).
 
-AWS Bedrock Anthropic Claude responses preserve the raw Anthropic usage object under `usage.provider_usage`, including cache counters such as `cache_read_input_tokens` and `cache_creation_input_tokens` when Bedrock returns them. Durable accounting still uses only normalized `prompt_tokens`, `completion_tokens`, and `total_tokens`; cache read/write discounts or surcharges are not priced in this slice.
+AWS Bedrock Anthropic Claude responses preserve the raw Anthropic usage object under `usage.provider_usage`, including cache counters such as `cache_read_input_tokens` and `cache_creation_input_tokens` when Bedrock returns them. Bedrock Claude thinking and Converse reasoning blocks are preserved as provider metadata on Chat Completions messages or stream deltas, but they are not priced as separate ledger dimensions. Durable accounting still uses only normalized `prompt_tokens`, `completion_tokens`, and `total_tokens`; cache read/write discounts, hidden thinking costs, and reasoning-specific counters remain aligned with [issue #92](https://github.com/ahstn/oceans-llm/issues/92).
 
 ## Relationship to Request Flow
 

--- a/docs/providers/aws-bedrock.md
+++ b/docs/providers/aws-bedrock.md
@@ -11,6 +11,7 @@ The gateway uses the Bedrock Runtime endpoint shape:
 - non-Anthropic chat models use Bedrock `Converse`
 - Anthropic Claude chat models use Bedrock `InvokeModel` with the native Anthropic Messages body for non-streaming requests
 - streaming chat uses Bedrock `ConverseStream` and is normalized into OpenAI-compatible chat-completion chunks
+- native Anthropic Messages streaming through `InvokeModelWithResponseStream` is not implemented in this gateway slice
 - `/v1/responses` and `/v1/embeddings` are not implemented for `aws_bedrock` routes
 
 The provider adapter supports bearer-token auth and IAM SigV4 request signing. AWS documents `AWS_BEARER_TOKEN_BEDROCK` as the environment variable recognized by Bedrock API-key auth and direct HTTP calls can pass the same value as `Authorization: Bearer ...`: [Use an Amazon Bedrock API key](https://docs.aws.amazon.com/en_us/bedrock/latest/userguide/api-keys-use.html).
@@ -116,6 +117,12 @@ Older Claude models do not support adaptive thinking. Claude Sonnet 4.5, Claude 
 
 For Opus 4.7 and later, non-default `temperature`, `top_p`, and `top_k` fail locally. Default `temperature: 1` and `top_p: 1` are omitted. If callers provide both normalized reasoning fields and provider-native `thinking` or `output_config` fields, the provider-native fields must agree with the normalized values; conflicting values are rejected. Other provider-native fields such as `anthropic_beta` and `context_management` remain pass-through.
 
+### Streaming and Tool Continuations
+
+Streaming Bedrock routes currently use Bedrock `ConverseStream`. Native Anthropic Messages streaming through `InvokeModelWithResponseStream` remains a separate follow-up tracked by [issue #139](https://github.com/ahstn/oceans-llm/issues/139). This matters for Claude-specific stream contracts: native Messages streams emit Anthropic SSE events such as `thinking_delta`, `signature_delta`, and `content_block_start`, while the current Bedrock stream path normalizes Bedrock Converse EventStream events.
+
+Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic thinking blocks and Bedrock Converse reasoning content are preserved under `provider_metadata.aws_bedrock.reasoning` for debugging and provider continuity. The gateway does not yet rehydrate those preserved `thinking`, `signature`, or `redacted_thinking` blocks back into future request content when callers send tool results. Anthropic documents that tool-use continuations with thinking may require complete unmodified thinking blocks, so callers should treat this as unsupported gateway-managed continuity until [issue #140](https://github.com/ahstn/oceans-llm/issues/140) lands.
+
 ## Amazon Nova Example
 
 Amazon Nova routes use the generic Bedrock Converse request shape.
@@ -190,7 +197,7 @@ The current runtime executes one selected route. Priority and weight affect rout
 - Set `responses: false` and `embeddings: false` on Bedrock routes until those API families exist in the provider adapter.
 - Keep `json_schema: false` unless a specific Bedrock route has explicit provider-specific overrides and tests.
 - Use `extra_body` only for additive Bedrock or Anthropic fields you have tested for the exact model family.
-- Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic thinking blocks and Bedrock Converse reasoning content are preserved under `provider_metadata.aws_bedrock.reasoning` for debugging and provider continuity; exact reasoning/cache accounting remains tracked by [issue #92](https://github.com/ahstn/oceans-llm/issues/92), and native Bedrock Anthropic streaming remains tracked by [issue #129](https://github.com/ahstn/oceans-llm/issues/129).
+- Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic thinking blocks and Bedrock Converse reasoning content are preserved under `provider_metadata.aws_bedrock.reasoning` for debugging and provider continuity. Exact reasoning/cache accounting remains tracked by [issue #92](https://github.com/ahstn/oceans-llm/issues/92), native Bedrock Anthropic streaming remains tracked by [issue #139](https://github.com/ahstn/oceans-llm/issues/139), and thinking block replay for tool-use continuations remains tracked by [issue #140](https://github.com/ahstn/oceans-llm/issues/140).
 - Check the model card before adding a new `upstream_model`; Bedrock model IDs and inference profile support differ by model and Region.
 - Prefer `default_chain` for production IAM roles and IRSA. Use `static_credentials` only for constrained local or controlled deployment cases where credential rotation is handled outside the gateway.
 

--- a/docs/providers/aws-bedrock.md
+++ b/docs/providers/aws-bedrock.md
@@ -95,6 +95,27 @@ models:
 
 Native Claude invocation requires callers to set `max_tokens` or `max_completion_tokens`. Bedrock-hosted Claude vision is limited to base64 image payloads in this gateway slice; remote image URLs are rejected before the provider call.
 
+### Claude Thinking Compatibility
+
+For native Claude Messages invocation, OpenAI-shaped `reasoning_effort` maps to Anthropic Messages `output_config.effort` without forwarding the OpenAI-only field. On Claude Opus 4.7 and later, the gateway also sends `thinking: { "type": "adaptive" }` and rejects manual `thinking.type: "enabled"` budgets. On Claude Opus 4.6 and Claude Sonnet 4.6, `reasoning_effort` also selects adaptive thinking, while explicit manual `thinking` budgets remain pass-through for existing callers.
+
+For Bedrock Converse and ConverseStream, the gateway uses Bedrock's provider-specific shape instead:
+
+```json
+{
+  "additionalModelRequestFields": {
+    "thinking": {
+      "type": "adaptive",
+      "effort": "high"
+    }
+  }
+}
+```
+
+Older Claude models do not support adaptive thinking. Claude Sonnet 4.5, Claude Haiku 4.5, and earlier models require a manual budget via `thinking.budget_tokens`, `reasoning.budget_tokens`, `reasoning_budget_tokens`, or `thinking_budget_tokens`; the gateway sends `thinking: { "type": "enabled", "budget_tokens": ... }` and does not add `output_config.effort`. Claude Opus 4.5 additionally supports Bedrock's beta effort parameter for native Messages invocation, so the gateway adds `anthropic_beta: ["effort-2025-11-24"]` when it maps `reasoning_effort` to `output_config.effort` for that model.
+
+For Opus 4.7 and later, non-default `temperature`, `top_p`, and `top_k` fail locally. Default `temperature: 1` and `top_p: 1` are omitted. If callers provide both normalized reasoning fields and provider-native `thinking` or `output_config` fields, the provider-native fields must agree with the normalized values; conflicting values are rejected. Other provider-native fields such as `anthropic_beta` and `context_management` remain pass-through.
+
 ## Amazon Nova Example
 
 Amazon Nova routes use the generic Bedrock Converse request shape.
@@ -169,6 +190,7 @@ The current runtime executes one selected route. Priority and weight affect rout
 - Set `responses: false` and `embeddings: false` on Bedrock routes until those API families exist in the provider adapter.
 - Keep `json_schema: false` unless a specific Bedrock route has explicit provider-specific overrides and tests.
 - Use `extra_body` only for additive Bedrock or Anthropic fields you have tested for the exact model family.
+- Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic thinking blocks and Bedrock Converse reasoning content are preserved under `provider_metadata.aws_bedrock.reasoning` for debugging and provider continuity; exact reasoning/cache accounting remains tracked by [issue #92](https://github.com/ahstn/oceans-llm/issues/92), and native Bedrock Anthropic streaming remains tracked by [issue #129](https://github.com/ahstn/oceans-llm/issues/129).
 - Check the model card before adding a new `upstream_model`; Bedrock model IDs and inference profile support differ by model and Region.
 - Prefer `default_chain` for production IAM roles and IRSA. Use `static_credentials` only for constrained local or controlled deployment cases where credential rotation is handled outside the gateway.
 

--- a/docs/providers/gcp-vertex.md
+++ b/docs/providers/gcp-vertex.md
@@ -103,6 +103,8 @@ models:
 
 Native Claude invocation requires `max_tokens`. If callers omit it, the gateway currently supplies `max_tokens: 1024` for Anthropic-on-Vertex routes.
 
+Keep `tools: false` and `vision: false` for Anthropic-on-Vertex routes in this slice. Upstream Claude-on-Vertex uses an Anthropic Messages-like API and current model cards advertise broader agent, computer-use, image, and document capabilities for some Claude models, but the gateway's current Anthropic-on-Vertex mapper is intentionally narrower. Function tools, tool-result continuations, image blocks, document blocks, and their stream behavior remain capability-gated until request mapping and fixtures are added in [issue #141](https://github.com/ahstn/oceans-llm/issues/141).
+
 ### Claude Thinking Compatibility
 
 For Anthropic-on-Vertex, OpenAI-shaped `reasoning_effort` maps to Anthropic Messages `output_config.effort` without forwarding the OpenAI-only field. The gateway also applies model-aware thinking policy before sending the Vertex request.
@@ -177,7 +179,7 @@ Manual budget example for an older Claude model:
 
 For Claude Sonnet 4.5, the gateway sends manual `thinking.type: "enabled"` with `budget_tokens` and omits `output_config.effort`. For Claude Opus 4.5, it sends the manual budget and `output_config.effort`.
 
-Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic `thinking`, `redacted_thinking`, `thinking_delta`, and `signature_delta` blocks are preserved under `provider_metadata.gcp_vertex.reasoning` for debugging and provider continuity.
+Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic `thinking`, `redacted_thinking`, `thinking_delta`, and `signature_delta` blocks are preserved under `provider_metadata.gcp_vertex.reasoning` for debugging and provider continuity. The gateway does not yet rehydrate that provider metadata into future Anthropic content blocks when callers send tool results. Anthropic documents that tool-use continuations with thinking may require complete unmodified thinking blocks, so gateway-managed replay remains tracked by [issue #140](https://github.com/ahstn/oceans-llm/issues/140).
 
 ## Gemini Example
 
@@ -210,6 +212,7 @@ Vertex Google multimodal inputs currently accept `gs://` image and file URIs thr
 - Vertex AI limits Anthropic request payloads to 30 MB. Large documents and many images can hit that byte limit before the model token limit.
 - Keep `json_schema: false` unless a route has explicit provider-specific overrides and tests.
 - Use `extra_body` only for additive provider fields you have tested for the exact publisher and model family.
+- Keep Anthropic-on-Vertex `tools: false` and `vision: false` unless you have gateway fixtures for that route. Upstream Claude model capability is not enough by itself; route capability flags should reflect the gateway mapper and tests.
 - Check Anthropic and Google Cloud model pages before adding a new Claude route; model IDs, endpoint availability, context windows, and retirement dates vary by model and location.
 
 ## Validation

--- a/docs/providers/gcp-vertex.md
+++ b/docs/providers/gcp-vertex.md
@@ -1,0 +1,217 @@
+# Google Vertex AI
+
+`See also`: [Configuration Reference](../configuration/configuration-reference.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Provider API Compatibility](../reference/provider-api-compatibility.md), [Pricing Catalog and Accounting](../configuration/pricing-catalog-and-accounting.md)
+
+This page owns provider-specific configuration examples for Google Vertex AI routes.
+
+## Current Runtime Boundary
+
+The gateway uses one `gcp_vertex` provider type for multiple Vertex publisher families:
+
+- `google/*` upstream models use Vertex `generateContent` and `streamGenerateContent`
+- `anthropic/*` upstream models use Anthropic-on-Vertex `rawPredict` and `streamRawPredict`
+- `/v1/responses` and `/v1/embeddings` are not implemented for `gcp_vertex` routes in this slice
+
+Vertex routes require Google Cloud authentication with the `https://www.googleapis.com/auth/cloud-platform` scope. The provider supports Application Default Credentials, service-account JSON from a mounted path, and static bearer tokens for constrained environments.
+
+## Provider
+
+```yaml
+providers:
+  - id: vertex-global
+    type: gcp_vertex
+    project_id: env.GCP_PROJECT_ID
+    location: global
+    auth:
+      mode: adc
+    display:
+      label: Google Vertex AI
+      icon_key: vertexai
+```
+
+`api_host` is optional. When omitted, the gateway uses `aiplatform.googleapis.com`, which is the right default for the global endpoint. For Vertex multi-region endpoints, set `api_host` explicitly to `aiplatform.us.rep.googleapis.com` or `aiplatform.eu.rep.googleapis.com`. For a regional endpoint, set it to the regional Vertex host such as `us-east5-aiplatform.googleapis.com`. Anthropic-on-Vertex pricing is currently supported only for `location: global`.
+
+Service-account and bearer examples:
+
+```yaml
+providers:
+  - id: vertex-service-account
+    type: gcp_vertex
+    project_id: env.GCP_PROJECT_ID
+    location: us
+    api_host: aiplatform.us.rep.googleapis.com
+    auth:
+      mode: service_account
+      credentials_path: /var/run/secrets/gcp/service-account.json
+
+  - id: vertex-bearer
+    type: gcp_vertex
+    project_id: env.GCP_PROJECT_ID
+    location: us-central1
+    api_host: us-central1-aiplatform.googleapis.com
+    auth:
+      mode: bearer
+      token: env.GCP_VERTEX_ACCESS_TOKEN
+```
+
+## Model Identity
+
+Use publisher-qualified `upstream_model` values:
+
+- Google models: `google/<model-id>`
+- Anthropic models: `anthropic/<model-id>`
+
+The publisher prefix selects the request mapper and pricing family. The model ID after the slash is passed to the Vertex endpoint path.
+
+Examples verified against Anthropic and Google Cloud docs on 2026-05-01:
+
+| Use case | Gateway model id | Vertex `upstream_model` | Notes |
+| --- | --- | --- | --- |
+| Latest high-capability Claude | `claude-opus-vertex` | `anthropic/claude-opus-4-7` | Claude Opus 4.7 is available through Anthropic-on-Vertex and supports adaptive thinking. |
+| Claude coding and agent workloads | `claude-sonnet-vertex` | `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 supports adaptive thinking with effort. |
+| Older pinned Claude | `claude-sonnet-45-vertex` | `anthropic/claude-sonnet-4-5@20250929` | Versioned Anthropic model IDs use the `@YYYYMMDD` suffix on Vertex. |
+| Gemini chat | `gemini-flash-vertex` | `google/gemini-2.0-flash` | Uses the Vertex Google publisher request shape. |
+
+Google documents that Claude model availability varies by endpoint and region. Prefer `global` when your residency policy allows it; use `us`, `eu`, or a regional location when you need a geography-specific processing boundary.
+
+## Claude Example
+
+Anthropic-on-Vertex uses the Anthropic Messages body shape with Vertex transport requirements:
+
+- the model stays in the endpoint path, not the JSON request body
+- the body includes `anthropic_version: "vertex-2023-10-16"`
+- non-streaming requests use `rawPredict`
+- streaming requests use `streamRawPredict`
+
+```yaml
+models:
+  - id: claude-opus-vertex
+    description: Claude Opus on Google Vertex AI
+    tags: [vertex, claude, reasoning]
+    routes:
+      - provider: vertex-global
+        upstream_model: anthropic/claude-opus-4-7
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: false
+          vision: false
+          json_schema: false
+```
+
+Native Claude invocation requires `max_tokens`. If callers omit it, the gateway currently supplies `max_tokens: 1024` for Anthropic-on-Vertex routes.
+
+### Claude Thinking Compatibility
+
+For Anthropic-on-Vertex, OpenAI-shaped `reasoning_effort` maps to Anthropic Messages `output_config.effort` without forwarding the OpenAI-only field. The gateway also applies model-aware thinking policy before sending the Vertex request.
+
+Adaptive example for Claude Opus 4.7:
+
+```json
+{
+  "anthropic_version": "vertex-2023-10-16",
+  "max_tokens": 16000,
+  "thinking": {
+    "type": "adaptive"
+  },
+  "output_config": {
+    "effort": "xhigh"
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Review this implementation plan."
+    }
+  ]
+}
+```
+
+Gateway callers can request the same shape with OpenAI-compatible fields:
+
+```json
+{
+  "model": "claude-opus-vertex",
+  "max_tokens": 16000,
+  "reasoning_effort": "xhigh",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Review this implementation plan."
+    }
+  ]
+}
+```
+
+The gateway sends `thinking: { "type": "adaptive" }` and `output_config.effort` upstream, and removes `reasoning_effort`.
+
+Model behavior:
+
+| Model family | Gateway behavior |
+| --- | --- |
+| Claude Opus 4.7 and later | `reasoning_effort` or `reasoning.effort` maps to `thinking: { "type": "adaptive" }` plus `output_config.effort`. Manual `thinking.type: "enabled"` and `budget_tokens` are rejected. Non-default `temperature`, `top_p`, and `top_k` are rejected; default `temperature: 1` and `top_p: 1` are omitted. |
+| Claude Opus 4.6 and Claude Sonnet 4.6 | `reasoning_effort` maps to adaptive thinking and `output_config.effort`. Caller-supplied manual budgets remain pass-through because Anthropic still accepts them, but they are deprecated upstream. |
+| Claude Mythos Preview | Adaptive thinking is the default when `thinking` is unset. `reasoning_effort` maps to `output_config.effort`; `thinking.type: "disabled"` is rejected. |
+| Claude Opus 4.5 | Adaptive thinking is rejected. `reasoning_effort` maps to `output_config.effort` only when a manual thinking budget is also supplied. |
+| Claude Sonnet/Haiku 4.5 and older Claude models | Adaptive thinking is rejected. These models require an explicit manual budget from `reasoning.budget_tokens`, `reasoning_budget_tokens`, `thinking_budget_tokens`, or caller-supplied `thinking.type: "enabled"` with `budget_tokens`; the gateway does not add `output_config.effort`. |
+
+Manual budget example for an older Claude model:
+
+```json
+{
+  "model": "claude-sonnet-45-vertex",
+  "max_tokens": 8192,
+  "reasoning": {
+    "effort": "medium",
+    "budget_tokens": 2048
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Analyze this migration risk."
+    }
+  ]
+}
+```
+
+For Claude Sonnet 4.5, the gateway sends manual `thinking.type: "enabled"` with `budget_tokens` and omits `output_config.effort`. For Claude Opus 4.5, it sends the manual budget and `output_config.effort`.
+
+Chat Completions hides Claude thinking from normal `content` and `delta.content`. Native Anthropic `thinking`, `redacted_thinking`, `thinking_delta`, and `signature_delta` blocks are preserved under `provider_metadata.gcp_vertex.reasoning` for debugging and provider continuity.
+
+## Gemini Example
+
+Google publisher routes use Vertex `generateContent` and `streamGenerateContent`.
+
+```yaml
+models:
+  - id: gemini-flash-vertex
+    description: Gemini Flash on Google Vertex AI
+    tags: [vertex, gemini]
+    routes:
+      - provider: vertex-global
+        upstream_model: google/gemini-2.0-flash
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: false
+          vision: true
+          json_schema: false
+```
+
+Vertex Google multimodal inputs currently accept `gs://` image and file URIs through OpenAI-compatible typed content. Inline/base64 data and remote HTTP URLs are not supported in this gateway slice.
+
+## Operational Notes
+
+- Set `responses: false` and `embeddings: false` on Vertex routes until those API families exist in the provider adapter.
+- Use `upstream_model: anthropic/<model-id>` for Claude and `upstream_model: google/<model-id>` for Gemini; unqualified model IDs fail at the gateway edge.
+- Vertex AI limits Anthropic request payloads to 30 MB. Large documents and many images can hit that byte limit before the model token limit.
+- Keep `json_schema: false` unless a route has explicit provider-specific overrides and tests.
+- Use `extra_body` only for additive provider fields you have tested for the exact publisher and model family.
+- Check Anthropic and Google Cloud model pages before adding a new Claude route; model IDs, endpoint availability, context windows, and retirement dates vary by model and location.
+
+## Validation
+
+Validate documentation-only edits with `mise run docs-check`. For runtime Vertex adapter changes, run `cargo test -p gateway-providers vertex::tests` and `cargo clippy -p gateway-providers --all-targets -- -D warnings`.

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -78,6 +78,33 @@ For example, a Vertex Google chat route should normally set `responses: false` a
 
 For Bedrock, this foundation guarantees config load, validation, seeding, registration, deterministic region, endpoint, timeout, display, auth metadata, Converse chat execution, Claude Messages invocation, and ConverseStream chat streaming for bearer-token auth. It also supports IAM/SigV4 signing for the `default_chain` and `static_credentials` auth modes. Bedrock `upstream_model` values should match Bedrock Runtime model identity: base model IDs, inference profile IDs, or Bedrock ARNs accepted by the target Bedrock Runtime operation. AWS documents `InvokeModel` as requiring `bedrock:InvokeModel`; streamed invocation and Converse access require the corresponding Bedrock runtime permissions.
 
+## Google Vertex Anthropic Claude
+
+Vertex-hosted Claude models are selected when the Vertex `upstream_model` starts with `anthropic/`. The model ID after the slash is used in the Vertex endpoint path:
+
+- non-streaming Chat Completions use `rawPredict`
+- streaming Chat Completions use `streamRawPredict`
+- `model` is not forwarded in the JSON body
+- `anthropic_version: "vertex-2023-10-16"` is included in the JSON body
+
+Anthropic-on-Vertex uses the Anthropic Messages body shape, so the gateway applies the same Claude request policy used for native Anthropic-style routes while preserving Vertex transport rules.
+
+Claude thinking compatibility is model-aware:
+
+| Model family | Gateway behavior |
+| --- | --- |
+| Claude Opus 4.7 and later | `reasoning_effort` or `reasoning.effort` maps to `thinking: { "type": "adaptive" }` plus `output_config.effort`; manual `thinking.type: "enabled"` and `budget_tokens` are rejected. Non-default `temperature`, `top_p`, and `top_k` are rejected; default `temperature: 1` and `top_p: 1` are omitted. |
+| Claude Opus 4.6 and Claude Sonnet 4.6 | `reasoning_effort` maps to adaptive thinking and `output_config.effort`. Caller-supplied manual budgets remain pass-through because Anthropic still accepts them, though they are deprecated upstream. |
+| Claude Mythos Preview | `reasoning_effort` maps to `output_config.effort`; `thinking.type: "disabled"` is rejected. |
+| Claude Opus 4.5 | Adaptive thinking is rejected. `reasoning_effort` maps to `output_config.effort` only when the request also includes a manual thinking budget. |
+| Claude Sonnet/Haiku 4.5 and older Claude models | Adaptive thinking is rejected. These models require an explicit manual budget from `reasoning.budget_tokens`, `reasoning_budget_tokens`, `thinking_budget_tokens`, or caller-supplied `thinking.type: "enabled"` with `budget_tokens`; the gateway does not add `output_config.effort`. |
+
+Provider-specific Anthropic fields remain available where they do not conflict with normalized compatibility behavior. If `reasoning_effort` disagrees with `reasoning.effort`, `output_config.effort`, caller-supplied `thinking`, or a manual budget, the request fails locally with a deterministic gateway error.
+
+Chat Completions response policy matches the Bedrock Claude policy. Native Anthropic `thinking` and `redacted_thinking` blocks are never concatenated into `choices[*].message.content`. Streaming `thinking_delta` and `signature_delta` events are never emitted as `delta.content`. The gateway preserves these blocks under `choices[*].message.provider_metadata.gcp_vertex.reasoning` and `choices[*].delta.provider_metadata.gcp_vertex.reasoning`.
+
+Vertex Google publisher routes remain separate from Anthropic-on-Vertex. `google/*` upstream models use Vertex `generateContent` and `streamGenerateContent`; Anthropic Messages fields such as `thinking`, `output_config`, and `anthropic_version` do not apply to those routes.
+
 ## AWS Bedrock Anthropic Claude
 
 Bedrock-hosted Claude models are selected when the Bedrock `upstream_model` contains `anthropic.claude`, including regional inference profile IDs such as `us.anthropic.claude-3-5-sonnet-20241022-v2:0`. Non-streaming Chat Completions for those routes use Bedrock Runtime `InvokeModel` (`/model/{modelId}/invoke`) with Anthropic's native Messages body instead of the generic Converse body.
@@ -88,13 +115,31 @@ The native Bedrock Anthropic body always includes:
 - combined `system` and `developer` text as Anthropic `system`
 - `messages` with Anthropic `text`, `image`, `tool_use`, and `tool_result` content blocks
 - `max_tokens` from `max_tokens` or `max_completion_tokens`
-- `temperature`, `top_p`, `top_k`, and `stop_sequences`
+- `temperature`, `top_p`, `top_k`, and `stop_sequences`, subject to Claude Opus 4.7+ sampling restrictions
 - function tools as Anthropic custom tools with `input_schema`
 - `tool_choice` mapped from OpenAI `auto`, `required`, and named function choices
 
-The implementation rejects missing `max_tokens` for native Claude invocation because Bedrock marks it required. It also rejects OpenAI-only controls such as penalties, `n`, `seed`, `parallel_tool_calls`, and `response_format`. JSON schema mode should stay disabled in route capabilities unless a route explicitly uses Bedrock/Anthropic-specific `output_config` through provider overrides and accepts the non-OpenAI contract. Thinking and beta features are pass-through provider fields (`thinking`, `output_config`, `anthropic_beta`, `context_management`) rather than normalized OpenAI fields in this slice.
+The implementation rejects missing `max_tokens` for native Claude invocation because Bedrock marks it required. It also rejects OpenAI-only controls such as penalties, `n`, `seed`, `parallel_tool_calls`, and `response_format`. JSON schema mode should stay disabled in route capabilities unless a route explicitly uses Bedrock/Anthropic-specific `output_config` through provider overrides and accepts the non-OpenAI contract.
+
+Claude thinking compatibility is model-aware:
+
+| Model family | Gateway behavior |
+| --- | --- |
+| Claude Opus 4.7 and later | `reasoning_effort` or `reasoning.effort` maps to `thinking: { "type": "adaptive" }` plus `output_config.effort`; manual `thinking.type: "enabled"` and `budget_tokens` are rejected. Non-default `temperature`, `top_p`, and `top_k` are rejected; default `temperature: 1` and `top_p: 1` are omitted. |
+| Claude Opus 4.6 and Claude Sonnet 4.6 | `reasoning_effort` or `reasoning.effort` maps to adaptive thinking and `output_config.effort`. Caller-supplied manual `thinking.type: "enabled"` with `budget_tokens` remains pass-through because Anthropic still accepts it. |
+| Claude Mythos Preview | `reasoning_effort` maps to adaptive thinking and `output_config.effort`; `thinking.type: "disabled"` is rejected. |
+| Claude Opus 4.5 | Adaptive thinking is rejected. `reasoning_effort` maps to Bedrock's beta `output_config.effort` for native Messages invocation and adds `anthropic_beta: ["effort-2025-11-24"]`. If a manual budget is also supplied through `reasoning.budget_tokens`, `reasoning_budget_tokens`, `thinking_budget_tokens`, or caller-supplied `thinking.type: "enabled"` with `budget_tokens`, the gateway sends manual `thinking.type: "enabled"` as well. |
+| Claude Sonnet/Haiku 4.5 and older Claude models | Adaptive thinking is rejected. These models do not receive `output_config.effort`; they require an explicit manual budget from `reasoning.budget_tokens`, `reasoning_budget_tokens`, `thinking_budget_tokens`, or caller-supplied `thinking.type: "enabled"` with `budget_tokens`, and the gateway then sends manual `thinking.type: "enabled"`. |
+
+Provider-specific fields remain available where they do not conflict with normalized compatibility behavior. `anthropic_beta`, `context_management`, `container`, and `metadata` are copied through. `thinking` and `output_config` are copied through first, then normalized OpenAI-shaped reasoning fields are applied. If `reasoning_effort` disagrees with `reasoning.effort`, `output_config.effort`, caller-supplied `thinking`, or a manual budget, the request fails locally with a deterministic gateway error instead of leaking incompatible OpenAI-only fields upstream. Route `extra_body` is still a final raw override for operator-controlled experiments.
+
+For Bedrock Converse and ConverseStream, Claude thinking controls are written to `additionalModelRequestFields.thinking`. Adaptive models receive `type: "adaptive"` and `effort` inside that object. Manual-budget models receive `type: "enabled"` and `budget_tokens` inside that object. Existing unrelated `additionalModelRequestFields` keys are preserved, while conflicting `thinking` values are rejected locally.
 
 Vision is supported only for Bedrock-compatible base64 image payloads. Remote image URLs are rejected because Bedrock Anthropic Messages requires base64 image sources. Tools and tool-result turns are supported for Claude 3+ models, subject to the model's Bedrock feature availability.
+
+Chat Completions response policy for Anthropic thinking is deliberately conservative. Native Anthropic `thinking` and `redacted_thinking` blocks, plus Bedrock Converse `reasoningContent` text, signatures, and redacted data, are never concatenated into `choices[*].message.content` or streamed as `delta.content`. The visible Chat Completions content remains answer text and tool calls only. Reasoning state that providers require for debugging or tool-use continuity is preserved under `choices[*].message.provider_metadata.aws_bedrock.reasoning` for non-streaming responses, and under `choices[*].delta.provider_metadata.aws_bedrock.reasoning` for ConverseStream chunks. Direct Anthropic Messages routes should follow the same split when added: hidden or summarized thinking metadata may be preserved explicitly, but it must not leak through ordinary Chat Completions text fields.
+
+Anthropic documents that Claude 4 models can return summarized thinking, encrypted signatures, and `redacted_thinking` blocks. Claude Opus 4.7 defaults thinking display to `omitted`, so a stream can open an empty thinking block, emit only a signature delta, and then begin normal text. Bedrock Converse represents equivalent state as `reasoningContent`, including `reasoningText.text`, `reasoningText.signature`, and redacted content. The gateway preserves those fields as provider metadata and treats billed output token counts as provider usage until exact reasoning accounting is implemented.
 
 Streaming boundary: native Anthropic Messages streaming over `InvokeModelWithResponseStream` is not part of this issue. If a Bedrock route enables streaming, it is using the generic Bedrock Converse stream adapter from [issue #128](https://github.com/ahstn/oceans-llm/issues/128), not the native Anthropic Messages stream event contract.
 
@@ -142,7 +187,7 @@ This is intentionally narrower than full tool-call streaming normalization. Tool
 
 The Responses stream adapter is separate. It parses SSE frames for transport safety, preserves `event: response.*` names and JSON payloads, surfaces malformed or incomplete streams as structured SSE error chunks, and appends one final `data: [DONE]` only after a successful upstream stream that omitted it.
 
-Bedrock chat streaming is a separate transport adapter because Bedrock Runtime does not return SSE for ConverseStream. It decodes AWS Smithy/EventStream frames, reads string headers such as `:message-type`, `:event-type`, and `:exception-type`, and normalizes ConverseStream events into Chat Completions SSE chunks. `messageStart` emits the assistant role, `contentBlockDelta` emits text or function-tool argument deltas, `messageStop` emits the terminal finish reason, and `metadata.usage` emits an OpenAI-shaped usage chunk when present. EventStream exception frames and malformed or incomplete frames emit structured SSE error chunks and do not receive a final `[DONE]`.
+Bedrock chat streaming is a separate transport adapter because Bedrock Runtime does not return SSE for ConverseStream. It decodes AWS Smithy/EventStream frames, reads string headers such as `:message-type`, `:event-type`, and `:exception-type`, and normalizes ConverseStream events into Chat Completions SSE chunks. `messageStart` emits the assistant role, `contentBlockDelta` emits text, function-tool argument deltas, or provider reasoning metadata deltas, `messageStop` emits the terminal finish reason, and `metadata.usage` emits an OpenAI-shaped usage chunk when present. EventStream exception frames and malformed or incomplete frames emit structured SSE error chunks and do not receive a final `[DONE]`.
 
 The current Bedrock frame parser validates frame lengths, header boundaries, supported header encodings, JSON payload shape, and clean finalization. It recognizes the prelude CRC and message CRC fields but does not validate CRC checksums in this slice. Provider-native `InvokeModelWithResponseStream` mappings, including Anthropic-specific native streaming payloads, remain separate provider-family work.
 

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -103,6 +103,10 @@ Provider-specific Anthropic fields remain available where they do not conflict w
 
 Chat Completions response policy matches the Bedrock Claude policy. Native Anthropic `thinking` and `redacted_thinking` blocks are never concatenated into `choices[*].message.content`. Streaming `thinking_delta` and `signature_delta` events are never emitted as `delta.content`. The gateway preserves these blocks under `choices[*].message.provider_metadata.gcp_vertex.reasoning` and `choices[*].delta.provider_metadata.gcp_vertex.reasoning`.
 
+Provider metadata preservation is not yet request-side replay. The current Vertex Anthropic mapper does not rehydrate preserved `thinking`, `signature`, or `redacted_thinking` blocks into later assistant content when callers send tool results. Tool-use continuations that require exact thinking block round-trip are tracked by [issue #140](https://github.com/ahstn/oceans-llm/issues/140).
+
+Vertex Claude route capabilities should stay aligned with tested gateway behavior, not only upstream model capability. Function tools, tool-result continuations, image/document content blocks, and related stream behavior for Anthropic-on-Vertex are tracked by [issue #141](https://github.com/ahstn/oceans-llm/issues/141). The broader cross-provider tool and multimodal matrices remain tracked by [issue #91](https://github.com/ahstn/oceans-llm/issues/91) and [issue #93](https://github.com/ahstn/oceans-llm/issues/93).
+
 Vertex Google publisher routes remain separate from Anthropic-on-Vertex. `google/*` upstream models use Vertex `generateContent` and `streamGenerateContent`; Anthropic Messages fields such as `thinking`, `output_config`, and `anthropic_version` do not apply to those routes.
 
 ## AWS Bedrock Anthropic Claude
@@ -141,7 +145,9 @@ Chat Completions response policy for Anthropic thinking is deliberately conserva
 
 Anthropic documents that Claude 4 models can return summarized thinking, encrypted signatures, and `redacted_thinking` blocks. Claude Opus 4.7 defaults thinking display to `omitted`, so a stream can open an empty thinking block, emit only a signature delta, and then begin normal text. Bedrock Converse represents equivalent state as `reasoningContent`, including `reasoningText.text`, `reasoningText.signature`, and redacted content. The gateway preserves those fields as provider metadata and treats billed output token counts as provider usage until exact reasoning accounting is implemented.
 
-Streaming boundary: native Anthropic Messages streaming over `InvokeModelWithResponseStream` is not part of this issue. If a Bedrock route enables streaming, it is using the generic Bedrock Converse stream adapter from [issue #128](https://github.com/ahstn/oceans-llm/issues/128), not the native Anthropic Messages stream event contract.
+Provider metadata preservation is not yet request-side replay. The current Bedrock Anthropic mappers do not rehydrate preserved `thinking`, `signature`, or `redacted_thinking` blocks into later assistant content when callers send tool results. Tool-use continuations that require exact thinking block round-trip are tracked by [issue #140](https://github.com/ahstn/oceans-llm/issues/140). Exact cache, reasoning, and modality token accounting remains tracked by [issue #92](https://github.com/ahstn/oceans-llm/issues/92).
+
+Streaming boundary: native Anthropic Messages streaming over `InvokeModelWithResponseStream` is not implemented in this slice. If a Bedrock route enables streaming, it is using the generic Bedrock Converse stream adapter from [issue #128](https://github.com/ahstn/oceans-llm/issues/128), not the native Anthropic Messages stream event contract. Native Bedrock Anthropic Messages streaming is tracked by [issue #139](https://github.com/ahstn/oceans-llm/issues/139).
 
 ## OpenAI-Compatible Profile Fields
 
@@ -189,7 +195,7 @@ The Responses stream adapter is separate. It parses SSE frames for transport saf
 
 Bedrock chat streaming is a separate transport adapter because Bedrock Runtime does not return SSE for ConverseStream. It decodes AWS Smithy/EventStream frames, reads string headers such as `:message-type`, `:event-type`, and `:exception-type`, and normalizes ConverseStream events into Chat Completions SSE chunks. `messageStart` emits the assistant role, `contentBlockDelta` emits text, function-tool argument deltas, or provider reasoning metadata deltas, `messageStop` emits the terminal finish reason, and `metadata.usage` emits an OpenAI-shaped usage chunk when present. EventStream exception frames and malformed or incomplete frames emit structured SSE error chunks and do not receive a final `[DONE]`.
 
-The current Bedrock frame parser validates frame lengths, header boundaries, supported header encodings, JSON payload shape, and clean finalization. It recognizes the prelude CRC and message CRC fields but does not validate CRC checksums in this slice. Provider-native `InvokeModelWithResponseStream` mappings, including Anthropic-specific native streaming payloads, remain separate provider-family work.
+The current Bedrock frame parser validates frame lengths, header boundaries, supported header encodings, JSON payload shape, and clean finalization. It recognizes the prelude CRC and message CRC fields but does not validate CRC checksums in this slice. Provider-native `InvokeModelWithResponseStream` mappings, including Anthropic-specific native streaming payloads, remain separate provider-family work tracked by [issue #139](https://github.com/ahstn/oceans-llm/issues/139).
 
 ## Accounting Boundary
 
@@ -224,5 +230,7 @@ These items are intentionally outside this first slice:
 - cache, reasoning, and modality token accounting: [issue #92](https://github.com/ahstn/oceans-llm/issues/92)
 - multimodal image/file compatibility across provider families: [issue #93](https://github.com/ahstn/oceans-llm/issues/93)
 - Vertex embeddings provider support: [issue #103](https://github.com/ahstn/oceans-llm/issues/103)
-- Bedrock native InvokeModel provider-family streaming mappings: [issue #129](https://github.com/ahstn/oceans-llm/issues/129)
+- Bedrock native Anthropic Messages streaming over `InvokeModelWithResponseStream`: [issue #139](https://github.com/ahstn/oceans-llm/issues/139)
+- Anthropic thinking block replay for tool-use continuations: [issue #140](https://github.com/ahstn/oceans-llm/issues/140)
+- Vertex Claude tool and multimodal parity: [issue #141](https://github.com/ahstn/oceans-llm/issues/141)
 - route readiness diagnostics: [issue #98](https://github.com/ahstn/oceans-llm/issues/98)

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -159,7 +159,7 @@ That separation matters in two common cases:
 - a request can be logged even when it becomes `unpriced`
 - a request can be logged even when a later accounting step hits a rough edge
 
-For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure. Chat Completions streams usually expose usage at top level. Responses streams expose usage on completed response events as `response.usage`. Bedrock streaming is normalized to OpenAI-compatible SSE before this logging path; see [AWS Bedrock](../providers/aws-bedrock.md) for adapter-specific frame and error mapping details. Stored stream events can be capped by payload policy without weakening usage or provider-error parsing.
+For streaming requests, the request-log payload path parses SSE incrementally across UTF-8 and frame boundaries and retains the latest coherent usage snapshot seen before stream completion or failure. Chat Completions streams usually expose usage at top level. Responses streams expose usage on completed response events as `response.usage`. Bedrock streaming is normalized to OpenAI-compatible SSE before this logging path; see [AWS Bedrock](../providers/aws-bedrock.md) for adapter-specific frame and error mapping details. Bedrock Claude reasoning deltas are preserved as explicit provider metadata, not as normal `delta.content`, so request-log payload policy controls whether that debug metadata is stored. Stored stream events can be capped by payload policy without weakening usage or provider-error parsing.
 
 ## Known Rough Edges
 


### PR DESCRIPTION
## Description

Adds model-aware Claude thinking compatibility across AWS Bedrock and Google Vertex Anthropic routes, plus provider-specific documentation for configuring these models.

- Summary of changes
  - Adds Bedrock Claude adaptive/manual thinking request handling, response reasoning metadata preservation, and ConverseStream reasoning deltas.
  - Adds Vertex Anthropic adaptive/manual thinking request handling and preserves `thinking`, `redacted_thinking`, `thinking_delta`, and `signature_delta` under `provider_metadata.gcp_vertex.reasoning`.
  - Adds provider docs for AWS Bedrock and Google Vertex AI, including current Claude model examples and reasoning configuration guidance.
  - Updates provider compatibility, pricing/accounting, request lifecycle, and docs navigation references.
- Why this approach was chosen
  - Keeps provider-specific transport requirements explicit while applying deterministic gateway-side validation for Claude model compatibility.
  - Preserves hidden/provider reasoning metadata separately from normal Chat Completions content and deltas.
- How it works
  - Gateway-normalized `reasoning_effort` and `reasoning` fields are translated into Anthropic-compatible `thinking` and `output_config` fields according to model family.
  - Unsupported adaptive/manual thinking combinations fail locally before hitting upstream provider APIs.
  - Provider reasoning blocks are attached to provider metadata for debugging and future tool-continuation support.
- Risks, tradeoffs, and alternatives considered
  - The Claude compatibility matrix is maintained locally from current provider documentation and will need updates as Anthropic releases or retires models.
  - Shared helper extraction across Bedrock and Vertex can be considered later; this keeps the current change scoped to provider adapters.
- Additional context for reviewers
  - Addresses Bedrock follow-up findings and implements issue #133 for Vertex Anthropic adaptive thinking compatibility.

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional verification run:

- `cargo fmt --check -p gateway-providers`
- `cargo test -p gateway-providers bedrock::tests -- --nocapture`
- `cargo test -p gateway-providers vertex::tests -- --nocapture`
- `cargo clippy -p gateway-providers --all-targets -- -D warnings`
- `mise run docs-check`
