### PR TITLE
feat(admin-ui): improve identity management UI

### DIFF
--- a/crates/admin-ui/web/bun.lock
+++ b/crates/admin-ui/web/bun.lock
@@ -19,6 +19,7 @@
         "@tanstack/react-router-ssr-query": "1.166.12",
         "@tanstack/react-start": "1.167.59",
         "@tanstack/react-virtual": "3.13.24",
+        "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -723,6 +724,8 @@
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "boring-avatars": ["boring-avatars@2.0.4", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-xhZO/w/6aFmRfkaWohcl2NfyIy87gK5SBbys8kctZeTGF1Apjpv/10pfUuv+YEfVPkESU/h2Y6tt/Dwp+bIZPw=="],
 
     "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
 

--- a/crates/admin-ui/web/package.json
+++ b/crates/admin-ui/web/package.json
@@ -33,6 +33,7 @@
     "@tanstack/react-router-ssr-query": "1.166.12",
     "@tanstack/react-start": "1.167.59",
     "@tanstack/react-virtual": "3.13.24",
+    "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/crates/admin-ui/web/src/components/app-sidebar.tsx
+++ b/crates/admin-ui/web/src/components/app-sidebar.tsx
@@ -1,9 +1,12 @@
-import { ArrowRight01Icon } from '@hugeicons/core-free-icons'
-import { Link } from '@tanstack/react-router'
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { Link } from "@tanstack/react-router";
 
-import { AppIcon } from '@/components/icons/app-icon'
-import { adminNavSections, matchesAdminPath } from '@/components/layout/admin-nav'
-import { GeneratedAvatar } from '@/components/ui/generated-avatar'
+import { AppIcon } from "@/components/icons/app-icon";
+import {
+  adminNavSections,
+  matchesAdminPath,
+} from "@/components/layout/admin-nav";
+import { GeneratedAvatar } from "@/components/ui/generated-avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,7 +14,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+} from "@/components/ui/dropdown-menu";
 import {
   Sidebar,
   SidebarContent,
@@ -24,17 +27,22 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-} from '@/components/ui/sidebar'
-import type { AuthSessionView } from '@/types/api'
+} from "@/components/ui/sidebar";
+import type { AuthSessionView } from "@/types/api";
 
 interface AppSidebarProps {
-  currentPath: string
-  session: AuthSessionView
-  signOutPending: boolean
-  onSignOut: () => void
+  currentPath: string;
+  session: AuthSessionView;
+  signOutPending: boolean;
+  onSignOut: () => void;
 }
 
-export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: AppSidebarProps) {
+export function AppSidebar({
+  currentPath,
+  session,
+  signOutPending,
+  onSignOut,
+}: AppSidebarProps) {
   return (
     <Sidebar collapsible="icon" variant="inset">
       <SidebarHeader className="gap-3 p-3 pb-2">
@@ -53,7 +61,9 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
                   <span className="text-sidebar-foreground truncate text-sm font-medium">
                     Oceans Gateway
                   </span>
-                  <span className="text-sidebar-foreground/70 truncate text-xs">Control plane</span>
+                  <span className="text-sidebar-foreground/70 truncate text-xs">
+                    Control plane
+                  </span>
                 </div>
               </div>
             </SidebarMenuButton>
@@ -70,7 +80,7 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
             <SidebarGroupContent>
               <SidebarMenu className="gap-1">
                 {section.items.map((item) => {
-                  const active = matchesAdminPath(currentPath, item.to)
+                  const active = matchesAdminPath(currentPath, item.to);
 
                   return (
                     <SidebarMenuItem key={item.to}>
@@ -81,12 +91,12 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
                         className="h-8 rounded-lg px-2 text-sm font-normal"
                       >
                         <Link to={item.to}>
-                          <AppIcon icon={item.icon} size={16} stroke={1.5} />
+                          <AppIcon icon={item.icon} size={18} stroke={1.5} />
                           <span>{item.label}</span>
                         </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
-                  )
+                  );
                 })}
               </SidebarMenu>
             </SidebarGroupContent>
@@ -99,7 +109,10 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
           <SidebarMenuItem>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <SidebarMenuButton size="lg" className="h-auto rounded-lg px-2 py-2">
+                <SidebarMenuButton
+                  size="lg"
+                  className="h-auto rounded-lg px-2 py-2"
+                >
                   <GeneratedAvatar
                     kind="user"
                     name={session.user.name || session.user.email}
@@ -108,7 +121,9 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
                     square
                   />
                   <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
-                    <span className="truncate font-medium">{session.user.name}</span>
+                    <span className="truncate font-medium">
+                      {session.user.name}
+                    </span>
                     <span className="text-sidebar-foreground/70 truncate text-xs">
                       {session.user.email}
                     </span>
@@ -123,7 +138,9 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
               </DropdownMenuTrigger>
               <DropdownMenuContent side="top" align="start" className="w-64">
                 <DropdownMenuLabel className="grid gap-1">
-                  <span className="truncate text-sm font-medium">{session.user.name}</span>
+                  <span className="truncate text-sm font-medium">
+                    {session.user.name}
+                  </span>
                   <span className="text-muted-foreground truncate text-xs font-normal">
                     {session.user.email}
                   </span>
@@ -139,11 +156,11 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
                   variant="destructive"
                   disabled={signOutPending}
                   onSelect={(event) => {
-                    event.preventDefault()
-                    onSignOut()
+                    event.preventDefault();
+                    onSignOut();
                   }}
                 >
-                  {signOutPending ? 'Signing out...' : 'Sign out'}
+                  {signOutPending ? "Signing out..." : "Sign out"}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -153,13 +170,13 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
 
       <SidebarRail />
     </Sidebar>
-  )
+  );
 }
 
 function formatRole(role: string) {
   return role
-    .split('_')
+    .split("_")
     .filter(Boolean)
     .map((part) => part[0]?.toUpperCase() + part.slice(1))
-    .join(' ')
+    .join(" ");
 }

--- a/crates/admin-ui/web/src/components/app-sidebar.tsx
+++ b/crates/admin-ui/web/src/components/app-sidebar.tsx
@@ -3,7 +3,7 @@ import { Link } from '@tanstack/react-router'
 
 import { AppIcon } from '@/components/icons/app-icon'
 import { adminNavSections, matchesAdminPath } from '@/components/layout/admin-nav'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { GeneratedAvatar } from '@/components/ui/generated-avatar'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -43,7 +43,7 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
             <SidebarMenuButton
               asChild
               size="lg"
-              className="h-auto cursor-default rounded-lg px-1 py-1 opacity-100 hover:bg-transparent hover:text-sidebar-foreground active:bg-transparent active:text-sidebar-foreground"
+              className="hover:text-sidebar-foreground active:text-sidebar-foreground h-auto cursor-default rounded-lg px-1 py-1 opacity-100 hover:bg-transparent active:bg-transparent"
             >
               <div>
                 <span className="bg-sidebar-primary text-sidebar-primary-foreground flex size-8 items-center justify-center rounded-lg">
@@ -100,11 +100,13 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <SidebarMenuButton size="lg" className="h-auto rounded-lg px-2 py-2">
-                  <Avatar className="size-8 rounded-lg">
-                    <AvatarFallback className="bg-sidebar-primary/15 text-sidebar-primary rounded-lg">
-                      {getInitials(session.user.name)}
-                    </AvatarFallback>
-                  </Avatar>
+                  <GeneratedAvatar
+                    kind="user"
+                    name={session.user.name || session.user.email}
+                    className="size-8 rounded-lg"
+                    size={32}
+                    square
+                  />
                   <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
                     <span className="truncate font-medium">{session.user.name}</span>
                     <span className="text-sidebar-foreground/70 truncate text-xs">
@@ -152,15 +154,6 @@ export function AppSidebar({ currentPath, session, signOutPending, onSignOut }: 
       <SidebarRail />
     </Sidebar>
   )
-}
-
-function getInitials(name: string) {
-  return name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((part) => part[0]?.toUpperCase() ?? '')
-    .join('')
 }
 
 function formatRole(role: string) {

--- a/crates/admin-ui/web/src/components/icons/app-icon.test.tsx
+++ b/crates/admin-ui/web/src/components/icons/app-icon.test.tsx
@@ -16,8 +16,8 @@ describe('AppIcon', () => {
     const node = container.querySelector('[data-testid="huge-icon"]')
     const props = JSON.parse(node?.getAttribute('data-props') ?? '{}')
 
-    expect(props.size).toBe(16)
-    expect(props.strokeWidth).toBe(1.2)
+    expect(props.size).toBe(22)
+    expect(props.strokeWidth).toBe(1.5)
   })
 
   it('allows supported stroke variants', () => {

--- a/crates/admin-ui/web/src/components/icons/app-icon.tsx
+++ b/crates/admin-ui/web/src/components/icons/app-icon.tsx
@@ -1,27 +1,27 @@
-import { HugeiconsIcon } from '@hugeicons/react'
+import { HugeiconsIcon } from "@hugeicons/react";
 
-type IconLike = unknown
+type IconLike = unknown;
 
-export type AppIconStroke = 1 | 1.2 | 1.5
+export type AppIconStroke = 1 | 1.2 | 1.5;
 
 interface AppIconProps {
-  icon: IconLike
-  size?: number
-  stroke?: AppIconStroke
-  color?: string
-  className?: string
-  'aria-hidden'?: boolean
-  'data-icon'?: 'inline-start' | 'inline-end'
+  icon: IconLike;
+  size?: number;
+  stroke?: AppIconStroke;
+  color?: string;
+  className?: string;
+  "aria-hidden"?: boolean;
+  "data-icon"?: "inline-start" | "inline-end";
 }
 
 export function AppIcon({
   icon,
-  size = 16,
-  stroke = 1.2,
-  color = 'currentColor',
+  size = 22,
+  stroke = 1.5,
+  color = "currentColor",
   className,
-  'aria-hidden': ariaHidden,
-  'data-icon': dataIcon,
+  "aria-hidden": ariaHidden,
+  "data-icon": dataIcon,
 }: AppIconProps) {
   return (
     <HugeiconsIcon
@@ -33,5 +33,5 @@ export function AppIcon({
       aria-hidden={ariaHidden}
       data-icon={dataIcon}
     />
-  )
+  );
 }

--- a/crates/admin-ui/web/src/components/icons/app-icon.tsx
+++ b/crates/admin-ui/web/src/components/icons/app-icon.tsx
@@ -10,6 +10,8 @@ interface AppIconProps {
   stroke?: AppIconStroke
   color?: string
   className?: string
+  'aria-hidden'?: boolean
+  'data-icon'?: 'inline-start' | 'inline-end'
 }
 
 export function AppIcon({
@@ -18,6 +20,8 @@ export function AppIcon({
   stroke = 1.2,
   color = 'currentColor',
   className,
+  'aria-hidden': ariaHidden,
+  'data-icon': dataIcon,
 }: AppIconProps) {
   return (
     <HugeiconsIcon
@@ -26,6 +30,8 @@ export function AppIcon({
       strokeWidth={stroke}
       color={color}
       className={className}
+      aria-hidden={ariaHidden}
+      data-icon={dataIcon}
     />
   )
 }

--- a/crates/admin-ui/web/src/components/layout/admin-nav.ts
+++ b/crates/admin-ui/web/src/components/layout/admin-nav.ts
@@ -1,84 +1,104 @@
-import { HomeIcon, Notification03Icon, SearchIcon, UserIcon } from '@hugeicons/core-free-icons'
+import {
+  HomeIcon,
+  McpServerIcon,
+  Notification03Icon,
+  SaveMoneyDollarIcon,
+  SearchIcon,
+  RoboticIcon,
+  UserIcon,
+  UserGroupIcon,
+  WaterfallUp02Icon,
+} from "@hugeicons/core-free-icons";
 
 export interface AdminNavItem {
-  label: string
-  to: string
-  icon: unknown
+  label: string;
+  to: string;
+  icon: unknown;
 }
 
 export interface AdminNavSection {
-  label: string
-  icon: unknown
-  items: AdminNavItem[]
+  label: string;
+  icon: unknown;
+  items: AdminNavItem[];
 }
 
 export const adminNavSections: AdminNavSection[] = [
   {
-    label: 'Control Plane',
+    label: "Control Plane",
     icon: SearchIcon,
     items: [
-      { label: 'API Keys', to: '/api-keys', icon: SearchIcon },
-      { label: 'Models', to: '/models', icon: HomeIcon },
-      { label: 'Spend Controls', to: '/spend-controls', icon: Notification03Icon },
+      { label: "API Keys", to: "/api-keys", icon: SearchIcon },
+      { label: "Models", to: "/models", icon: HomeIcon },
     ],
   },
   {
-    label: 'Observability',
+    label: "Budget & Spending",
+    icon: SaveMoneyDollarIcon,
+    items: [
+      {
+        label: "Usage Costs",
+        to: "/observability/usage-costs",
+        icon: SaveMoneyDollarIcon,
+      },
+      {
+        label: "Spend Controls",
+        to: "/spend-controls",
+        icon: Notification03Icon,
+      },
+      {
+        label: "Leaderboard",
+        to: "/observability/leaderboard",
+        icon: WaterfallUp02Icon,
+      },
+    ],
+  },
+  {
+    label: "Observability",
     icon: Notification03Icon,
     items: [
       {
-        label: 'Leaderboard',
-        to: '/observability/leaderboard',
-        icon: Notification03Icon,
+        label: "Agent Harnesses",
+        to: "/observability/agent-harnesses",
+        icon: RoboticIcon,
       },
       {
-        label: 'Agent Harnesses',
-        to: '/observability/agent-harnesses',
-        icon: Notification03Icon,
-      },
-      {
-        label: 'Usage Costs',
-        to: '/observability/usage-costs',
-        icon: Notification03Icon,
-      },
-      {
-        label: 'Request Logs',
-        to: '/observability/request-logs',
+        label: "Request Logs",
+        to: "/observability/request-logs",
         icon: SearchIcon,
       },
       {
-        label: 'MCP Invocations',
-        to: '/observability/mcp-invocations',
-        icon: SearchIcon,
+        label: "MCP Invocations",
+        to: "/observability/mcp-invocations",
+        icon: McpServerIcon,
       },
     ],
   },
   {
-    label: 'Identity',
+    label: "Identity",
     icon: UserIcon,
     items: [
-      { label: 'Teams', to: '/identity/teams', icon: UserIcon },
-      { label: 'Users', to: '/identity/users', icon: UserIcon },
+      { label: "Teams", to: "/identity/teams", icon: UserGroupIcon },
+      { label: "Users", to: "/identity/users", icon: UserIcon },
     ],
   },
-]
+];
 
 export function normalizeAdminPath(pathname: string) {
-  return pathname.replace(/^\/admin(?=\/|$)/, '') || '/'
+  return pathname.replace(/^\/admin(?=\/|$)/, "") || "/";
 }
 
 export function getActiveNavSection(currentPath: string) {
   return adminNavSections.find((section) =>
     section.items.some((item) => matchesAdminPath(currentPath, item.to)),
-  )
+  );
 }
 
 export function getActiveNavItem(currentPath: string) {
   return adminNavSections
     .flatMap((section) => section.items)
-    .find((item) => matchesAdminPath(currentPath, item.to))
+    .find((item) => matchesAdminPath(currentPath, item.to));
 }
 
 export function matchesAdminPath(currentPath: string, to: string) {
-  return currentPath === to
+  return currentPath === to;
 }

--- a/crates/admin-ui/web/src/components/ui/generated-avatar.test.tsx
+++ b/crates/admin-ui/web/src/components/ui/generated-avatar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('boring-avatars', () => ({
+  default: ({ name, variant, colors, ...props }: Record<string, unknown>) => (
+    <svg
+      data-testid={String(props['data-testid'])}
+      data-name={String(name)}
+      data-variant={variant ? String(variant) : ''}
+      data-colors={Array.isArray(colors) ? colors.join(',') : ''}
+      aria-label={String(props['aria-label'])}
+    />
+  ),
+}))
+
+import { GeneratedAvatar, OCEANS_AVATAR_COLORS } from '@/components/ui/generated-avatar'
+
+describe('GeneratedAvatar', () => {
+  it('renders team avatars without an explicit variant', () => {
+    render(<GeneratedAvatar kind="team" name="Core Platform" />)
+
+    const avatar = screen.getByLabelText('Team avatar for Core Platform')
+    expect(avatar).toHaveAttribute('data-testid', 'team-generated-avatar')
+    expect(avatar).toHaveAttribute('data-name', 'Core Platform')
+    expect(avatar).toHaveAttribute('data-variant', '')
+    expect(avatar).toHaveAttribute('data-colors', OCEANS_AVATAR_COLORS.join(','))
+  })
+
+  it('renders user avatars with the beam variant', () => {
+    render(<GeneratedAvatar kind="user" name="Alice Paul" />)
+
+    const avatar = screen.getByLabelText('User avatar for Alice Paul')
+    expect(avatar).toHaveAttribute('data-testid', 'user-generated-avatar')
+    expect(avatar).toHaveAttribute('data-name', 'Alice Paul')
+    expect(avatar).toHaveAttribute('data-variant', 'beam')
+  })
+})

--- a/crates/admin-ui/web/src/components/ui/generated-avatar.tsx
+++ b/crates/admin-ui/web/src/components/ui/generated-avatar.tsx
@@ -1,0 +1,37 @@
+import type * as React from 'react'
+import BoringAvatar from 'boring-avatars'
+
+import { cn } from '@/lib/utils'
+
+export const OCEANS_AVATAR_COLORS = ['#B0E0E0', '#106090', '#2080B0', '#7C3AED', '#22C55E'] as const
+
+type GeneratedAvatarKind = 'team' | 'user'
+
+type GeneratedAvatarProps = Omit<
+  React.ComponentProps<typeof BoringAvatar>,
+  'colors' | 'name' | 'variant'
+> & {
+  kind: GeneratedAvatarKind
+  name: string
+  className?: string
+}
+
+function GeneratedAvatar({ kind, name, className, size = 32, ...props }: GeneratedAvatarProps) {
+  const avatarName = name.trim() || (kind === 'team' ? 'Unnamed team' : 'Unnamed user')
+  const variantProps = kind === 'user' ? ({ variant: 'beam' } as const) : {}
+
+  return (
+    <BoringAvatar
+      data-testid={`${kind}-generated-avatar`}
+      aria-label={`${kind === 'team' ? 'Team' : 'User'} avatar for ${avatarName}`}
+      className={cn('shrink-0 rounded-full', className)}
+      colors={[...OCEANS_AVATAR_COLORS]}
+      name={avatarName}
+      size={size}
+      {...variantProps}
+      {...props}
+    />
+  )
+}
+
+export { GeneratedAvatar }

--- a/crates/admin-ui/web/src/routes/identity/teams.tsx
+++ b/crates/admin-ui/web/src/routes/identity/teams.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useMemo, useState, useTransition, type FormEvent } from 'react'
 import { UnfoldMoreDownIcon, UnfoldMoreUpIcon, UserIcon } from '@hugeicons/core-free-icons'
-import { createFileRoute, useRouter } from '@tanstack/react-router'
+import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { AppIcon } from '@/components/icons/app-icon'
@@ -33,6 +33,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty'
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field'
+import { GeneratedAvatar } from '@/components/ui/generated-avatar'
 import { Input } from '@/components/ui/input'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -62,7 +63,11 @@ import {
   transferIdentityTeamMember,
   updateIdentityTeam,
 } from '@/server/admin-data.functions'
-import { EntityTagBadges, EntityTagsField, sanitizeEntityTags } from '@/routes/identity/-entity-tags'
+import {
+  EntityTagBadges,
+  EntityTagsField,
+  sanitizeEntityTags,
+} from '@/routes/identity/-entity-tags'
 import type {
   CreateTeamInput,
   CreateUserInput,
@@ -425,13 +430,16 @@ export function TeamsPage() {
                       className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4"
                     >
                       <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="truncate font-semibold text-[var(--color-text)]">
-                            {team.name}
-                          </p>
-                          <p className="truncate text-xs text-[var(--color-text-soft)]">
-                            {team.key}
-                          </p>
+                        <div className="flex min-w-0 items-center gap-3">
+                          <GeneratedAvatar kind="team" name={team.name} size={40} />
+                          <div className="min-w-0">
+                            <p className="truncate font-semibold text-[var(--color-text)]">
+                              {team.name}
+                            </p>
+                            <p className="truncate text-xs text-[var(--color-text-soft)]">
+                              {team.key}
+                            </p>
+                          </div>
                         </div>
                         <Badge variant={team.status === 'active' ? 'success' : 'warning'}>
                           {team.status}
@@ -461,7 +469,7 @@ export function TeamsPage() {
 
                       <div className="mt-4 flex flex-wrap gap-2">
                         {team.admins.length > 0 ? (
-                          team.admins.map((admin) => <Badge key={admin.id}>{admin.name}</Badge>)
+                          team.admins.map((admin) => <UserEntityLink key={admin.id} user={admin} />)
                         ) : (
                           <span className="text-xs text-[var(--color-text-soft)]">
                             No admins assigned
@@ -536,17 +544,22 @@ export function TeamsPage() {
                         <Fragment key={team.id}>
                           <TableRow aria-expanded={isExpanded}>
                             <TableCell className="px-3 py-3">
-                              <div className="flex flex-col gap-1">
-                                <p className="text-[var(--color-text)]">{team.name}</p>
-                                <p className="text-xs text-[var(--color-text-soft)]">{team.key}</p>
-                                <EntityTagBadges tags={team.tags} />
+                              <div className="flex min-w-0 items-center gap-3">
+                                <GeneratedAvatar kind="team" name={team.name} size={32} />
+                                <div className="flex min-w-0 flex-col gap-1">
+                                  <p className="truncate text-[var(--color-text)]">{team.name}</p>
+                                  <p className="truncate text-xs text-[var(--color-text-soft)]">
+                                    {team.key}
+                                  </p>
+                                  <EntityTagBadges tags={team.tags} />
+                                </div>
                               </div>
                             </TableCell>
                             <TableCell className="px-3 py-3">
                               {team.admins.length > 0 ? (
                                 <div className="flex flex-wrap gap-2">
                                   {team.admins.map((admin) => (
-                                    <Badge key={admin.id}>{admin.name}</Badge>
+                                    <UserEntityLink key={admin.id} user={admin} compact />
                                   ))}
                                 </div>
                               ) : (
@@ -1079,6 +1092,30 @@ export function TeamsPage() {
   )
 }
 
+function UserEntityLink({
+  user,
+  compact = false,
+}: {
+  user: { id: string; name: string; email: string; status?: string }
+  compact?: boolean
+}) {
+  return (
+    <Button asChild type="button" size="sm" variant="secondary" className="h-auto px-2 py-1">
+      <Link
+        to="/identity/users"
+        search={{ user_id: user.id, user_section: 'overview' }}
+        aria-label={`Open ${user.name}`}
+      >
+        <GeneratedAvatar kind="user" name={user.name || user.email} size={compact ? 20 : 24} />
+        <span className="truncate">{user.name}</span>
+        {!compact && user.status ? (
+          <span className="text-xs text-[var(--color-text-soft)]">{user.status}</span>
+        ) : null}
+      </Link>
+    </Button>
+  )
+}
+
 function TeamMemberRoster({
   teamId,
   members,
@@ -1110,6 +1147,7 @@ function TeamMemberRoster({
             key={member.id}
             className="flex flex-wrap items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2"
           >
+            <GeneratedAvatar kind="user" name={member.name || member.email} size={32} />
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium text-[var(--color-text)]">{member.name}</p>
               <p className="truncate text-xs text-[var(--color-text-soft)]">{member.email}</p>
@@ -1222,6 +1260,7 @@ function UserMultiSelectField({
                     <span className="w-4 text-[var(--color-text-soft)]">
                       {selectedUserIds.includes(user.id) ? '✓' : ''}
                     </span>
+                    <GeneratedAvatar kind="user" name={user.name || user.email} size={28} />
                     <div className="flex min-w-0 flex-1 flex-col gap-1">
                       <span className="truncate">{user.name}</span>
                       <span className="truncate text-xs text-[var(--color-text-soft)]">

--- a/crates/admin-ui/web/src/routes/identity/teams.tsx
+++ b/crates/admin-ui/web/src/routes/identity/teams.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo, useState, useTransition, type FormEvent } from 'react'
-import { UserIcon } from '@hugeicons/core-free-icons'
+import { UnfoldMoreDownIcon, UnfoldMoreUpIcon, UserIcon } from '@hugeicons/core-free-icons'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
@@ -478,7 +478,10 @@ export function TeamsPage() {
                           aria-controls={membersRegionId}
                           onClick={() => toggleTeamMembers(team.id)}
                         >
-                          {isExpanded ? 'Hide' : 'Show'} {formatMemberCount(team.member_count)}
+                          <TeamMembersToggleLabel
+                            isExpanded={isExpanded}
+                            memberCount={team.member_count}
+                          />
                         </Button>
                         <Button
                           type="button"
@@ -561,8 +564,10 @@ export function TeamsPage() {
                                 aria-controls={membersRegionId}
                                 onClick={() => toggleTeamMembers(team.id)}
                               >
-                                {isExpanded ? 'Hide' : 'Show'}{' '}
-                                {formatMemberCount(team.member_count)}
+                                <TeamMembersToggleLabel
+                                  isExpanded={isExpanded}
+                                  memberCount={team.member_count}
+                                />
                               </Button>
                             </TableCell>
                             <TableCell className="px-3 py-3">
@@ -1299,8 +1304,28 @@ function isInviteOidcDisabled(
   return form.auth_mode === 'oidc' && (providers.length === 0 || !form.oidc_provider_key)
 }
 
-function formatMemberCount(count: number) {
-  return `${count} ${count === 1 ? 'member' : 'members'}`
+function TeamMembersToggleLabel({
+  isExpanded,
+  memberCount,
+}: {
+  isExpanded: boolean
+  memberCount: number
+}) {
+  return (
+    <>
+      <AppIcon
+        icon={isExpanded ? UnfoldMoreUpIcon : UnfoldMoreDownIcon}
+        stroke={1.5}
+        aria-hidden
+        data-icon="inline-start"
+        className="transition-transform duration-200 ease-out"
+      />
+      <span>
+        {isExpanded ? 'Hide' : 'Show'} <span className="tabular-nums">{memberCount}</span>{' '}
+        {memberCount === 1 ? 'member' : 'members'}
+      </span>
+    </>
+  )
 }
 
 function getErrorMessage(error: unknown) {

--- a/crates/admin-ui/web/src/routes/identity/teams.tsx
+++ b/crates/admin-ui/web/src/routes/identity/teams.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useTransition, type FormEvent } from 'react'
+import { Fragment, useMemo, useState, useTransition, type FormEvent } from 'react'
 import { UserIcon } from '@hugeicons/core-free-icons'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
@@ -45,6 +45,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import {
   addIdentityTeamMembers,
   createIdentityTeam,
@@ -109,6 +117,7 @@ export function TeamsPage() {
   const [inviteForm, setInviteForm] = useState<CreateUserInput>(initialInviteForm)
   const [inviteResult, setInviteResult] = useState<CreateUserResult | null>(null)
   const [memberDialog, setMemberDialog] = useState<TeamMemberDialogState>({ mode: 'closed' })
+  const [expandedTeamIds, setExpandedTeamIds] = useState<string[]>([])
   const [transferForm, setTransferForm] = useState<TransferTeamMemberInput>({
     destination_team_id: '',
     destination_role: 'member',
@@ -227,6 +236,12 @@ export function TeamsPage() {
       destination_team_id: '',
       destination_role: 'member',
     })
+  }
+
+  function toggleTeamMembers(teamId: string) {
+    setExpandedTeamIds((current) =>
+      current.includes(teamId) ? current.filter((id) => id !== teamId) : [...current, teamId],
+    )
   }
 
   function setInviteAuthMode(authMode: CreateUserInput['auth_mode']) {
@@ -400,257 +415,203 @@ export function TeamsPage() {
           ) : (
             <div className="flex flex-col gap-4">
               <div className="grid gap-3 md:hidden">
-                {teamMembersByTeam.map(({ team, members }) => (
-                  <article
-                    key={team.id}
-                    className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate font-semibold text-[var(--color-text)]">
-                          {team.name}
-                        </p>
-                        <p className="truncate text-xs text-[var(--color-text-soft)]">{team.key}</p>
-                      </div>
-                      <Badge variant={team.status === 'active' ? 'success' : 'warning'}>
-                        {team.status}
-                      </Badge>
-                    </div>
+                {teamMembersByTeam.map(({ team, members }) => {
+                  const isExpanded = expandedTeamIds.includes(team.id)
+                  const membersRegionId = `team-members-mobile-${team.id}`
 
-                    <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
-                      <div>
-                        <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
-                          Members
-                        </dt>
-                        <dd className="text-[var(--color-text-muted)]">{team.member_count}</dd>
+                  return (
+                    <article
+                      key={team.id}
+                      className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="truncate font-semibold text-[var(--color-text)]">
+                            {team.name}
+                          </p>
+                          <p className="truncate text-xs text-[var(--color-text-soft)]">
+                            {team.key}
+                          </p>
+                        </div>
+                        <Badge variant={team.status === 'active' ? 'success' : 'warning'}>
+                          {team.status}
+                        </Badge>
                       </div>
-                      <div>
-                        <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
-                          Admins
-                        </dt>
-                        <dd className="text-[var(--color-text-muted)]">
-                          {team.admins.length > 0 ? team.admins.length : 'None'}
-                        </dd>
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <EntityTagBadges tags={team.tags} />
                       </div>
-                    </dl>
 
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <EntityTagBadges tags={team.tags} />
-                    </div>
+                      <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+                        <div>
+                          <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+                            Members
+                          </dt>
+                          <dd className="text-[var(--color-text-muted)]">{team.member_count}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+                            Admins
+                          </dt>
+                          <dd className="text-[var(--color-text-muted)]">
+                            {team.admins.length > 0 ? team.admins.length : 'None'}
+                          </dd>
+                        </div>
+                      </dl>
 
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      {team.admins.length > 0 ? (
-                        team.admins.map((admin) => <Badge key={admin.id}>{admin.name}</Badge>)
-                      ) : (
-                        <span className="text-xs text-[var(--color-text-soft)]">
-                          No admins assigned
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="mt-4 flex flex-col gap-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <h3 className="text-sm font-semibold text-[var(--color-text)]">Members</h3>
-                        <span className="text-xs text-[var(--color-text-soft)]">
-                          {members.length} total
-                        </span>
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {team.admins.length > 0 ? (
+                          team.admins.map((admin) => <Badge key={admin.id}>{admin.name}</Badge>)
+                        ) : (
+                          <span className="text-xs text-[var(--color-text-soft)]">
+                            No admins assigned
+                          </span>
+                        )}
                       </div>
-                      {members.length > 0 ? (
-                        <div className="flex flex-col gap-2">
-                          {members.map((member) => (
-                            <div
-                              key={member.id}
-                              className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-3"
-                            >
-                              <div className="flex items-start justify-between gap-3">
-                                <div className="min-w-0">
-                                  <p className="truncate text-sm font-semibold text-[var(--color-text)]">
-                                    {member.name}
-                                  </p>
-                                  <p className="truncate text-xs text-[var(--color-text-soft)]">
-                                    {member.email}
-                                  </p>
-                                </div>
-                                <Badge
-                                  variant={member.team_role === 'owner' ? 'warning' : 'default'}
-                                >
-                                  {member.team_role ?? 'member'}
-                                </Badge>
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          aria-expanded={isExpanded}
+                          aria-controls={membersRegionId}
+                          onClick={() => toggleTeamMembers(team.id)}
+                        >
+                          {isExpanded ? 'Hide' : 'Show'} {formatMemberCount(team.member_count)}
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => openEditTeamDialog(team)}
+                        >
+                          Edit team
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => openMembersDialog(team)}
+                        >
+                          Add members
+                        </Button>
+                      </div>
+
+                      {isExpanded ? (
+                        <div id={membersRegionId} className="mt-4">
+                          <TeamMemberRoster
+                            teamId={team.id}
+                            members={members}
+                            onTransferMember={openTransferMemberDialog}
+                            onRemoveMember={openRemoveMemberDialog}
+                          />
+                        </div>
+                      ) : null}
+                    </article>
+                  )
+                })}
+              </div>
+
+              <div className="hidden overflow-hidden rounded-md border border-[color:var(--color-border)] md:block">
+                <Table className="text-left">
+                  <TableHeader className="bg-[color:var(--color-surface-muted)] text-[var(--color-text-soft)]">
+                    <TableRow>
+                      <TableHead className="px-3 py-2 font-semibold">Team</TableHead>
+                      <TableHead className="px-3 py-2 font-semibold">Admins</TableHead>
+                      <TableHead className="px-3 py-2 font-semibold">Members</TableHead>
+                      <TableHead className="px-3 py-2 font-semibold">Status</TableHead>
+                      <TableHead className="px-3 py-2 font-semibold">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {teamMembersByTeam.map(({ team, members }) => {
+                      const isExpanded = expandedTeamIds.includes(team.id)
+                      const membersRegionId = `team-members-desktop-${team.id}`
+
+                      return (
+                        <Fragment key={team.id}>
+                          <TableRow aria-expanded={isExpanded}>
+                            <TableCell className="px-3 py-3">
+                              <div className="flex flex-col gap-1">
+                                <p className="text-[var(--color-text)]">{team.name}</p>
+                                <p className="text-xs text-[var(--color-text-soft)]">{team.key}</p>
+                                <EntityTagBadges tags={team.tags} />
                               </div>
-                              <div className="mt-3 flex flex-wrap gap-2">
+                            </TableCell>
+                            <TableCell className="px-3 py-3">
+                              {team.admins.length > 0 ? (
+                                <div className="flex flex-wrap gap-2">
+                                  {team.admins.map((admin) => (
+                                    <Badge key={admin.id}>{admin.name}</Badge>
+                                  ))}
+                                </div>
+                              ) : (
+                                <span className="text-xs text-[var(--color-text-soft)]">
+                                  No admins
+                                </span>
+                              )}
+                            </TableCell>
+                            <TableCell className="px-3 py-3">
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                aria-expanded={isExpanded}
+                                aria-controls={membersRegionId}
+                                onClick={() => toggleTeamMembers(team.id)}
+                              >
+                                {isExpanded ? 'Hide' : 'Show'}{' '}
+                                {formatMemberCount(team.member_count)}
+                              </Button>
+                            </TableCell>
+                            <TableCell className="px-3 py-3">
+                              <Badge variant={team.status === 'active' ? 'success' : 'warning'}>
+                                {team.status}
+                              </Badge>
+                            </TableCell>
+                            <TableCell className="px-3 py-3">
+                              <div className="flex flex-wrap gap-2">
                                 <Button
                                   type="button"
                                   size="sm"
                                   variant="secondary"
-                                  onClick={() => openTransferMemberDialog(team.id, member.id)}
-                                  disabled={member.team_role === 'owner'}
+                                  onClick={() => openEditTeamDialog(team)}
                                 >
-                                  Transfer
+                                  Edit team
                                 </Button>
                                 <Button
                                   type="button"
                                   size="sm"
                                   variant="ghost"
-                                  onClick={() => openRemoveMemberDialog(team.id, member.id)}
-                                  disabled={member.team_role === 'owner'}
+                                  onClick={() => openMembersDialog(team)}
                                 >
-                                  Remove
+                                  Add members
                                 </Button>
                               </div>
-                              {member.team_role === 'owner' ? (
-                                <p className="mt-2 text-xs text-[var(--color-text-soft)]">
-                                  Owner memberships cannot be removed or transferred in this slice.
-                                </p>
-                              ) : null}
-                            </div>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="text-sm text-[var(--color-text-soft)]">
-                          No members assigned yet.
-                        </p>
-                      )}
-                    </div>
-
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="secondary"
-                        onClick={() => openEditTeamDialog(team)}
-                      >
-                        Edit team
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => openMembersDialog(team)}
-                      >
-                        Add members
-                      </Button>
-                    </div>
-                  </article>
-                ))}
-              </div>
-
-              <div className="hidden overflow-hidden rounded-md border border-[color:var(--color-border)] md:block">
-                <table className="w-full text-left text-sm">
-                  <thead className="bg-[color:var(--color-surface-muted)] text-[var(--color-text-soft)]">
-                    <tr>
-                      <th className="px-3 py-2 font-semibold">Team</th>
-                      <th className="px-3 py-2 font-semibold">Admins</th>
-                      <th className="px-3 py-2 font-semibold">Members</th>
-                      <th className="px-3 py-2 font-semibold">Status</th>
-                      <th className="px-3 py-2 font-semibold">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {teamMembersByTeam.map(({ team, members }) => (
-                      <tr
-                        key={team.id}
-                        className="border-t border-[color:var(--color-border)] align-top"
-                      >
-                        <td className="px-3 py-3">
-                          <div className="flex flex-col gap-1">
-                            <p className="text-[var(--color-text)]">{team.name}</p>
-                            <p className="text-xs text-[var(--color-text-soft)]">{team.key}</p>
-                            <EntityTagBadges tags={team.tags} />
-                          </div>
-                        </td>
-                        <td className="px-3 py-3">
-                          {team.admins.length > 0 ? (
-                            <div className="flex flex-wrap gap-2">
-                              {team.admins.map((admin) => (
-                                <Badge key={admin.id}>{admin.name}</Badge>
-                              ))}
-                            </div>
-                          ) : (
-                            <span className="text-xs text-[var(--color-text-soft)]">No admins</span>
-                          )}
-                        </td>
-                        <td className="px-3 py-3">
-                          <div className="flex flex-col gap-2">
-                            <div className="text-sm text-[var(--color-text-muted)]">
-                              {team.member_count} members
-                            </div>
-                            {members.length > 0 ? (
-                              <div className="flex flex-col gap-2">
-                                {members.map((member) => (
-                                  <div
-                                    key={member.id}
-                                    className="flex flex-wrap items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] px-2 py-2"
-                                  >
-                                    <div className="min-w-0 flex-1">
-                                      <p className="truncate text-[var(--color-text)]">
-                                        {member.name}
-                                      </p>
-                                      <p className="truncate text-xs text-[var(--color-text-soft)]">
-                                        {member.email}
-                                      </p>
-                                    </div>
-                                    <Badge
-                                      variant={member.team_role === 'owner' ? 'warning' : 'default'}
-                                    >
-                                      {member.team_role ?? 'member'}
-                                    </Badge>
-                                    <Button
-                                      type="button"
-                                      size="sm"
-                                      variant="secondary"
-                                      onClick={() => openTransferMemberDialog(team.id, member.id)}
-                                      disabled={member.team_role === 'owner'}
-                                    >
-                                      Transfer
-                                    </Button>
-                                    <Button
-                                      type="button"
-                                      size="sm"
-                                      variant="ghost"
-                                      onClick={() => openRemoveMemberDialog(team.id, member.id)}
-                                      disabled={member.team_role === 'owner'}
-                                    >
-                                      Remove
-                                    </Button>
-                                  </div>
-                                ))}
-                              </div>
-                            ) : (
-                              <span className="text-sm text-[var(--color-text-soft)]">
-                                No members assigned yet
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-3 py-3">
-                          <Badge variant={team.status === 'active' ? 'success' : 'warning'}>
-                            {team.status}
-                          </Badge>
-                        </td>
-                        <td className="px-3 py-3">
-                          <div className="flex flex-wrap gap-2">
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="secondary"
-                              onClick={() => openEditTeamDialog(team)}
-                            >
-                              Edit team
-                            </Button>
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => openMembersDialog(team)}
-                            >
-                              Add members
-                            </Button>
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                            </TableCell>
+                          </TableRow>
+                          {isExpanded ? (
+                            <TableRow>
+                              <TableCell
+                                id={membersRegionId}
+                                colSpan={5}
+                                className="bg-[color:var(--color-surface-muted)] px-3 py-4 whitespace-normal"
+                              >
+                                <TeamMemberRoster
+                                  teamId={team.id}
+                                  members={members}
+                                  onTransferMember={openTransferMemberDialog}
+                                  onRemoveMember={openRemoveMemberDialog}
+                                />
+                              </TableCell>
+                            </TableRow>
+                          ) : null}
+                        </Fragment>
+                      )
+                    })}
+                  </TableBody>
+                </Table>
               </div>
             </div>
           )}
@@ -1113,6 +1074,74 @@ export function TeamsPage() {
   )
 }
 
+function TeamMemberRoster({
+  teamId,
+  members,
+  onTransferMember,
+  onRemoveMember,
+}: {
+  teamId: string
+  members: TeamAssignableUserView[]
+  onTransferMember: (teamId: string, userId: string) => void
+  onRemoveMember: (teamId: string, userId: string) => void
+}) {
+  if (members.length === 0) {
+    return (
+      <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] p-4 text-sm text-[var(--color-text-soft)]">
+        No members assigned yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-[var(--color-text)]">Members</h3>
+        <span className="text-xs text-[var(--color-text-soft)]">{members.length} total</span>
+      </div>
+      <div className="grid gap-2">
+        {members.map((member) => (
+          <div
+            key={member.id}
+            className="flex flex-wrap items-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-bg)] px-3 py-2"
+          >
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-[var(--color-text)]">{member.name}</p>
+              <p className="truncate text-xs text-[var(--color-text-soft)]">{member.email}</p>
+            </div>
+            <Badge variant={member.team_role === 'owner' ? 'warning' : 'default'}>
+              {member.team_role ?? 'member'}
+            </Badge>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => onTransferMember(teamId, member.id)}
+              disabled={member.team_role === 'owner'}
+            >
+              Transfer
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => onRemoveMember(teamId, member.id)}
+              disabled={member.team_role === 'owner'}
+            >
+              Remove
+            </Button>
+            {member.team_role === 'owner' ? (
+              <p className="basis-full text-xs text-[var(--color-text-soft)]">
+                Owner memberships cannot be removed or transferred in this slice.
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function UserMultiSelectField({
   label,
   description,
@@ -1268,6 +1297,10 @@ function isInviteOidcDisabled(
   providers: IdentityTeamsPayload['oidc_providers'],
 ) {
   return form.auth_mode === 'oidc' && (providers.length === 0 || !form.oidc_provider_key)
+}
+
+function formatMemberCount(count: number) {
+  return `${count} ${count === 1 ? 'member' : 'members'}`
 }
 
 function getErrorMessage(error: unknown) {

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -1,4 +1,4 @@
-import { useState, useTransition, type FormEvent } from 'react'
+import { useEffect, useState, useTransition, type CSSProperties, type FormEvent } from 'react'
 import { UserIcon } from '@hugeicons/core-free-icons'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/empty'
 import { Field, FieldDescription, FieldGroup, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
+import { GeneratedAvatar } from '@/components/ui/generated-avatar'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { requireAdminSession } from '@/routes/-admin-guard'
 import {
@@ -38,6 +39,16 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from '@/components/ui/sidebar'
+import {
   deactivateIdentityUser,
   createIdentityUser,
   getUsers,
@@ -46,7 +57,11 @@ import {
   resendIdentityUserPasswordInvite,
   updateIdentityUser,
 } from '@/server/admin-data.functions'
-import { EntityTagBadges, EntityTagsField, sanitizeEntityTags } from '@/routes/identity/-entity-tags'
+import {
+  EntityTagBadges,
+  EntityTagsField,
+  sanitizeEntityTags,
+} from '@/routes/identity/-entity-tags'
 import type {
   CreateUserInput,
   CreateUserResult,
@@ -57,6 +72,7 @@ import type {
 
 export const Route = createFileRoute('/identity/users')({
   beforeLoad: ({ location }) => requireAdminSession(location),
+  validateSearch: (search: Record<string, unknown>) => normalizeUserSearch(search),
   loader: () => getUsers(),
   component: UsersPage,
 })
@@ -81,7 +97,14 @@ const initialUpdateForm: UpdateUserInput = {
   tags: [],
 }
 
-type UserDialogState = { mode: 'closed' } | { mode: 'edit'; userId: string }
+const userDetailsSections = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'configuration', label: 'Configuration' },
+  { id: 'auth', label: 'Auth & onboarding' },
+  { id: 'usage', label: 'Usage' },
+] as const
+
+type UserDetailsSection = (typeof userDetailsSections)[number]['id']
 
 export function UsersPage() {
   const router = useRouter()
@@ -91,14 +114,35 @@ export function UsersPage() {
   const [isOpen, setIsOpen] = useState(false)
   const [form, setForm] = useState<CreateUserInput>(initialForm)
   const [result, setResult] = useState<CreateUserResult | null>(null)
-  const [userDialog, setUserDialog] = useState<UserDialogState>({ mode: 'closed' })
+  const search = Route.useSearch()
   const [updateForm, setUpdateForm] = useState<UpdateUserInput>(initialUpdateForm)
   const [onboardingResult, setOnboardingResult] = useState<CreateUserResult | null>(null)
   const [isPending, startTransition] = useTransition()
-  const selectedUser =
-    userDialog.mode === 'edit'
-      ? (users.find((user) => user.id === userDialog.userId) ?? null)
-      : null
+  const selectedUser = search.user_id
+    ? (users.find((user) => user.id === search.user_id) ?? null)
+    : null
+  const selectedUserSection = search.user_section
+
+  useEffect(() => {
+    if (!selectedUser) {
+      setUpdateForm(initialUpdateForm)
+      setOnboardingResult(null)
+      return
+    }
+
+    setUpdateForm({
+      global_role: selectedUser.global_role,
+      team_id: selectedUser.team_id,
+      team_role: selectedUser.team_role === 'owner' ? null : selectedUser.team_role,
+      auth_mode: selectedUser.auth_mode,
+      oidc_provider_key:
+        selectedUser.onboarding?.kind === 'oidc_sign_in'
+          ? selectedUser.onboarding.provider_key
+          : null,
+      tags: selectedUser.tags,
+    })
+    setOnboardingResult(null)
+  }, [selectedUser])
 
   function resetDialog() {
     setForm(initialForm)
@@ -107,7 +151,10 @@ export function UsersPage() {
   }
 
   function resetUserDialog() {
-    setUserDialog({ mode: 'closed' })
+    void router.navigate({
+      to: '/identity/users',
+      search: {},
+    })
     setUpdateForm(initialUpdateForm)
     setOnboardingResult(null)
   }
@@ -136,18 +183,22 @@ export function UsersPage() {
     }))
   }
 
-  function openUserDialog(user: UserView) {
-    setUserDialog({ mode: 'edit', userId: user.id })
-    setUpdateForm({
-      global_role: user.global_role,
-      team_id: user.team_id,
-      team_role: user.team_role === 'owner' ? null : user.team_role,
-      auth_mode: user.auth_mode,
-      oidc_provider_key:
-        user.onboarding?.kind === 'oidc_sign_in' ? user.onboarding.provider_key : null,
-      tags: user.tags,
+  function openUserDialog(user: UserView, section: UserDetailsSection = 'overview') {
+    void router.navigate({
+      to: '/identity/users',
+      search: { user_id: user.id, user_section: section },
     })
-    setOnboardingResult(null)
+  }
+
+  function setSelectedUserSection(section: UserDetailsSection) {
+    if (!selectedUser) {
+      return
+    }
+
+    void router.navigate({
+      to: '/identity/users',
+      search: { user_id: selectedUser.id, user_section: section },
+    })
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -175,7 +226,7 @@ export function UsersPage() {
 
   async function handleUpdateUser(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (userDialog.mode !== 'edit' || !selectedUser) {
+    if (!selectedUser) {
       return
     }
 
@@ -197,7 +248,7 @@ export function UsersPage() {
   }
 
   async function handleDeactivateUser() {
-    if (userDialog.mode !== 'edit' || !selectedUser) {
+    if (!selectedUser) {
       return
     }
 
@@ -214,7 +265,7 @@ export function UsersPage() {
   }
 
   async function handleReactivateUser() {
-    if (userDialog.mode !== 'edit' || !selectedUser) {
+    if (!selectedUser) {
       return
     }
 
@@ -231,7 +282,7 @@ export function UsersPage() {
   }
 
   async function handleResetUserOnboarding() {
-    if (userDialog.mode !== 'edit' || !selectedUser) {
+    if (!selectedUser) {
       return
     }
 
@@ -613,13 +664,16 @@ export function UsersPage() {
                     className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4"
                   >
                     <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate font-semibold text-[var(--color-text)]">
-                          {user.name}
-                        </p>
-                        <p className="truncate text-sm text-[var(--color-text-muted)]">
-                          {user.email}
-                        </p>
+                      <div className="flex min-w-0 items-center gap-3">
+                        <GeneratedAvatar kind="user" name={user.name || user.email} size={40} />
+                        <div className="min-w-0">
+                          <p className="truncate font-semibold text-[var(--color-text)]">
+                            {user.name}
+                          </p>
+                          <p className="truncate text-sm text-[var(--color-text-muted)]">
+                            {user.email}
+                          </p>
+                        </div>
                       </div>
                       <Badge
                         variant={
@@ -708,7 +762,12 @@ export function UsersPage() {
                         key={user.id}
                         className="border-t border-[color:var(--color-border)] align-top"
                       >
-                        <td className="px-3 py-3 text-[var(--color-text)]">{user.name}</td>
+                        <td className="px-3 py-3 text-[var(--color-text)]">
+                          <div className="flex min-w-0 items-center gap-3">
+                            <GeneratedAvatar kind="user" name={user.name || user.email} size={32} />
+                            <span className="truncate">{user.name}</span>
+                          </div>
+                        </td>
                         <td className="px-3 py-3 text-[var(--color-text-muted)]">{user.email}</td>
                         <td className="px-3 py-3 text-[var(--color-text-muted)]">
                           {user.auth_mode}
@@ -764,309 +823,534 @@ export function UsersPage() {
       </Card>
 
       <Dialog
-        open={userDialog.mode === 'edit'}
+        open={Boolean(selectedUser)}
         onOpenChange={(open) => {
           if (!open) {
             resetUserDialog()
           }
         }}
       >
-        <DialogContent className="w-[min(760px,calc(100vw-32px))]">
-          <DialogHeader>
-            <DialogTitle>Manage user</DialogTitle>
-            <DialogDescription>
-              Update role and membership fields, then use the lifecycle actions to deactivate,
-              reactivate, or reset onboarding.
-            </DialogDescription>
-          </DialogHeader>
+        <DialogContent className="overflow-hidden p-0 md:max-h-[680px] md:max-w-[920px]">
+          <DialogTitle className="sr-only">Manage user</DialogTitle>
+          <DialogDescription className="sr-only">
+            Review user status, configuration, auth settings, and usage.
+          </DialogDescription>
 
           {selectedUser ? (
-            <div className="flex flex-col gap-5">
-              <div className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4">
-                <p className="font-semibold text-[var(--color-text)]">{selectedUser.name}</p>
-                <p className="text-sm text-[var(--color-text-muted)]">{selectedUser.email}</p>
-                <p className="mt-1 text-sm text-[var(--color-text-muted)]">
-                  Request logging: {selectedUser.request_logging_enabled ? 'enabled' : 'disabled'}
-                </p>
-                <div className="mt-3">
-                  <EntityTagBadges tags={selectedUser.tags} />
-                </div>
-                <p className="mt-2 text-xs text-[var(--color-text-soft)]">
-                  {selectedUser.status === 'invited'
-                    ? 'Auth mode can only be changed while the user is still invited.'
-                    : 'Auth mode is locked after activation; use reset onboarding to reissue credentials.'}
-                </p>
-                {selectedUser.team_role === 'owner' ? (
-                  <Alert className="mt-3">
-                    <AlertTitle>Owner membership is locked</AlertTitle>
-                    <AlertDescription>
-                      This user is an owner on their current team. In this slice, owner memberships
-                      cannot be moved or changed through the admin UI.
-                    </AlertDescription>
-                  </Alert>
-                ) : null}
-              </div>
+            <SidebarProvider
+              className="min-h-0 items-start"
+              style={{ '--sidebar-width': '13.5rem' } as CSSProperties}
+            >
+              <Sidebar
+                collapsible="none"
+                className="hidden border-r border-[color:var(--color-border)] md:flex"
+              >
+                <SidebarContent>
+                  <SidebarGroup>
+                    <SidebarGroupContent>
+                      <SidebarMenu>
+                        {userDetailsSections.map((section) => (
+                          <SidebarMenuItem key={section.id}>
+                            <SidebarMenuButton
+                              type="button"
+                              isActive={selectedUserSection === section.id}
+                              onClick={() => setSelectedUserSection(section.id)}
+                            >
+                              <span>{section.label}</span>
+                            </SidebarMenuButton>
+                          </SidebarMenuItem>
+                        ))}
+                      </SidebarMenu>
+                    </SidebarGroupContent>
+                  </SidebarGroup>
+                </SidebarContent>
+              </Sidebar>
 
-              <form className="flex flex-col gap-5" onSubmit={handleUpdateUser}>
-                <FieldGroup>
-                  <Field>
-                    <FieldLabel htmlFor="manage-global-role">Global role</FieldLabel>
-                    <Select
-                      value={updateForm.global_role}
-                      onValueChange={(value: UpdateUserInput['global_role']) =>
-                        setUpdateForm((current) => ({ ...current, global_role: value }))
+              <main className="flex max-h-[680px] min-h-[520px] flex-1 flex-col overflow-hidden">
+                <header className="flex shrink-0 flex-col gap-3 border-b border-[color:var(--color-border)] px-5 py-4">
+                  <div className="flex items-center gap-3">
+                    <GeneratedAvatar
+                      kind="user"
+                      name={selectedUser.name || selectedUser.email}
+                      size={44}
+                    />
+                    <div className="min-w-0">
+                      <h2 className="truncate text-lg font-semibold text-[var(--color-text)]">
+                        {selectedUser.name}
+                      </h2>
+                      <p className="truncate text-sm text-[var(--color-text-muted)]">
+                        {selectedUser.email}
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <EntityTagBadges tags={selectedUser.tags} />
+                      </div>
+                    </div>
+                    <Badge
+                      className="ml-auto"
+                      variant={
+                        selectedUser.status === 'active'
+                          ? 'success'
+                          : selectedUser.status === 'invited'
+                            ? 'warning'
+                            : 'default'
                       }
                     >
-                      <SelectTrigger id="manage-global-role">
-                        <SelectValue placeholder="Select role" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          <SelectItem value="user">User</SelectItem>
-                          <SelectItem value="platform_admin">Platform admin</SelectItem>
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </Field>
+                      {selectedUser.status}
+                    </Badge>
+                  </div>
 
-                  <Field>
-                    <FieldLabel htmlFor="manage-team">Team</FieldLabel>
-                    <Select
-                      value={updateForm.team_id ?? 'none'}
-                      onValueChange={(value) =>
-                        setUpdateForm((current) => ({
-                          ...current,
-                          team_id: value === 'none' ? null : value,
-                          team_role: value === 'none' ? null : (current.team_role ?? 'member'),
-                        }))
-                      }
-                      disabled={selectedUser.team_role === 'owner'}
-                    >
-                      <SelectTrigger id="manage-team">
-                        <SelectValue placeholder="No team" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          <SelectItem value="none">No team</SelectItem>
-                          {teams.map((team) => (
-                            <SelectItem key={team.id} value={team.id}>
-                              {team.name}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-
-                  {updateForm.team_id ? (
-                    <Field>
-                      <FieldLabel htmlFor="manage-team-role">Team role</FieldLabel>
-                      <Select
-                        value={updateForm.team_role ?? 'member'}
-                        onValueChange={(value: NonNullable<UpdateUserInput['team_role']>) =>
-                          setUpdateForm((current) => ({ ...current, team_role: value }))
-                        }
-                        disabled={selectedUser.team_role === 'owner'}
+                  <div className="flex gap-2 overflow-x-auto md:hidden">
+                    {userDetailsSections.map((section) => (
+                      <Button
+                        key={section.id}
+                        type="button"
+                        size="sm"
+                        variant={selectedUserSection === section.id ? 'secondary' : 'ghost'}
+                        onClick={() => setSelectedUserSection(section.id)}
                       >
-                        <SelectTrigger id="manage-team-role">
-                          <SelectValue placeholder="Select team role" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectGroup>
-                            <SelectItem value="member">Member</SelectItem>
-                            <SelectItem value="admin">Admin</SelectItem>
-                          </SelectGroup>
-                        </SelectContent>
-                      </Select>
-                    </Field>
-                  ) : null}
+                        {section.label}
+                      </Button>
+                    ))}
+                  </div>
+                </header>
 
-                  <Field>
-                    <FieldLabel htmlFor="manage-auth-mode">Auth method</FieldLabel>
-                    <Select
-                      value={updateForm.auth_mode}
-                      onValueChange={setUpdateAuthMode}
-                      disabled={selectedUser.status !== 'invited'}
-                    >
-                      <SelectTrigger id="manage-auth-mode">
-                        <SelectValue placeholder="Select auth method" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          <SelectItem value="password">Password</SelectItem>
-                          <SelectItem value="oidc">SSO (OIDC)</SelectItem>
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                    <FieldDescription>
-                      {selectedUser.status === 'invited'
-                        ? 'You can switch onboarding mode before the user completes setup.'
-                        : 'Auth mode is read-only after activation.'}
-                    </FieldDescription>
-                  </Field>
+                <form className="flex min-h-0 flex-1 flex-col" onSubmit={handleUpdateUser}>
+                  <div className="flex-1 overflow-y-auto p-5">
+                    {selectedUserSection === 'overview' ? (
+                      <div className="grid gap-4 lg:grid-cols-3">
+                        <section className="rounded-lg border border-[color:var(--color-border)] p-4 lg:col-span-2">
+                          <h3 className="text-sm font-semibold text-[var(--color-text)]">
+                            Profile
+                          </h3>
+                          <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                            <UserDetailRow
+                              label="Global role"
+                              value={formatRole(selectedUser.global_role)}
+                            />
+                            <UserDetailRow
+                              label="Team"
+                              value={selectedUser.team_name ?? 'No team'}
+                            />
+                            <UserDetailRow
+                              label="Team role"
+                              value={selectedUser.team_role ?? '—'}
+                            />
+                            <UserDetailRow label="Auth method" value={selectedUser.auth_mode} />
+                            <UserDetailRow
+                              label="Request logging"
+                              value={selectedUser.request_logging_enabled ? 'Enabled' : 'Disabled'}
+                            />
+                            <UserDetailRow label="Status" value={selectedUser.status} />
+                          </dl>
+                        </section>
 
-                  {updateForm.auth_mode === 'oidc' ? (
-                    <>
-                      {oidcProviders.length === 0 ? (
+                        <section className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4">
+                          <h3 className="text-sm font-semibold text-[var(--color-text)]">
+                            Next actions
+                          </h3>
+                          <div className="mt-3 flex flex-col gap-2">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="secondary"
+                              onClick={() => setSelectedUserSection('configuration')}
+                            >
+                              Edit configuration
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => setSelectedUserSection('auth')}
+                            >
+                              Manage auth
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => setSelectedUserSection('usage')}
+                            >
+                              View usage
+                            </Button>
+                          </div>
+                        </section>
+                      </div>
+                    ) : null}
+
+                    {selectedUserSection === 'configuration' ? (
+                      <div className="flex flex-col gap-4">
+                        {selectedUser.team_role === 'owner' ? (
+                          <Alert>
+                            <AlertTitle>Owner membership is locked</AlertTitle>
+                            <AlertDescription>
+                              This user is an owner on their current team. In this slice, owner
+                              memberships cannot be moved or changed through the admin UI.
+                            </AlertDescription>
+                          </Alert>
+                        ) : null}
+
+                        <FieldGroup>
+                          <Field>
+                            <FieldLabel htmlFor="manage-global-role">Global role</FieldLabel>
+                            <Select
+                              value={updateForm.global_role}
+                              onValueChange={(value: UpdateUserInput['global_role']) =>
+                                setUpdateForm((current) => ({ ...current, global_role: value }))
+                              }
+                            >
+                              <SelectTrigger id="manage-global-role">
+                                <SelectValue placeholder="Select role" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectGroup>
+                                  <SelectItem value="user">User</SelectItem>
+                                  <SelectItem value="platform_admin">Platform admin</SelectItem>
+                                </SelectGroup>
+                              </SelectContent>
+                            </Select>
+                          </Field>
+
+                          <Field>
+                            <FieldLabel htmlFor="manage-team">Team</FieldLabel>
+                            <Select
+                              value={updateForm.team_id ?? 'none'}
+                              onValueChange={(value) =>
+                                setUpdateForm((current) => ({
+                                  ...current,
+                                  team_id: value === 'none' ? null : value,
+                                  team_role:
+                                    value === 'none' ? null : (current.team_role ?? 'member'),
+                                }))
+                              }
+                              disabled={selectedUser.team_role === 'owner'}
+                            >
+                              <SelectTrigger id="manage-team">
+                                <SelectValue placeholder="No team" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectGroup>
+                                  <SelectItem value="none">No team</SelectItem>
+                                  {teams.map((team) => (
+                                    <SelectItem key={team.id} value={team.id}>
+                                      {team.name}
+                                    </SelectItem>
+                                  ))}
+                                </SelectGroup>
+                              </SelectContent>
+                            </Select>
+                          </Field>
+
+                          {updateForm.team_id ? (
+                            <Field>
+                              <FieldLabel htmlFor="manage-team-role">Team role</FieldLabel>
+                              <Select
+                                value={updateForm.team_role ?? 'member'}
+                                onValueChange={(value: NonNullable<UpdateUserInput['team_role']>) =>
+                                  setUpdateForm((current) => ({ ...current, team_role: value }))
+                                }
+                                disabled={selectedUser.team_role === 'owner'}
+                              >
+                                <SelectTrigger id="manage-team-role">
+                                  <SelectValue placeholder="Select team role" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectGroup>
+                                    <SelectItem value="member">Member</SelectItem>
+                                    <SelectItem value="admin">Admin</SelectItem>
+                                  </SelectGroup>
+                                </SelectContent>
+                              </Select>
+                            </Field>
+                          ) : null}
+                        </FieldGroup>
+
+                        <EntityTagsField
+                          label="Tags"
+                          tags={updateForm.tags}
+                          onChange={(tags) => setUpdateForm((current) => ({ ...current, tags }))}
+                        />
+                      </div>
+                    ) : null}
+
+                    {selectedUserSection === 'auth' ? (
+                      <div className="flex flex-col gap-4">
                         <Alert>
-                          <AlertTitle>No SSO providers configured</AlertTitle>
+                          <AlertTitle>
+                            {selectedUser.status === 'invited'
+                              ? 'Auth mode can still be changed'
+                              : 'Auth mode is locked after activation'}
+                          </AlertTitle>
                           <AlertDescription>
-                            Add an OIDC provider in the gateway before switching a user to SSO.
+                            {selectedUser.status === 'invited'
+                              ? 'You can switch onboarding mode before the user completes setup.'
+                              : 'Use reset onboarding to reissue credentials for invited or disabled users.'}
                           </AlertDescription>
                         </Alert>
-                      ) : null}
 
-                      <Field>
-                        <FieldLabel htmlFor="manage-oidc-provider">OIDC provider</FieldLabel>
-                        <Select
-                          value={updateForm.oidc_provider_key ?? undefined}
-                          onValueChange={(value) =>
-                            setUpdateForm((current) => ({
-                              ...current,
-                              oidc_provider_key: value,
-                            }))
-                          }
-                          disabled={selectedUser.status !== 'invited'}
-                        >
-                          <SelectTrigger id="manage-oidc-provider">
-                            <SelectValue placeholder="Select provider" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectGroup>
-                              {oidcProviders.map((provider) => (
-                                <SelectItem key={provider.key} value={provider.key}>
-                                  {provider.label}
-                                </SelectItem>
-                              ))}
-                            </SelectGroup>
-                          </SelectContent>
-                        </Select>
-                      </Field>
-                    </>
-                  ) : null}
+                        <FieldGroup>
+                          <Field>
+                            <FieldLabel htmlFor="manage-auth-mode">Auth method</FieldLabel>
+                            <Select
+                              value={updateForm.auth_mode}
+                              onValueChange={setUpdateAuthMode}
+                              disabled={selectedUser.status !== 'invited'}
+                            >
+                              <SelectTrigger id="manage-auth-mode">
+                                <SelectValue placeholder="Select auth method" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectGroup>
+                                  <SelectItem value="password">Password</SelectItem>
+                                  <SelectItem value="oidc">SSO (OIDC)</SelectItem>
+                                </SelectGroup>
+                              </SelectContent>
+                            </Select>
+                            <FieldDescription>
+                              {selectedUser.status === 'invited'
+                                ? 'You can switch onboarding mode before the user completes setup.'
+                                : 'Auth mode is read-only after activation.'}
+                            </FieldDescription>
+                          </Field>
 
-                  <EntityTagsField
-                    label="Tags"
-                    tags={updateForm.tags}
-                    onChange={(tags) => setUpdateForm((current) => ({ ...current, tags }))}
-                  />
-                </FieldGroup>
+                          {updateForm.auth_mode === 'oidc' ? (
+                            <>
+                              {oidcProviders.length === 0 ? (
+                                <Alert>
+                                  <AlertTitle>No SSO providers configured</AlertTitle>
+                                  <AlertDescription>
+                                    Add an OIDC provider in the gateway before switching a user to
+                                    SSO.
+                                  </AlertDescription>
+                                </Alert>
+                              ) : null}
 
-                <section className="flex flex-col gap-3 rounded-lg border border-[color:var(--color-border)] p-4">
-                  <div className="flex flex-col gap-1">
-                    <h3 className="text-sm font-semibold text-[var(--color-text)]">
-                      Lifecycle actions
-                    </h3>
-                    <p className="text-sm text-[var(--color-text-muted)]">
-                      These operations take effect immediately and the list will refresh from the
-                      gateway after each action.
-                    </p>
-                  </div>
+                              <Field>
+                                <FieldLabel htmlFor="manage-oidc-provider">
+                                  OIDC provider
+                                </FieldLabel>
+                                <Select
+                                  value={updateForm.oidc_provider_key ?? undefined}
+                                  onValueChange={(value) =>
+                                    setUpdateForm((current) => ({
+                                      ...current,
+                                      oidc_provider_key: value,
+                                    }))
+                                  }
+                                  disabled={selectedUser.status !== 'invited'}
+                                >
+                                  <SelectTrigger id="manage-oidc-provider">
+                                    <SelectValue placeholder="Select provider" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectGroup>
+                                      {oidcProviders.map((provider) => (
+                                        <SelectItem key={provider.key} value={provider.key}>
+                                          {provider.label}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectGroup>
+                                  </SelectContent>
+                                </Select>
+                              </Field>
+                            </>
+                          ) : null}
+                        </FieldGroup>
 
-                  <div className="flex flex-wrap gap-2">
-                    {selectedUser.status !== 'disabled' ? (
-                      <Button
-                        type="button"
-                        variant="destructive"
-                        onClick={handleDeactivateUser}
-                        disabled={isPending}
-                      >
-                        Deactivate
-                      </Button>
-                    ) : (
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        onClick={handleReactivateUser}
-                        disabled={isPending}
-                      >
-                        Reactivate
-                      </Button>
-                    )}
+                        <section className="flex flex-col gap-3 rounded-lg border border-[color:var(--color-border)] p-4">
+                          <div className="flex flex-col gap-1">
+                            <h3 className="text-sm font-semibold text-[var(--color-text)]">
+                              Lifecycle actions
+                            </h3>
+                            <p className="text-sm text-[var(--color-text-muted)]">
+                              These operations take effect immediately and the list will refresh
+                              from the gateway after each action.
+                            </p>
+                          </div>
 
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={handleResetUserOnboarding}
-                      disabled={
-                        isPending ||
-                        (selectedUser.status !== 'invited' && selectedUser.status !== 'disabled')
-                      }
-                    >
-                      Reset onboarding
-                    </Button>
-                  </div>
+                          <div className="flex flex-wrap gap-2">
+                            {selectedUser.status !== 'disabled' ? (
+                              <Button
+                                type="button"
+                                variant="destructive"
+                                onClick={handleDeactivateUser}
+                                disabled={isPending}
+                              >
+                                Deactivate
+                              </Button>
+                            ) : (
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                onClick={handleReactivateUser}
+                                disabled={isPending}
+                              >
+                                Reactivate
+                              </Button>
+                            )}
 
-                  {onboardingResult ? (
-                    <Alert>
-                      <AlertTitle>
-                        {onboardingResult.kind === 'password_invite'
-                          ? 'Password invite ready'
-                          : 'SSO sign-in URL ready'}
-                      </AlertTitle>
-                      <AlertDescription>
-                        {onboardingResult.kind === 'password_invite'
-                          ? `Share this invite before ${onboardingResult.expires_at}.`
-                          : `Share this URL with ${onboardingResult.user.email} so they can finish SSO onboarding.`}
-                      </AlertDescription>
-
-                      <Field className="mt-3">
-                        <FieldLabel htmlFor="reset-onboarding-url">Generated URL</FieldLabel>
-                        <InputGroup>
-                          <InputGroupInput
-                            id="reset-onboarding-url"
-                            readOnly
-                            value={
-                              onboardingResult.kind === 'password_invite'
-                                ? onboardingResult.invite_url
-                                : onboardingResult.sign_in_url
-                            }
-                          />
-                          <InputGroupAddon align="inline-end">
                             <Button
                               type="button"
                               variant="ghost"
-                              size="sm"
-                              onClick={() =>
-                                handleCopy(
-                                  onboardingResult.kind === 'password_invite'
-                                    ? onboardingResult.invite_url
-                                    : onboardingResult.sign_in_url,
-                                  'URL copied',
-                                )
+                              onClick={handleResetUserOnboarding}
+                              disabled={
+                                isPending ||
+                                (selectedUser.status !== 'invited' &&
+                                  selectedUser.status !== 'disabled')
                               }
                             >
-                              Copy
+                              Reset onboarding
                             </Button>
-                          </InputGroupAddon>
-                        </InputGroup>
-                      </Field>
-                    </Alert>
-                  ) : null}
-                </section>
+                          </div>
 
-                <DialogFooter>
-                  <Button type="button" variant="secondary" onClick={resetUserDialog}>
-                    Cancel
-                  </Button>
-                  <Button
-                    type="submit"
-                    disabled={
-                      isPending ||
-                      (updateForm.auth_mode === 'oidc' &&
-                        (oidcProviders.length === 0 || !updateForm.oidc_provider_key))
-                    }
-                  >
-                    {isPending ? 'Saving…' : 'Save changes'}
-                  </Button>
-                </DialogFooter>
-              </form>
-            </div>
+                          {onboardingResult ? (
+                            <Alert>
+                              <AlertTitle>
+                                {onboardingResult.kind === 'password_invite'
+                                  ? 'Password invite ready'
+                                  : 'SSO sign-in URL ready'}
+                              </AlertTitle>
+                              <AlertDescription>
+                                {onboardingResult.kind === 'password_invite'
+                                  ? `Share this invite before ${onboardingResult.expires_at}.`
+                                  : `Share this URL with ${onboardingResult.user.email} so they can finish SSO onboarding.`}
+                              </AlertDescription>
+
+                              <Field className="mt-3">
+                                <FieldLabel htmlFor="reset-onboarding-url">
+                                  Generated URL
+                                </FieldLabel>
+                                <InputGroup>
+                                  <InputGroupInput
+                                    id="reset-onboarding-url"
+                                    readOnly
+                                    value={
+                                      onboardingResult.kind === 'password_invite'
+                                        ? onboardingResult.invite_url
+                                        : onboardingResult.sign_in_url
+                                    }
+                                  />
+                                  <InputGroupAddon align="inline-end">
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() =>
+                                        handleCopy(
+                                          onboardingResult.kind === 'password_invite'
+                                            ? onboardingResult.invite_url
+                                            : onboardingResult.sign_in_url,
+                                          'URL copied',
+                                        )
+                                      }
+                                    >
+                                      Copy
+                                    </Button>
+                                  </InputGroupAddon>
+                                </InputGroup>
+                              </Field>
+                            </Alert>
+                          ) : null}
+                        </section>
+                      </div>
+                    ) : null}
+
+                    {selectedUserSection === 'usage' ? (
+                      <div className="grid gap-4 md:grid-cols-3">
+                        <section className="rounded-lg border border-[color:var(--color-border)] p-4">
+                          <p className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+                            Favourite model
+                          </p>
+                          <p className="mt-2 text-lg font-semibold text-[var(--color-text)]">
+                            Not enough data
+                          </p>
+                          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                            Wire this to model-level usage once the backend exposes per-user
+                            aggregates.
+                          </p>
+                        </section>
+                        <section className="rounded-lg border border-[color:var(--color-border)] p-4">
+                          <p className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+                            Weekly usage
+                          </p>
+                          <p className="mt-2 text-lg font-semibold text-[var(--color-text)]">
+                            Pending
+                          </p>
+                          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                            Planned: spend, tokens, and request counts over the last seven days.
+                          </p>
+                        </section>
+                        <section className="rounded-lg border border-[color:var(--color-border)] p-4">
+                          <p className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+                            Recent activity
+                          </p>
+                          <p className="mt-2 text-lg font-semibold text-[var(--color-text)]">
+                            Pending
+                          </p>
+                          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+                            Planned: latest requests and policy outcomes for this user.
+                          </p>
+                        </section>
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <DialogFooter className="border-t border-[color:var(--color-border)] px-5 py-4">
+                    <Button type="button" variant="secondary" onClick={resetUserDialog}>
+                      Close
+                    </Button>
+                    <Button
+                      type="submit"
+                      disabled={
+                        isPending ||
+                        (updateForm.auth_mode === 'oidc' &&
+                          (oidcProviders.length === 0 || !updateForm.oidc_provider_key))
+                      }
+                    >
+                      {isPending ? 'Saving…' : 'Save changes'}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </main>
+            </SidebarProvider>
           ) : null}
         </DialogContent>
       </Dialog>
     </div>
   )
+}
+
+function UserDetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
+        {label}
+      </dt>
+      <dd className="mt-1 text-[var(--color-text-muted)]">{value}</dd>
+    </div>
+  )
+}
+
+function normalizeUserSearch(search: Record<string, unknown>) {
+  const section = typeof search.user_section === 'string' ? search.user_section : 'overview'
+
+  return {
+    user_id:
+      typeof search.user_id === 'string' && search.user_id.length > 0 ? search.user_id : undefined,
+    user_section: isUserDetailsSection(section) ? section : 'overview',
+  }
+}
+
+function isUserDetailsSection(value: string): value is UserDetailsSection {
+  return userDetailsSections.some((section) => section.id === value)
+}
+
+function formatRole(role: string) {
+  return role
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ')
 }
 
 function sanitizeForm(form: CreateUserInput): CreateUserInput {

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState, useTransition, type CSSProperties, type FormEvent } from 'react'
-import { UserIcon } from '@hugeicons/core-free-icons'
+import {
+  Cancel01Icon,
+  ChartLineData01Icon,
+  Configuration01Icon,
+  ShieldKeyIcon,
+  UserIcon,
+  UserCircleIcon,
+} from '@hugeicons/core-free-icons'
 import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
@@ -10,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -54,7 +62,6 @@ import {
   getUsers,
   reactivateIdentityUser,
   resetIdentityUserOnboarding,
-  resendIdentityUserPasswordInvite,
   updateIdentityUser,
 } from '@/server/admin-data.functions'
 import {
@@ -98,10 +105,10 @@ const initialUpdateForm: UpdateUserInput = {
 }
 
 const userDetailsSections = [
-  { id: 'overview', label: 'Overview' },
-  { id: 'configuration', label: 'Configuration' },
-  { id: 'auth', label: 'Auth & onboarding' },
-  { id: 'usage', label: 'Usage' },
+  { id: 'overview', label: 'Overview', icon: UserCircleIcon },
+  { id: 'configuration', label: 'Configuration', icon: Configuration01Icon },
+  { id: 'auth', label: 'Auth & onboarding', icon: ShieldKeyIcon },
+  { id: 'usage', label: 'Usage', icon: ChartLineData01Icon },
 ] as const
 
 type UserDetailsSection = (typeof userDetailsSections)[number]['id']
@@ -309,61 +316,6 @@ export function UsersPage() {
     } catch {
       toast.error('Clipboard access failed')
     }
-  }
-
-  function handleResend(user: UserView) {
-    startTransition(async () => {
-      try {
-        const response = await resendIdentityUserPasswordInvite({ data: { userId: user.id } })
-        await handleCopy(response.data.invite_url, 'Invite URL copied')
-        await refreshUsers()
-      } catch (error) {
-        toast.error(getErrorMessage(error))
-      }
-    })
-  }
-
-  function renderOnboardingActions(user: UserView) {
-    if (user.onboarding?.kind === 'password_invite') {
-      return (
-        <>
-          {user.onboarding.invite_url ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="secondary"
-              onClick={() => handleCopy(user.onboarding?.invite_url ?? '', 'Invite URL copied')}
-            >
-              Copy invite
-            </Button>
-          ) : null}
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            onClick={() => handleResend(user)}
-            disabled={isPending}
-          >
-            Resend invite
-          </Button>
-        </>
-      )
-    }
-
-    if (user.onboarding?.kind === 'oidc_sign_in') {
-      return (
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          onClick={() => handleCopy(user.onboarding?.sign_in_url ?? '', 'Sign-in URL copied')}
-        >
-          Copy sign-in URL
-        </Button>
-      )
-    }
-
-    return <span className="text-xs text-[var(--color-text-soft)]">No action available</span>
   }
 
   return (
@@ -691,12 +643,6 @@ export function UsersPage() {
                     <dl className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
                       <div>
                         <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
-                          Auth
-                        </dt>
-                        <dd className="text-[var(--color-text-muted)]">{user.auth_mode}</dd>
-                      </div>
-                      <div>
-                        <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
                           Global role
                         </dt>
                         <dd className="text-[var(--color-text-muted)]">{user.global_role}</dd>
@@ -707,20 +653,6 @@ export function UsersPage() {
                         </dt>
                         <dd className="text-[var(--color-text-muted)]">
                           {user.team_name ?? 'No team'}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
-                          Team role
-                        </dt>
-                        <dd className="text-[var(--color-text-muted)]">{user.team_role ?? '—'}</dd>
-                      </div>
-                      <div>
-                        <dt className="text-xs font-semibold tracking-[0.08em] text-[var(--color-text-soft)] uppercase">
-                          Logs
-                        </dt>
-                        <dd className="text-[var(--color-text-muted)]">
-                          {user.request_logging_enabled ? 'Enabled' : 'Disabled'}
                         </dd>
                       </div>
                     </dl>
@@ -734,7 +666,6 @@ export function UsersPage() {
                       >
                         Manage
                       </Button>
-                      {renderOnboardingActions(user)}
                     </div>
                   </article>
                 ))}
@@ -746,13 +677,9 @@ export function UsersPage() {
                     <tr>
                       <th className="px-3 py-2 font-semibold">Name</th>
                       <th className="px-3 py-2 font-semibold">Email</th>
-                      <th className="px-3 py-2 font-semibold">Auth</th>
                       <th className="px-3 py-2 font-semibold">Global role</th>
-                      <th className="px-3 py-2 font-semibold">Logs</th>
                       <th className="px-3 py-2 font-semibold">Team</th>
-                      <th className="px-3 py-2 font-semibold">Team role</th>
                       <th className="px-3 py-2 font-semibold">Status</th>
-                      <th className="px-3 py-2 font-semibold">Onboarding</th>
                       <th className="px-3 py-2 font-semibold">Actions</th>
                     </tr>
                   </thead>
@@ -770,19 +697,10 @@ export function UsersPage() {
                         </td>
                         <td className="px-3 py-3 text-[var(--color-text-muted)]">{user.email}</td>
                         <td className="px-3 py-3 text-[var(--color-text-muted)]">
-                          {user.auth_mode}
-                        </td>
-                        <td className="px-3 py-3 text-[var(--color-text-muted)]">
                           {user.global_role}
                         </td>
                         <td className="px-3 py-3 text-[var(--color-text-muted)]">
-                          {user.request_logging_enabled ? 'Enabled' : 'Disabled'}
-                        </td>
-                        <td className="px-3 py-3 text-[var(--color-text-muted)]">
                           {user.team_name ?? '—'}
-                        </td>
-                        <td className="px-3 py-3 text-[var(--color-text-muted)]">
-                          {user.team_role ?? '—'}
                         </td>
                         <td className="px-3 py-3">
                           <Badge
@@ -796,11 +714,6 @@ export function UsersPage() {
                           >
                             {user.status}
                           </Badge>
-                        </td>
-                        <td className="px-3 py-3">
-                          <div className="flex flex-wrap gap-2">
-                            {renderOnboardingActions(user)}
-                          </div>
                         </td>
                         <td className="px-3 py-3">
                           <Button
@@ -830,7 +743,10 @@ export function UsersPage() {
           }
         }}
       >
-        <DialogContent className="overflow-hidden p-0 md:max-h-[680px] md:max-w-[920px]">
+        <DialogContent
+          showCloseButton={false}
+          className="overflow-hidden p-0 md:max-h-[680px] md:max-w-[920px]"
+        >
           <DialogTitle className="sr-only">Manage user</DialogTitle>
           <DialogDescription className="sr-only">
             Review user status, configuration, auth settings, and usage.
@@ -839,23 +755,25 @@ export function UsersPage() {
           {selectedUser ? (
             <SidebarProvider
               className="min-h-0 items-start"
-              style={{ '--sidebar-width': '13.5rem' } as CSSProperties}
+              style={{ '--sidebar-width': '14rem' } as CSSProperties}
             >
               <Sidebar
                 collapsible="none"
                 className="hidden border-r border-[color:var(--color-border)] md:flex"
               >
-                <SidebarContent>
-                  <SidebarGroup>
+                <SidebarContent className="p-3">
+                  <SidebarGroup className="px-0 py-0">
                     <SidebarGroupContent>
-                      <SidebarMenu>
+                      <SidebarMenu className="gap-1">
                         {userDetailsSections.map((section) => (
                           <SidebarMenuItem key={section.id}>
                             <SidebarMenuButton
                               type="button"
+                              className="h-10 px-3 py-2"
                               isActive={selectedUserSection === section.id}
                               onClick={() => setSelectedUserSection(section.id)}
                             >
+                              <AppIcon icon={section.icon} stroke={1.5} aria-hidden />
                               <span>{section.label}</span>
                             </SidebarMenuButton>
                           </SidebarMenuItem>
@@ -867,36 +785,42 @@ export function UsersPage() {
               </Sidebar>
 
               <main className="flex max-h-[680px] min-h-[520px] flex-1 flex-col overflow-hidden">
-                <header className="flex shrink-0 flex-col gap-3 border-b border-[color:var(--color-border)] px-5 py-4">
-                  <div className="flex items-center gap-3">
+                <header className="flex shrink-0 flex-col gap-4 border-b border-[color:var(--color-border)] px-6 py-5">
+                  <div className="flex items-start gap-3">
                     <GeneratedAvatar
                       kind="user"
                       name={selectedUser.name || selectedUser.email}
                       size={44}
                     />
-                    <div className="min-w-0">
-                      <h2 className="truncate text-lg font-semibold text-[var(--color-text)]">
+                    <div className="min-w-0 flex-1 pt-0.5">
+                      <h2 className="truncate text-lg leading-tight font-semibold text-[var(--color-text)]">
                         {selectedUser.name}
                       </h2>
-                      <p className="truncate text-sm text-[var(--color-text-muted)]">
+                      <p className="mt-1 truncate text-sm text-[var(--color-text-muted)]">
                         {selectedUser.email}
                       </p>
                       <div className="mt-2 flex flex-wrap gap-2">
                         <EntityTagBadges tags={selectedUser.tags} />
                       </div>
                     </div>
-                    <Badge
-                      className="ml-auto"
-                      variant={
-                        selectedUser.status === 'active'
-                          ? 'success'
-                          : selectedUser.status === 'invited'
-                            ? 'warning'
-                            : 'default'
-                      }
-                    >
-                      {selectedUser.status}
-                    </Badge>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Badge
+                        variant={
+                          selectedUser.status === 'active'
+                            ? 'success'
+                            : selectedUser.status === 'invited'
+                              ? 'warning'
+                              : 'default'
+                        }
+                      >
+                        {selectedUser.status}
+                      </Badge>
+                      <DialogClose asChild>
+                        <Button type="button" variant="ghost" size="icon-sm" aria-label="Close">
+                          <AppIcon icon={Cancel01Icon} stroke={1.5} aria-hidden />
+                        </Button>
+                      </DialogClose>
+                    </div>
                   </div>
 
                   <div className="flex gap-2 overflow-x-auto md:hidden">
@@ -908,6 +832,12 @@ export function UsersPage() {
                         variant={selectedUserSection === section.id ? 'secondary' : 'ghost'}
                         onClick={() => setSelectedUserSection(section.id)}
                       >
+                        <AppIcon
+                          icon={section.icon}
+                          stroke={1.5}
+                          aria-hidden
+                          data-icon="inline-start"
+                        />
                         {section.label}
                       </Button>
                     ))}
@@ -915,66 +845,24 @@ export function UsersPage() {
                 </header>
 
                 <form className="flex min-h-0 flex-1 flex-col" onSubmit={handleUpdateUser}>
-                  <div className="flex-1 overflow-y-auto p-5">
+                  <div className="flex-1 overflow-y-auto p-6">
                     {selectedUserSection === 'overview' ? (
-                      <div className="grid gap-4 lg:grid-cols-3">
-                        <section className="rounded-lg border border-[color:var(--color-border)] p-4 lg:col-span-2">
-                          <h3 className="text-sm font-semibold text-[var(--color-text)]">
-                            Profile
-                          </h3>
-                          <dl className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
-                            <UserDetailRow
-                              label="Global role"
-                              value={formatRole(selectedUser.global_role)}
-                            />
-                            <UserDetailRow
-                              label="Team"
-                              value={selectedUser.team_name ?? 'No team'}
-                            />
-                            <UserDetailRow
-                              label="Team role"
-                              value={selectedUser.team_role ?? '—'}
-                            />
-                            <UserDetailRow label="Auth method" value={selectedUser.auth_mode} />
-                            <UserDetailRow
-                              label="Request logging"
-                              value={selectedUser.request_logging_enabled ? 'Enabled' : 'Disabled'}
-                            />
-                            <UserDetailRow label="Status" value={selectedUser.status} />
-                          </dl>
-                        </section>
-
-                        <section className="rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4">
-                          <h3 className="text-sm font-semibold text-[var(--color-text)]">
-                            Next actions
-                          </h3>
-                          <div className="mt-3 flex flex-col gap-2">
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="secondary"
-                              onClick={() => setSelectedUserSection('configuration')}
-                            >
-                              Edit configuration
-                            </Button>
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => setSelectedUserSection('auth')}
-                            >
-                              Manage auth
-                            </Button>
-                            <Button
-                              type="button"
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => setSelectedUserSection('usage')}
-                            >
-                              View usage
-                            </Button>
-                          </div>
-                        </section>
+                      <div>
+                        <h3 className="text-sm font-semibold text-[var(--color-text)]">Profile</h3>
+                        <dl className="mt-5 grid gap-x-8 gap-y-6 text-sm sm:grid-cols-2 lg:grid-cols-3">
+                          <UserDetailRow
+                            label="Global role"
+                            value={formatRole(selectedUser.global_role)}
+                          />
+                          <UserDetailRow label="Team" value={selectedUser.team_name ?? 'No team'} />
+                          <UserDetailRow label="Team role" value={selectedUser.team_role ?? '—'} />
+                          <UserDetailRow label="Auth method" value={selectedUser.auth_mode} />
+                          <UserDetailRow
+                            label="Request logging"
+                            value={selectedUser.request_logging_enabled ? 'Enabled' : 'Disabled'}
+                          />
+                          <UserDetailRow label="Status" value={selectedUser.status} />
+                        </dl>
                       </div>
                     ) : null}
 
@@ -1295,7 +1183,7 @@ export function UsersPage() {
                     ) : null}
                   </div>
 
-                  <DialogFooter className="border-t border-[color:var(--color-border)] px-5 py-4">
+                  <DialogFooter className="mx-0 mb-0 rounded-none border-t border-[color:var(--color-border)] px-6 py-4">
                     <Button type="button" variant="secondary" onClick={resetUserDialog}>
                       Close
                     </Button>

--- a/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
@@ -61,7 +61,7 @@ describe('TeamsPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('shows member roster actions and blocks owner transfers', async () => {
+  it('keeps member rosters collapsed until a team is expanded', async () => {
     routeMock.useLoaderData.mockReturnValue({
       data: {
         teams: [
@@ -103,6 +103,20 @@ describe('TeamsPage', () => {
     render(<TeamsPage />)
 
     expect(screen.getAllByText('Jane Admin').length).toBeGreaterThan(0)
+    expect(
+      screen.queryByText('Owner memberships cannot be removed or transferred in this slice.'),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Transfer' })).not.toBeInTheDocument()
+
+    const showMembersButtons = screen.getAllByRole('button', { name: 'Show 1 member' })
+    expect(showMembersButtons[0]).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(showMembersButtons[0])
+
+    expect(screen.getAllByRole('button', { name: 'Hide 1 member' })[0]).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
     expect(
       screen.getAllByText('Owner memberships cannot be removed or transferred in this slice.')
         .length,

--- a/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
@@ -110,13 +110,13 @@ describe('TeamsPage', () => {
 
     const showMembersButtons = screen.getAllByRole('button', { name: 'Show 1 member' })
     expect(showMembersButtons[0]).toHaveAttribute('aria-expanded', 'false')
+    expect(showMembersButtons[0].querySelector('[data-icon="inline-start"]')).toBeInTheDocument()
 
     fireEvent.click(showMembersButtons[0])
 
-    expect(screen.getAllByRole('button', { name: 'Hide 1 member' })[0]).toHaveAttribute(
-      'aria-expanded',
-      'true',
-    )
+    const hideMembersButton = screen.getAllByRole('button', { name: 'Hide 1 member' })[0]
+    expect(hideMembersButton).toHaveAttribute('aria-expanded', 'true')
+    expect(hideMembersButton.querySelector('[data-icon="inline-start"]')).toBeInTheDocument()
     expect(
       screen.getAllByText('Owner memberships cannot be removed or transferred in this slice.')
         .length,

--- a/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
@@ -1,3 +1,4 @@
+import type * as React from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -13,6 +14,16 @@ const routerMock = {
 
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => () => routeMock,
+  Link: ({
+    children,
+    search: _search,
+    to,
+    ...props
+  }: React.ComponentProps<'a'> & { search?: unknown; to?: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
   useRouter: () => routerMock,
 }))
 
@@ -102,6 +113,7 @@ describe('TeamsPage', () => {
 
     render(<TeamsPage />)
 
+    expect(screen.getAllByLabelText('Team avatar for Core Platform').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Jane Admin').length).toBeGreaterThan(0)
     expect(
       screen.queryByText('Owner memberships cannot be removed or transferred in this slice.'),
@@ -121,6 +133,7 @@ describe('TeamsPage', () => {
       screen.getAllByText('Owner memberships cannot be removed or transferred in this slice.')
         .length,
     ).toBeGreaterThan(0)
+    expect(screen.getAllByLabelText('User avatar for Jane Admin').length).toBeGreaterThan(0)
     expect(screen.getAllByRole('button', { name: 'Transfer' })[0]).toBeDisabled()
     expect(screen.getAllByRole('button', { name: 'Remove' })[0]).toBeDisabled()
   })

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -5,6 +5,7 @@ import type { IdentityUsersPayload } from '@/types/api'
 
 const routeMock = {
   useLoaderData: vi.fn(),
+  useSearch: vi.fn(),
 }
 
 const routerMock = {
@@ -45,6 +46,7 @@ const basePayload: IdentityUsersPayload = {
 describe('UsersPage', () => {
   beforeEach(() => {
     routeMock.useLoaderData.mockReset()
+    routeMock.useSearch.mockReturnValue({ user_id: undefined, user_section: 'overview' })
     routerMock.invalidate.mockClear()
     createIdentityUserMock.mockReset()
     resendInviteMock.mockReset()
@@ -137,19 +139,21 @@ describe('UsersPage', () => {
       } satisfies IdentityUsersPayload,
     })
 
+    routeMock.useSearch.mockReturnValue({ user_id: 'user_1', user_section: 'configuration' })
+
     const { UsersPage } = await import('@/routes/identity/users')
 
-    render(<UsersPage />)
+    const { rerender } = render(<UsersPage />)
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Manage' })[0])
-
+    expect(screen.getAllByLabelText('User avatar for Jane Admin').length).toBeGreaterThan(0)
     expect(screen.getByText('Owner membership is locked')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'Auth mode is locked after activation; use reset onboarding to reissue credentials.',
-      ),
-    ).toBeInTheDocument()
+
+    routeMock.useSearch.mockReturnValue({ user_id: 'user_1', user_section: 'auth' })
+    rerender(<UsersPage />)
+
+    expect(screen.getByText('Auth mode is locked after activation')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Reset onboarding' })).toBeDisabled()
-    expect(screen.getAllByLabelText('Auth method')[1]).toBeDisabled()
+    const authMethodControls = screen.getAllByLabelText('Auth method')
+    expect(authMethodControls[authMethodControls.length - 1]).toBeDisabled()
   })
 })


### PR DESCRIPTION
## Description

Adds identity admin UI improvements for users and teams.

- Adds deterministic generated avatars for users and teams using `boring-avatars`.
- Makes team admin references clickable so they open the referenced user in the users route.
- Reworks user management into a route-addressable sidebar-in-dialog detail view with Overview, Configuration, Auth & onboarding, and Usage sections.
- Polishes the user detail dialog with icon navigation, improved header/close alignment, unclipped footer actions, and a simpler unwrapped Overview page.
- Simplifies the users table by keeping Auth, Team role, Logs, and Onboarding details in the dialog rather than duplicating them in the table.

This keeps the existing users page as the primary surface while making entity references shareable through URL search params and leaving room for richer future user detail sections such as favourite model and weekly usage.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation:

- [x] `bun run fmt`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build` completed with an existing Node/Vite version warning
