### PR TITLE
feat(admin-ui): show request operations in logs

### DIFF
--- a/crates/admin-ui/web/src/routes/observability/request-logs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/request-logs.tsx
@@ -282,6 +282,7 @@ export function RequestLogsPage() {
 
                   <div className="mt-4 flex items-center justify-between gap-3">
                     <div className="flex flex-wrap gap-2">
+                      <OperationBadge item={item} />
                       {metadataBoolean(item, 'stream') ? (
                         <Badge variant="outline">stream</Badge>
                       ) : null}
@@ -342,6 +343,7 @@ export function RequestLogsPage() {
                             {item.request_log_id}
                           </div>
                           <div className="mt-1 flex flex-wrap gap-1">
+                            <OperationBadge item={item} />
                             <PayloadPolicyBadges item={item} />
                           </div>
                         </div>
@@ -452,6 +454,7 @@ export function RequestLogsPage() {
                   label="Tokens"
                   value={formatTokenCount(selectedDetail.log.total_tokens)}
                 />
+                <OperationDetailRow item={selectedDetail.log} />
                 <DetailRow
                   label="Stream"
                   value={metadataBoolean(selectedDetail.log, 'stream') ? 'yes' : 'no'}
@@ -811,6 +814,54 @@ function formatCaptureMode(captureMode: string) {
       return 'redacted payloads'
     default:
       return captureMode
+  }
+}
+
+function OperationBadge({ item }: { item: RequestLogView }) {
+  const operation = operationMetadata(item)
+
+  if (!operation) {
+    return null
+  }
+
+  return <Badge variant="secondary">{formatOperation(operation)}</Badge>
+}
+
+function OperationDetailRow({ item }: { item: RequestLogView }) {
+  const operation = operationMetadata(item)
+
+  if (!operation) {
+    return null
+  }
+
+  return <DetailRow label="Operation" value={formatOperation(operation)} />
+}
+
+function operationMetadata(item: RequestLogView) {
+  return metadataString(item, 'operation')
+}
+
+function metadataString(item: RequestLogView, key: string) {
+  const value = item.metadata[key]
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function formatOperation(operation: string) {
+  switch (operation) {
+    case 'chat_completions':
+      return 'Chat Completions'
+    case 'responses':
+      return 'Responses'
+    case 'embeddings':
+      return 'Embeddings'
+    default: {
+      const formatted = operation
+        .split(/[_\s-]+/)
+        .filter((part) => part.length > 0)
+        .map((part) => part[0].toUpperCase() + part.slice(1))
+        .join(' ')
+      return formatted.length > 0 ? formatted : operation
+    }
   }
 }
 

--- a/crates/admin-ui/web/src/routes/observability/request-logs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/request-logs.tsx
@@ -818,32 +818,30 @@ function formatCaptureMode(captureMode: string) {
 }
 
 function OperationBadge({ item }: { item: RequestLogView }) {
-  const operation = operationMetadata(item)
+  const label = operationLabel(item)
 
-  if (!operation) {
+  if (!label) {
     return null
   }
 
-  return <Badge variant="secondary">{formatOperation(operation)}</Badge>
+  return <Badge variant="secondary">{label}</Badge>
 }
 
 function OperationDetailRow({ item }: { item: RequestLogView }) {
-  const operation = operationMetadata(item)
+  const label = operationLabel(item)
 
-  if (!operation) {
+  if (!label) {
     return null
   }
 
-  return <DetailRow label="Operation" value={formatOperation(operation)} />
+  return <DetailRow label="Operation" value={label} />
 }
 
-function operationMetadata(item: RequestLogView) {
-  return metadataString(item, 'operation')
-}
-
-function metadataString(item: RequestLogView, key: string) {
-  const value = item.metadata[key]
-  return typeof value === 'string' && value.trim().length > 0 ? value : null
+function operationLabel(item: RequestLogView) {
+  const operation = item.metadata.operation
+  return typeof operation === 'string' && operation.trim().length > 0
+    ? formatOperation(operation)
+    : null
 }
 
 function formatOperation(operation: string) {

--- a/crates/admin-ui/web/src/server/admin-data.server.test.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.test.ts
@@ -418,6 +418,7 @@ describe('server-side admin data wrappers', () => {
                     bespoke: [{ key: 'feature', value: 'guest_checkout' }],
                   },
                   metadata: {
+                    operation: 'chat_completions',
                     stream: false,
                   },
                   payload_policy: {
@@ -475,6 +476,7 @@ describe('server-side admin data wrappers', () => {
                   bespoke: [{ key: 'feature', value: 'guest_checkout' }],
                 },
                 metadata: {
+                  operation: 'chat_completions',
                   stream: false,
                 },
                 payload_policy: {

--- a/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
@@ -57,6 +57,7 @@ const items: RequestLogView[] = [
       bespoke: [{ key: 'feature', value: 'guest_checkout' }],
     },
     metadata: {
+      operation: 'chat_completions',
       stream: false,
     },
     payload_policy: {
@@ -105,6 +106,43 @@ describe('RequestLogsPage', () => {
     expect(screen.getAllByText(/exposed 2/)).toHaveLength(2)
     expect(screen.getAllByText(/called 0/)).toHaveLength(2)
     expect(screen.getAllByText(/MCP n\/a/)).toHaveLength(2)
+    expect(screen.getAllByText('Chat Completions')).toHaveLength(2)
+    expect(screen.getByText('service:checkout')).toBeInTheDocument()
+    expect(screen.getByText('component:pricing_api')).toBeInTheDocument()
+    expect(screen.getByText('env:prod')).toBeInTheDocument()
+    expect(screen.getByText('feature:guest_checkout')).toBeInTheDocument()
+  })
+
+  it('renders known and unknown operation metadata without hiding stream badges', async () => {
+    const responsesItem: RequestLogView = {
+      ...items[0],
+      request_log_id: 'reqlog_2',
+      request_id: 'req_2',
+      metadata: {
+        operation: 'responses',
+        stream: true,
+      },
+    }
+    const unknownOperationItem: RequestLogView = {
+      ...items[0],
+      request_log_id: 'reqlog_3',
+      request_id: 'req_3',
+      metadata: {
+        operation: 'batch_predictions',
+        stream: false,
+      },
+    }
+    routeMock.useLoaderData.mockReturnValue({
+      data: { items: [items[0], responsesItem, unknownOperationItem], total: 3 },
+    })
+
+    const { RequestLogsPage } = await import('@/routes/observability/request-logs')
+
+    render(<RequestLogsPage />)
+
+    expect(screen.getByText('Responses')).toBeInTheDocument()
+    expect(screen.getByText('Batch Predictions')).toBeInTheDocument()
+    expect(screen.getByText('stream')).toBeInTheDocument()
   })
 
   it('renders request-log detail without fallback-era fields', async () => {
@@ -155,6 +193,9 @@ describe('RequestLogsPage', () => {
     expect(
       screen.getByText('Review summary fields and sanitized request and response payloads.'),
     ).toBeInTheDocument()
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Operation')).toBeInTheDocument()
+    expect(within(dialog).getByText('Chat Completions')).toBeInTheDocument()
     expect(screen.queryByText('Attempt Count')).not.toBeInTheDocument()
     expect(screen.queryByText('Fallback')).not.toBeInTheDocument()
     expect(screen.getByText('MCP & Tools')).toBeInTheDocument()

--- a/crates/gateway/src/local_demo_seed/mod.rs
+++ b/crates/gateway/src/local_demo_seed/mod.rs
@@ -5,7 +5,7 @@ use gateway_core::{
     RequestLogRecord, RequestLogRepository, RequestTag, RequestTags, UsageLedgerRecord,
     UsagePricingStatus, UserStatus,
 };
-use gateway_service::hash_gateway_key_secret;
+use gateway_service::{RequestLogPayloadPolicy, hash_gateway_key_secret};
 use gateway_store::{AnyStore, GatewayStore};
 use serde_json::{Map, Value, json};
 use time::OffsetDateTime;
@@ -284,6 +284,15 @@ pub async fn seed_local_demo_data(store: &AnyStore) -> anyhow::Result<Vec<(&'sta
             }],
         };
         let metadata = Map::from_iter([
+            (
+                "operation".to_string(),
+                Value::String("chat_completions".to_string()),
+            ),
+            ("stream".to_string(), Value::Bool(false)),
+            (
+                "payload_policy".to_string(),
+                RequestLogPayloadPolicy::default().metadata_value(),
+            ),
             (
                 "seed_source".to_string(),
                 Value::String("local_demo_seed".to_string()),

--- a/docs/access/admin-control-plane.md
+++ b/docs/access/admin-control-plane.md
@@ -119,6 +119,7 @@ Admins can:
 - inspect request-log summaries
 - filter request logs by caller service, component, environment, and one bespoke tag match
 - inspect sanitized request-log payload detail
+- see each request log's public operation through row metadata
 - see per-row payload capture mode, byte limits, stream event limit, policy version, and truncation state
 - see per-row MCP/tool cardinality counts for request logs
 - compare leaderboard users with average tool exposure and invocation counts

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -220,6 +220,8 @@ Each request-log row persists lightweight policy metadata in `request_logs.metad
 
 ```json
 {
+  "operation": "chat_completions",
+  "stream": false,
   "payload_policy": {
     "capture_mode": "redacted_payloads",
     "request_max_bytes": 65536,
@@ -295,6 +297,8 @@ Platform admins can inspect request logs through:
 - `GET /api/v1/admin/observability/leaderboard`
 - `GET /api/v1/admin/observability/request-logs`
 - `GET /api/v1/admin/observability/request-logs/{request_log_id}`
+
+Request-log list and detail responses include the row metadata, so admins can see the public operation for each row, such as `chat_completions`, `responses`, or `embeddings`, alongside the typed payload policy and truncation fields.
 
 ## Usage Leaderboard
 

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -300,6 +300,8 @@ Platform admins can inspect request logs through:
 
 Request-log list and detail responses include the row metadata, so admins can see the public operation for each row, such as `chat_completions`, `responses`, or `embeddings`, alongside the typed payload policy and truncation fields.
 
+Validate documentation-only edits to this page with `mise run docs:check` before handoff.
+
 ## Usage Leaderboard
 
 The leaderboard is a separate admin observability surface from spend reporting.

--- a/docs/reference/data-relationships.md
+++ b/docs/reference/data-relationships.md
@@ -103,7 +103,7 @@ Compatibility metadata is not a provider config fallback and is not an `extra_bo
   - Notes: this is the canonical spend ledger used for enforcement and reporting
 - `request_logs`
   - Key columns: `request_log_id`, `request_id`, `api_key_id`, `user_id`, `team_id`, `model_key`, `resolved_model_key`, `provider_key`, `caller_service`, `caller_component`, `caller_env`, `status_code`, `referenced_mcp_server_count`, `exposed_tool_count`, `invoked_tool_count`, `filtered_tool_count`, `metadata_json`, `occurred_at`
-  - Notes: one summary row per final request outcome; `metadata_json.payload_policy` records the capture mode and limits used for the row when request logging is enabled; tool-cardinality columns are nullable typed facts, with historical or not-yet-observable dimensions left `null`
+  - Notes: one summary row per final request outcome; `metadata_json.operation` records the public API family, `metadata_json.stream` records whether the request was streaming, and `metadata_json.payload_policy` records the capture mode and limits used for the row when request logging is enabled; tool-cardinality columns are nullable typed facts, with historical or not-yet-observable dimensions left `null`
 - `request_log_payloads`
   - Key columns: `request_log_id`, `request_json`, `response_json`
   - Notes: summary and payload are intentionally split; rows exist only when the payload policy captures redacted payloads


### PR DESCRIPTION
## Description

Show request-log operation metadata in the admin Request Logs UI so operators can distinguish Chat Completions, Responses, Embeddings, and future operation families without opening raw payloads.

- Summary of changes
- Adds operation badges to request-log mobile cards and the desktop request badge strip.
- Adds an Operation row to the request-log detail dialog when `metadata.operation` is present.
- Formats known operation values as readable labels and renders unknown future strings deterministically.
- Aligns admin UI tests, server wrapper fixtures, local demo seed request-log metadata, and docs with the current metadata contract.

- Why this approach was chosen
- The badge strip avoids desktop table width churn while making the operation visible in both list layouts.
- Missing operation metadata is treated as absent rather than synthesized; unknown string values remain visible instead of being hidden.
- The local demo seed now writes the current metadata contract directly rather than relying on compatibility fallbacks.

- How it works
- The UI reads `metadata.operation` only when it is a non-empty string, formats known values explicitly, and title-cases unknown tokenized strings.
- Seeded local demo request logs include `operation`, `stream`, and default `payload_policy` metadata.

- Risks, tradeoffs, and alternatives considered
- A dedicated desktop Operation column was avoided to keep the existing table layout stable.
- No backend API contract change is required because request-log metadata already flows through as open JSON metadata.

- Additional context for reviewers
- Closes #97.
- Focused verification run: `bun run --cwd crates/admin-ui/web test -- src/test/routes/request-logs-route.test.tsx src/server/admin-data.server.test.ts`.
- Additional verification run: `cargo fmt --check`, `mise run docs:check`, `mise run lint`, `git diff --check`.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`
