### PR TITLE
feat(gateway): track additional agent harness user agents

### DIFF
--- a/crates/gateway-service/src/request_logging.rs
+++ b/crates/gateway-service/src/request_logging.rs
@@ -948,7 +948,25 @@ pub fn classify_agent_harness(user_agent: Option<&str>) -> AgentHarness {
             label: "Opencode",
         };
     }
-    if looks_like_pi_user_agent(user_agent, &lower) {
+    if lower.starts_with("claude-cli/") {
+        return AgentHarness {
+            key: "claude_cli",
+            label: "Claude CLI",
+        };
+    }
+    if lower.starts_with("dspy/") {
+        return AgentHarness {
+            key: "dspy",
+            label: "DSPy",
+        };
+    }
+    if lower.starts_with("curl/") {
+        return AgentHarness {
+            key: "curl",
+            label: "curl",
+        };
+    }
+    if lower.starts_with("pi/") {
         return AgentHarness {
             key: "pi",
             label: "Pi",
@@ -982,13 +1000,6 @@ pub fn classify_agent_harness(user_agent: Option<&str>) -> AgentHarness {
     }
 
     AgentHarness::UNKNOWN
-}
-
-fn looks_like_pi_user_agent(user_agent: &str, lower: &str) -> bool {
-    lower.starts_with("pi/")
-        && user_agent.contains(" (")
-        && user_agent.ends_with(')')
-        && (lower.contains("; bun/") || lower.contains("; node/"))
 }
 
 #[must_use]
@@ -1235,14 +1246,32 @@ mod tests {
         let cases = [
             ("opencode/1.2.3", "opencode", "Opencode"),
             ("opencode/1.2.3-beta.1", "opencode", "Opencode"),
+            (
+                "opencode/1.16.0 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14",
+                "opencode",
+                "Opencode",
+            ),
             ("pi/0.4.0 (darwin; bun/1.2.19; arm64)", "pi", "Pi"),
             ("pi/0.4.0 (linux; node/v22.14.0; x64)", "pi", "Pi"),
+            ("pi/0.4.0", "pi", "Pi"),
             ("claude-code/2.1.89 (cli)", "claude_code", "Claude Code"),
+            (
+                "claude-cli/2.1.170 (external, claude-vscode, agent-sdk/0.3.165)",
+                "claude_cli",
+                "Claude CLI",
+            ),
+            (
+                "claude-cli/2.1.158 (external, cli)",
+                "claude_cli",
+                "Claude CLI",
+            ),
             (
                 "Claude-User (claude-code/2.1.83; +https://support.anthropic.com/)",
                 "claude_code",
                 "Claude Code",
             ),
+            ("DSPy/3.2.1", "dspy", "DSPy"),
+            ("curl/8.7.1", "curl", "curl"),
             (
                 "GeminiCLI/0.37.0/gemini-pro (linux; x64; terminal)",
                 "gemini_cli",


### PR DESCRIPTION
## Description

Track additional self-identifying User-Agent patterns in Agent Harness classification.

- Adds `claude-cli/<version>` as `claude_cli` / `Claude CLI`
- Adds `DSPy/<version>` as `dspy` / `DSPy`
- Adds `curl/<version>` as `curl` / `curl`
- Treats bare `pi/<version>` as `pi` / `Pi`
- Keeps richer `opencode/<version> ...` headers classified as Opencode
- Adds regression coverage for the reported user-agent examples

This closes #173. The classifier now uses direct prefix checks for these explicit client identifiers, which matches the existing style used for Opencode and Claude Code patterns. The main tradeoff is that `curl` traffic is intentionally surfaced as its own harness bucket rather than remaining unknown.

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Validation performed for this Rust-only change:

- `cargo test -p gateway-service request_logging::tests::classifies_known_agent_harness_user_agents`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `mise run fmt`