### PR TITLE
feat(admin-ui): add Claude Code client config snippets

### DIFF
--- a/crates/admin-ui/web/src/generated/admin-api.ts
+++ b/crates/admin-ui/web/src/generated/admin-api.ts
@@ -830,9 +830,13 @@ export interface components {
             team_name?: string | null;
             team_role?: string | null;
         };
-        AdminModelClientConfigView: {
+        AdminModelClientConfigBlockView: {
             content: string;
             filename: string;
+            label: string;
+        };
+        AdminModelClientConfigView: {
+            blocks: components["schemas"]["AdminModelClientConfigBlockView"][];
             key: string;
             label: string;
             notes: string[];

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -106,7 +106,9 @@ export function ModelsPage() {
   }
 
   const activeClientConfig =
-    configDialog?.model.client_configurations.find((config) => config.key === configDialog.activeKey) ??
+    configDialog?.model.client_configurations.find(
+      (config) => config.key === configDialog.activeKey,
+    ) ??
     configDialog?.model.client_configurations[0] ??
     null
 
@@ -456,24 +458,36 @@ function ClientConfigDialog({
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => onCopy(activeConfig.content)}
-              >
-                Copy JSON
-              </Button>
             </div>
 
-            <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-sm">
-              <Badge variant="secondary">{activeConfig.filename}</Badge>
-              <span>{model.upstream_model ?? model.resolved_model_key}</span>
-            </div>
+            <div className="flex min-w-0 flex-col gap-4">
+              {activeConfig.blocks.map((block) => (
+                <div
+                  key={`${block.label}:${block.filename}`}
+                  className="flex min-w-0 flex-col gap-3"
+                >
+                  <div className="text-muted-foreground flex flex-wrap items-center justify-between gap-3 text-sm">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <Badge variant="secondary">{block.filename}</Badge>
+                      {block.label !== block.filename ? <span>{block.label}</span> : null}
+                      <span>{model.upstream_model ?? model.resolved_model_key}</span>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onCopy(block.content)}
+                    >
+                      Copy JSON
+                    </Button>
+                  </div>
 
-            <pre className="bg-muted text-muted-foreground max-h-[min(55vh,520px)] min-h-[320px] overflow-auto rounded-md border p-4 text-xs leading-6">
-              <code>{activeConfig.content}</code>
-            </pre>
+                  <pre className="bg-muted text-muted-foreground max-h-[min(42vh,420px)] min-h-[220px] overflow-auto rounded-md border p-4 text-xs leading-6">
+                    <code>{block.content}</code>
+                  </pre>
+                </div>
+              ))}
+            </div>
 
             {activeConfig.notes.length > 0 ? (
               <div className="text-muted-foreground flex flex-col gap-2 text-sm">
@@ -518,7 +532,9 @@ function MetricDetail({
 
 function ModelStatusIndicator({ status }: { status: string }) {
   const tone =
-    status === 'healthy' ? 'bg-emerald-500 shadow-emerald-500/30' : 'bg-amber-400 shadow-amber-400/30'
+    status === 'healthy'
+      ? 'bg-emerald-500 shadow-emerald-500/30'
+      : 'bg-amber-400 shadow-amber-400/30'
 
   return (
     <Tooltip>

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -78,16 +78,45 @@ const modelPage: ModelPageView = {
         {
           key: 'opencode',
           label: 'OpenCode',
-          filename: 'opencode.json',
-          content: '{\n  "provider": "opencode"\n}',
+          blocks: [
+            {
+              label: 'opencode.json',
+              filename: 'opencode.json',
+              content: '{\n  "provider": "opencode"\n}',
+            },
+          ],
           notes: [],
         },
         {
           key: 'pi',
           label: 'Pi',
-          filename: 'models.json',
-          content: '{\n  "provider": "pi"\n}',
+          blocks: [
+            {
+              label: 'models.json',
+              filename: 'models.json',
+              content: '{\n  "provider": "pi"\n}',
+            },
+          ],
           notes: ['Manual note'],
+        },
+        {
+          key: 'claude-code',
+          label: 'Claude Code',
+          blocks: [
+            {
+              label: 'Gateway model settings',
+              filename: 'settings.json',
+              content:
+                '{\n  "$schema": "https://json.schemastore.org/claude-code-settings.json",\n  "env": {\n    "ANTHROPIC_MODEL": "claude-sonnet"\n  }\n}',
+            },
+            {
+              label: 'Lower token usage settings',
+              filename: 'settings.json',
+              content:
+                '{\n  "$schema": "https://json.schemastore.org/claude-code-settings.json",\n  "env": {\n    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000"\n  }\n}',
+            },
+          ],
+          notes: [],
         },
       ],
     },
@@ -184,7 +213,9 @@ describe('ModelsPage', () => {
     expect(backupRow).not.toBeNull()
     const backupCells = within(backupRow as HTMLElement).getAllByRole('cell')
 
-    expect(within(backupCells[1] as HTMLElement).getByText('google/gemini-2.0-flash')).toBeInTheDocument()
+    expect(
+      within(backupCells[1] as HTMLElement).getByText('google/gemini-2.0-flash'),
+    ).toBeInTheDocument()
     expect(within(backupCells[2] as HTMLElement).getByText('Google Vertex AI')).toBeInTheDocument()
     expect(within(backupCells[2] as HTMLElement).getByText('vertex-gemini')).toBeInTheDocument()
     expect(within(backupCells[3] as HTMLElement).getByText('Input')).toBeInTheDocument()
@@ -232,7 +263,9 @@ describe('ModelsPage', () => {
     const claudeRow = within(table).getByText('claude-sonnet').closest('tr')
     expect(claudeRow).not.toBeNull()
 
-    fireEvent.click(within(claudeRow as HTMLElement).getByRole('button', { name: /Client config/i }))
+    fireEvent.click(
+      within(claudeRow as HTMLElement).getByRole('button', { name: /Client config/i }),
+    )
     expect(screen.getByRole('dialog', { name: 'Client config' })).toBeInTheDocument()
     expect(screen.getByText('opencode.json')).toBeInTheDocument()
     expect(screen.getByText(/"provider": "opencode"/)).toBeInTheDocument()
@@ -243,5 +276,18 @@ describe('ModelsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy JSON' }))
     expect(writeText).toHaveBeenCalledWith('{\n  "provider": "pi"\n}')
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Claude Code' }))
+    expect(screen.getAllByText('settings.json')).toHaveLength(2)
+    expect(screen.getByText('Gateway model settings')).toBeInTheDocument()
+    expect(screen.getByText('Lower token usage settings')).toBeInTheDocument()
+    expect(screen.getByText(/"ANTHROPIC_MODEL": "claude-sonnet"/)).toBeInTheDocument()
+    expect(screen.getByText(/"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000"/)).toBeInTheDocument()
+
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy JSON' })
+    fireEvent.click(copyButtons[1] as HTMLElement)
+    expect(writeText).toHaveBeenLastCalledWith(
+      '{\n  "$schema": "https://json.schemastore.org/claude-code-settings.json",\n  "env": {\n    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000"\n  }\n}',
+    )
   })
 })

--- a/crates/gateway-client-config/src/lib.rs
+++ b/crates/gateway-client-config/src/lib.rs
@@ -87,9 +87,15 @@ impl Default for ClientConfigInput {
 pub struct ClientConfig {
     pub key: String,
     pub label: String,
+    pub blocks: Vec<ClientConfigCodeBlock>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientConfigCodeBlock {
+    pub label: String,
     pub filename: String,
     pub content: String,
-    pub notes: Vec<String>,
 }
 
 pub trait ClientConfigTemplate {
@@ -101,6 +107,9 @@ pub struct OpenCodeConfigTemplate;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PiConfigTemplate;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ClaudeCodeConfigTemplate;
 
 impl ClientConfigTemplate for OpenCodeConfigTemplate {
     fn render(&self, input: &ClientConfigInput) -> ClientConfig {
@@ -162,8 +171,11 @@ impl ClientConfigTemplate for OpenCodeConfigTemplate {
         ClientConfig {
             key: "opencode".to_string(),
             label: "OpenCode".to_string(),
-            filename: "opencode.json".to_string(),
-            content: to_pretty_json(&config),
+            blocks: vec![ClientConfigCodeBlock {
+                label: "opencode.json".to_string(),
+                filename: "opencode.json".to_string(),
+                content: to_pretty_json(&config),
+            }],
             notes: thinking_notes(input),
         }
     }
@@ -218,8 +230,67 @@ impl ClientConfigTemplate for PiConfigTemplate {
         ClientConfig {
             key: "pi".to_string(),
             label: "Pi".to_string(),
-            filename: "models.json".to_string(),
-            content: to_pretty_json(&config),
+            blocks: vec![ClientConfigCodeBlock {
+                label: "models.json".to_string(),
+                filename: "models.json".to_string(),
+                content: to_pretty_json(&config),
+            }],
+            notes: thinking_notes(input),
+        }
+    }
+}
+
+impl ClientConfigTemplate for ClaudeCodeConfigTemplate {
+    fn render(&self, input: &ClientConfigInput) -> ClientConfig {
+        let model_override_key = claude_code_model_override_key(input);
+        let default_model_env_var = claude_code_default_model_env_var(input);
+        let mut env = Map::from_iter([
+            (
+                "ANTHROPIC_AUTH_TOKEN".to_string(),
+                json!(format!("<{}>", input.api_key_env_var)),
+            ),
+            (
+                "ANTHROPIC_BASE_URL".to_string(),
+                json!(input.gateway_base_url),
+            ),
+            (
+                "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(),
+                json!("1"),
+            ),
+            ("ANTHROPIC_MODEL".to_string(), json!(input.model_id)),
+            (
+                "ANTHROPIC_SMALL_FAST_MODEL".to_string(),
+                json!(input.model_id),
+            ),
+        ]);
+
+        if let Some(env_var) = default_model_env_var {
+            env.insert(env_var.to_string(), json!(input.model_id));
+        }
+
+        let config = json!({
+            "$schema": "https://json.schemastore.org/claude-code-settings.json",
+            "env": Value::Object(env),
+            "modelOverrides": {
+                model_override_key.as_str(): input.model_id.as_str(),
+            },
+        });
+
+        ClientConfig {
+            key: "claude-code".to_string(),
+            label: "Claude Code".to_string(),
+            blocks: vec![
+                ClientConfigCodeBlock {
+                    label: "Gateway model settings".to_string(),
+                    filename: "settings.json".to_string(),
+                    content: to_pretty_json(&config),
+                },
+                ClientConfigCodeBlock {
+                    label: "Lower token usage settings".to_string(),
+                    filename: "settings.json".to_string(),
+                    content: to_pretty_json(&claude_code_minimal_experience_config()),
+                },
+            ],
             notes: thinking_notes(input),
         }
     }
@@ -230,6 +301,7 @@ pub fn render_default_configs(input: &ClientConfigInput) -> Vec<ClientConfig> {
     vec![
         OpenCodeConfigTemplate.render(input),
         PiConfigTemplate.render(input),
+        ClaudeCodeConfigTemplate.render(input),
     ]
 }
 
@@ -315,6 +387,71 @@ fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
     }
 }
 
+fn claude_code_model_override_key(input: &ClientConfigInput) -> String {
+    input
+        .upstream_model
+        .as_deref()
+        .and_then(canonical_claude_code_model_id)
+        .or_else(|| canonical_claude_code_model_id(&input.model_id))
+        .unwrap_or_else(|| input.model_id.clone())
+}
+
+fn canonical_claude_code_model_id(value: &str) -> Option<String> {
+    let model = value
+        .rsplit('/')
+        .next()
+        .unwrap_or(value)
+        .split('@')
+        .next()
+        .unwrap_or(value)
+        .trim()
+        .to_ascii_lowercase()
+        .replace('.', "-");
+
+    if model.starts_with("claude-") {
+        Some(model)
+    } else {
+        None
+    }
+}
+
+fn claude_code_default_model_env_var(input: &ClientConfigInput) -> Option<&'static str> {
+    let joined = [
+        input.model_id.as_str(),
+        input.upstream_model.as_deref().unwrap_or_default(),
+    ]
+    .join(" ")
+    .to_ascii_lowercase();
+
+    if joined.contains("opus") {
+        Some("ANTHROPIC_DEFAULT_OPUS_MODEL")
+    } else if joined.contains("sonnet") {
+        Some("ANTHROPIC_DEFAULT_SONNET_MODEL")
+    } else if joined.contains("haiku") {
+        Some("ANTHROPIC_DEFAULT_HAIKU_MODEL")
+    } else {
+        None
+    }
+}
+
+fn claude_code_minimal_experience_config() -> Value {
+    json!({
+        "$schema": "https://json.schemastore.org/claude-code-settings.json",
+        "env": {
+            "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+            "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+            "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
+            "ENABLE_TOOL_SEARCH": "auto",
+            "CLAUDE_CODE_NO_FLICKER": "1",
+            "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
+            "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+            "DISABLE_ERROR_REPORTING": "1",
+            "DISABLE_TELEMETRY": "1"
+        }
+    })
+}
+
 fn to_pretty_json(value: &Value) -> String {
     serde_json::to_string_pretty(value).expect("client config JSON should serialize")
 }
@@ -324,14 +461,16 @@ mod tests {
     use serde_json::Value;
 
     use super::{
-        AnthropicThinkingPolicy, ClientConfigInput, ClientConfigTemplate, ClientModelCapabilities,
-        OpenCodeConfigTemplate, PiConfigTemplate, infer_anthropic_thinking_policy,
+        AnthropicThinkingPolicy, ClaudeCodeConfigTemplate, ClientConfigInput, ClientConfigTemplate,
+        ClientModelCapabilities, OpenCodeConfigTemplate, PiConfigTemplate,
+        infer_anthropic_thinking_policy,
     };
 
     fn input(policy: Option<AnthropicThinkingPolicy>) -> ClientConfigInput {
         ClientConfigInput {
             model_id: "claude-sonnet".to_string(),
             display_name: "Claude Sonnet".to_string(),
+            upstream_model: Some("anthropic/claude-sonnet-4-6".to_string()),
             input_cost_per_million_tokens_usd_10000: Some(30_000),
             output_cost_per_million_tokens_usd_10000: Some(150_000),
             cache_read_cost_per_million_tokens_usd_10000: Some(3_000),
@@ -351,7 +490,7 @@ mod tests {
     fn opencode_shape_includes_required_cost_and_limits() {
         let rendered =
             OpenCodeConfigTemplate.render(&input(Some(AnthropicThinkingPolicy::SafeEffort)));
-        let value: Value = serde_json::from_str(&rendered.content).expect("json");
+        let value: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
         let model = &value["provider"]["oceans-llm"]["models"]["claude-sonnet"];
 
         assert_eq!(value["$schema"], "https://opencode.ai/config.json");
@@ -365,7 +504,7 @@ mod tests {
     #[test]
     fn pi_shape_includes_provider_model_cost_and_windows() {
         let rendered = PiConfigTemplate.render(&input(Some(AnthropicThinkingPolicy::SafeEffort)));
-        let value: Value = serde_json::from_str(&rendered.content).expect("json");
+        let value: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
         let provider = &value["providers"]["oceans-llm"];
         let model = &provider["models"][0];
 
@@ -383,9 +522,10 @@ mod tests {
         input.cache_read_cost_per_million_tokens_usd_10000 = None;
 
         let opencode: Value =
-            serde_json::from_str(&OpenCodeConfigTemplate.render(&input).content).expect("json");
+            serde_json::from_str(&OpenCodeConfigTemplate.render(&input).blocks[0].content)
+                .expect("json");
         let pi: Value =
-            serde_json::from_str(&PiConfigTemplate.render(&input).content).expect("json");
+            serde_json::from_str(&PiConfigTemplate.render(&input).blocks[0].content).expect("json");
 
         assert!(
             opencode["provider"]["oceans-llm"]["models"]["claude-sonnet"]["cost"]
@@ -405,9 +545,10 @@ mod tests {
             infer_anthropic_thinking_policy(["anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6"]);
         let input = input(policy);
         let opencode: Value =
-            serde_json::from_str(&OpenCodeConfigTemplate.render(&input).content).expect("json");
+            serde_json::from_str(&OpenCodeConfigTemplate.render(&input).blocks[0].content)
+                .expect("json");
         let pi: Value =
-            serde_json::from_str(&PiConfigTemplate.render(&input).content).expect("json");
+            serde_json::from_str(&PiConfigTemplate.render(&input).blocks[0].content).expect("json");
 
         assert_eq!(
             opencode["provider"]["oceans-llm"]["models"]["claude-sonnet"]["variants"]["high"]["reasoningEffort"],
@@ -423,7 +564,7 @@ mod tests {
     fn opencode_safe_effort_config_matches_expected_full_shape() {
         let rendered =
             OpenCodeConfigTemplate.render(&input(Some(AnthropicThinkingPolicy::SafeEffort)));
-        let value: Value = serde_json::from_str(&rendered.content).expect("json");
+        let value: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
 
         assert_eq!(
             value,
@@ -472,7 +613,7 @@ mod tests {
     #[test]
     fn pi_safe_effort_config_matches_expected_full_shape() {
         let rendered = PiConfigTemplate.render(&input(Some(AnthropicThinkingPolicy::SafeEffort)));
-        let value: Value = serde_json::from_str(&rendered.content).expect("json");
+        let value: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
 
         assert_eq!(
             value,
@@ -522,7 +663,7 @@ mod tests {
         let policy = infer_anthropic_thinking_policy(["anthropic/claude-sonnet-4-5@20250929"]);
         let input = input(policy);
         let rendered = OpenCodeConfigTemplate.render(&input);
-        let value: Value = serde_json::from_str(&rendered.content).expect("json");
+        let value: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
 
         assert_eq!(policy, Some(AnthropicThinkingPolicy::ManualBudget));
         assert!(
@@ -531,5 +672,36 @@ mod tests {
                 .is_none()
         );
         assert!(!rendered.notes.is_empty());
+    }
+
+    #[test]
+    fn claude_code_shape_includes_gateway_env_and_model_override() {
+        let rendered =
+            ClaudeCodeConfigTemplate.render(&input(Some(AnthropicThinkingPolicy::SafeEffort)));
+        let gateway_settings: Value =
+            serde_json::from_str(&rendered.blocks[0].content).expect("json");
+        let lower_usage_settings: Value =
+            serde_json::from_str(&rendered.blocks[1].content).expect("json");
+
+        assert_eq!(rendered.key, "claude-code");
+        assert_eq!(rendered.blocks.len(), 2);
+        assert_eq!(
+            gateway_settings["$schema"],
+            "https://json.schemastore.org/claude-code-settings.json"
+        );
+        assert_eq!(gateway_settings["env"]["ANTHROPIC_MODEL"], "claude-sonnet");
+        assert_eq!(
+            gateway_settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"],
+            "claude-sonnet"
+        );
+        assert_eq!(
+            gateway_settings["modelOverrides"]["claude-sonnet-4-6"],
+            "claude-sonnet"
+        );
+        assert_eq!(
+            lower_usage_settings["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
+            "200000"
+        );
+        assert_eq!(lower_usage_settings["env"]["ENABLE_TOOL_SEARCH"], "auto");
     }
 }

--- a/crates/gateway-client-config/src/lib.rs
+++ b/crates/gateway-client-config/src/lib.rs
@@ -4,6 +4,20 @@ use serde_json::{Map, Value, json};
 pub const DEFAULT_GATEWAY_BASE_URL: &str = "http://127.0.0.1:3000/v1";
 pub const DEFAULT_API_KEY_ENV_VAR: &str = "OCEANS_LLM_API_KEY";
 pub const DEFAULT_PROVIDER_ID: &str = "oceans-llm";
+const CLAUDE_CODE_SETTINGS_SCHEMA: &str = "https://json.schemastore.org/claude-code-settings.json";
+const CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER: &str = "<gateway api token>";
+const CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV: [(&str, &str); 10] = [
+    ("CLAUDE_CODE_ENABLE_TELEMETRY", "0"),
+    ("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "1"),
+    ("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1"),
+    ("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "200000"),
+    ("ENABLE_TOOL_SEARCH", "auto"),
+    ("CLAUDE_CODE_NO_FLICKER", "1"),
+    ("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1"),
+    ("CLAUDE_CODE_ATTRIBUTION_HEADER", "0"),
+    ("DISABLE_ERROR_REPORTING", "1"),
+    ("DISABLE_TELEMETRY", "1"),
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -242,39 +256,7 @@ impl ClientConfigTemplate for PiConfigTemplate {
 
 impl ClientConfigTemplate for ClaudeCodeConfigTemplate {
     fn render(&self, input: &ClientConfigInput) -> ClientConfig {
-        let model_override_key = claude_code_model_override_key(input);
-        let default_model_env_var = claude_code_default_model_env_var(input);
-        let mut env = Map::from_iter([
-            (
-                "ANTHROPIC_AUTH_TOKEN".to_string(),
-                json!(format!("<{}>", input.api_key_env_var)),
-            ),
-            (
-                "ANTHROPIC_BASE_URL".to_string(),
-                json!(input.gateway_base_url),
-            ),
-            (
-                "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(),
-                json!("1"),
-            ),
-            ("ANTHROPIC_MODEL".to_string(), json!(input.model_id)),
-            (
-                "ANTHROPIC_SMALL_FAST_MODEL".to_string(),
-                json!(input.model_id),
-            ),
-        ]);
-
-        if let Some(env_var) = default_model_env_var {
-            env.insert(env_var.to_string(), json!(input.model_id));
-        }
-
-        let config = json!({
-            "$schema": "https://json.schemastore.org/claude-code-settings.json",
-            "env": Value::Object(env),
-            "modelOverrides": {
-                model_override_key.as_str(): input.model_id.as_str(),
-            },
-        });
+        let config = claude_code_gateway_model_config(input);
 
         ClientConfig {
             key: "claude-code".to_string(),
@@ -291,7 +273,7 @@ impl ClientConfigTemplate for ClaudeCodeConfigTemplate {
                     content: to_pretty_json(&claude_code_minimal_experience_config()),
                 },
             ],
-            notes: thinking_notes(input),
+            notes: claude_code_notes(input),
         }
     }
 }
@@ -387,6 +369,66 @@ fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
     }
 }
 
+fn claude_code_notes(input: &ClientConfigInput) -> Vec<String> {
+    let mut notes = thinking_notes(input);
+    notes.push(format!(
+        "Replace {CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER} with a gateway API key before using Claude Code settings."
+    ));
+    notes.push(format!(
+        "ANTHROPIC_BASE_URL is set to the Claude-compatible gateway base URL; Claude Code appends Anthropic endpoints such as /v1/messages and /v1/models. Keep the OpenAI-compatible base URL ({}) for OpenCode and Pi.",
+        input.gateway_base_url
+    ));
+    notes
+}
+
+fn claude_code_gateway_model_config(input: &ClientConfigInput) -> Value {
+    let model_override_key = claude_code_model_override_key(input);
+    json!({
+        "$schema": CLAUDE_CODE_SETTINGS_SCHEMA,
+        "env": Value::Object(claude_code_gateway_env(input)),
+        "modelOverrides": {
+            model_override_key.as_str(): input.model_id.as_str(),
+        },
+    })
+}
+
+fn claude_code_gateway_env(input: &ClientConfigInput) -> Map<String, Value> {
+    let mut env = Map::from_iter([
+        (
+            "ANTHROPIC_AUTH_TOKEN".to_string(),
+            json!(CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER),
+        ),
+        (
+            "ANTHROPIC_BASE_URL".to_string(),
+            json!(claude_code_gateway_base_url(input)),
+        ),
+        (
+            "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(),
+            json!("1"),
+        ),
+        ("ANTHROPIC_MODEL".to_string(), json!(input.model_id)),
+        (
+            "ANTHROPIC_SMALL_FAST_MODEL".to_string(),
+            json!(input.model_id),
+        ),
+    ]);
+
+    if let Some(env_var) = claude_code_default_model_env_var(input) {
+        env.insert(env_var.to_string(), json!(input.model_id));
+    }
+
+    env
+}
+
+fn claude_code_gateway_base_url(input: &ClientConfigInput) -> String {
+    input
+        .gateway_base_url
+        .trim_end_matches('/')
+        .strip_suffix("/v1")
+        .unwrap_or_else(|| input.gateway_base_url.trim_end_matches('/'))
+        .to_string()
+}
+
 fn claude_code_model_override_key(input: &ClientConfigInput) -> String {
     input
         .upstream_model
@@ -436,20 +478,18 @@ fn claude_code_default_model_env_var(input: &ClientConfigInput) -> Option<&'stat
 
 fn claude_code_minimal_experience_config() -> Value {
     json!({
-        "$schema": "https://json.schemastore.org/claude-code-settings.json",
-        "env": {
-            "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
-            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
-            "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
-            "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
-            "ENABLE_TOOL_SEARCH": "auto",
-            "CLAUDE_CODE_NO_FLICKER": "1",
-            "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1",
-            "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
-            "DISABLE_ERROR_REPORTING": "1",
-            "DISABLE_TELEMETRY": "1"
-        }
+        "$schema": CLAUDE_CODE_SETTINGS_SCHEMA,
+        "env": env_from_pairs(&CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV),
     })
+}
+
+fn env_from_pairs(pairs: &[(&str, &str)]) -> Value {
+    Value::Object(
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), json!(value)))
+            .collect(),
+    )
 }
 
 fn to_pretty_json(value: &Value) -> String {
@@ -689,6 +729,14 @@ mod tests {
             gateway_settings["$schema"],
             "https://json.schemastore.org/claude-code-settings.json"
         );
+        assert_eq!(
+            gateway_settings["env"]["ANTHROPIC_AUTH_TOKEN"],
+            "<gateway api token>"
+        );
+        assert_eq!(
+            gateway_settings["env"]["ANTHROPIC_BASE_URL"],
+            "http://127.0.0.1:3000"
+        );
         assert_eq!(gateway_settings["env"]["ANTHROPIC_MODEL"], "claude-sonnet");
         assert_eq!(
             gateway_settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"],
@@ -703,5 +751,11 @@ mod tests {
             "200000"
         );
         assert_eq!(lower_usage_settings["env"]["ENABLE_TOOL_SEARCH"], "auto");
+        assert!(
+            rendered
+                .notes
+                .iter()
+                .any(|note| note.contains("/v1/messages"))
+        );
     }
 }

--- a/crates/gateway-service/src/admin_models.rs
+++ b/crates/gateway-service/src/admin_models.rs
@@ -1061,23 +1061,35 @@ mod tests {
             items[0].cache_read_cost_per_million_tokens_usd_10000,
             Some(3_000)
         );
-        assert_eq!(items[0].client_configurations.len(), 2);
+        assert_eq!(items[0].client_configurations.len(), 3);
         assert_eq!(items[0].client_configurations[0].key, "opencode");
         assert!(
-            items[0].client_configurations[0]
+            items[0].client_configurations[0].blocks[0]
                 .content
                 .contains("\"cache_read\": 0.3")
         );
         assert!(
-            items[0].client_configurations[0]
+            items[0].client_configurations[0].blocks[0]
                 .content
                 .contains("\"variants\"")
         );
         assert_eq!(items[0].client_configurations[1].key, "pi");
         assert!(
-            items[0].client_configurations[1]
+            items[0].client_configurations[1].blocks[0]
                 .content
                 .contains("\"thinkingLevelMap\"")
+        );
+        assert_eq!(items[0].client_configurations[2].key, "claude-code");
+        assert_eq!(items[0].client_configurations[2].blocks.len(), 2);
+        assert!(
+            items[0].client_configurations[2].blocks[0]
+                .content
+                .contains("\"modelOverrides\"")
+        );
+        assert!(
+            items[0].client_configurations[2].blocks[1]
+                .content
+                .contains("\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\": \"200000\"")
         );
     }
 }

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -2844,14 +2844,12 @@
           }
         }
       },
-      "AdminModelClientConfigView": {
+      "AdminModelClientConfigBlockView": {
         "type": "object",
         "required": [
-          "key",
           "label",
           "filename",
-          "content",
-          "notes"
+          "content"
         ],
         "properties": {
           "content": {
@@ -2859,6 +2857,26 @@
           },
           "filename": {
             "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "AdminModelClientConfigView": {
+        "type": "object",
+        "required": [
+          "key",
+          "label",
+          "blocks",
+          "notes"
+        ],
+        "properties": {
+          "blocks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminModelClientConfigBlockView"
+            }
           },
           "key": {
             "type": "string"

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -287,9 +287,15 @@ pub struct AdminModelView {
 pub struct AdminModelClientConfigView {
     pub key: String,
     pub label: String,
+    pub blocks: Vec<AdminModelClientConfigBlockView>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AdminModelClientConfigBlockView {
+    pub label: String,
     pub filename: String,
     pub content: String,
-    pub notes: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Default, IntoParams)]

--- a/crates/gateway/src/http/models.rs
+++ b/crates/gateway/src/http/models.rs
@@ -8,8 +8,8 @@ use gateway_service::{AdminModelSummary, AdminModelsService};
 use crate::http::{
     admin_auth::require_platform_admin,
     admin_contract::{
-        AdminModelClientConfigView, AdminModelListQuery, AdminModelPageView, AdminModelView,
-        Envelope, envelope,
+        AdminModelClientConfigBlockView, AdminModelClientConfigView, AdminModelListQuery,
+        AdminModelPageView, AdminModelView, Envelope, envelope,
     },
     error::AppError,
     state::AppState,
@@ -90,8 +90,15 @@ fn map_model_summary(model: AdminModelSummary) -> AdminModelView {
             .map(|config| AdminModelClientConfigView {
                 key: config.key,
                 label: config.label,
-                filename: config.filename,
-                content: config.content,
+                blocks: config
+                    .blocks
+                    .into_iter()
+                    .map(|block| AdminModelClientConfigBlockView {
+                        label: block.label,
+                        filename: block.filename,
+                        content: block.content,
+                    })
+                    .collect(),
                 notes: config.notes,
             })
             .collect(),

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,10 @@ export default defineConfig({
             link: "/configuration/model-routing-and-api-behavior",
           },
           {
+            text: "Client Harness Configuration",
+            link: "/configuration/client-harness-configuration",
+          },
+          {
             text: "Pricing Catalog and Accounting",
             link: "/configuration/pricing-catalog-and-accounting",
           },

--- a/docs/access/admin-control-plane.md
+++ b/docs/access/admin-control-plane.md
@@ -31,6 +31,7 @@ These areas are backed by real gateway APIs today:
 - request-log list and detail inspection
 - MCP invocation list and detail inspection
 - MCP server registry UI, recommended-server catalog, registry CRUD, soft-disable, tool list, and discovery refresh
+- generated client configuration snippets for supported model harnesses; see [Client Harness Configuration](../configuration/client-harness-configuration.md)
 
 ## Live But Still Maturing Surfaces
 

--- a/docs/adr/2026-05-02-server-generated-client-config-snippets.md
+++ b/docs/adr/2026-05-02-server-generated-client-config-snippets.md
@@ -7,7 +7,7 @@
 
 The admin Models page exposes the resolved model catalog, selected route metadata, pricing, token limits, and model capabilities that end users need when configuring local coding agents against the gateway's OpenAI-compatible endpoint.
 
-OpenCode, Pi, and Claude Code support custom model configuration, but their file shapes and thinking controls differ. Anthropic models add another layer of policy: newer Claude safe-effort families can use effort-style thinking values, while older Claude models require caller-supplied manual budget tokens. Generating snippets directly in the browser would duplicate this policy in TypeScript and make it harder to keep client instructions aligned with gateway routing behavior.
+OpenCode and Pi both support custom provider/model configuration, but their file shapes and thinking controls differ. Anthropic models add another layer of policy: newer Claude safe-effort families can use effort-style thinking values, while older Claude models require caller-supplied manual budget tokens. Generating snippets directly in the browser would duplicate this policy in TypeScript and make it harder to keep client instructions aligned with gateway routing behavior.
 
 ## Decision
 
@@ -17,8 +17,7 @@ Implementation points:
 
 - `crates/gateway-client-config` owns the config templating boundary.
 - `ClientConfigTemplate` is the shared interface for client-specific renderers.
-- OpenCode, Pi, and Claude Code are implemented as separate templates with their own JSON shapes.
-- Each client configuration contains one or more code blocks. OpenCode and Pi currently emit one block. Claude Code emits a gateway `settings.json` block and a separate lower-token-usage `settings.json` block.
+- OpenCode and Pi are implemented as separate templates with their own JSON shapes.
 - `AdminModelsService` builds snippets only for Anthropic-labeled rows.
 - The admin model list payload includes `client_configurations`, so the UI does not need a second endpoint.
 - The crate centralizes Anthropic thinking policy for this feature: safe-effort variants are emitted only for Claude 4.6/4.7/Mythos-style families, while manual-budget Claude models remain reasoning-capable without generated variants.
@@ -27,7 +26,7 @@ Implementation points:
 
 Server-side generation keeps pricing, model ids, token limits, route/provider labels, and thinking policy close to the source of truth. It also keeps the UI focused on presentation and copy behavior instead of embedding provider-specific config semantics in React code.
 
-A separate crate gives this feature a clear ownership boundary. Future clients can add another `ClientConfigTemplate` implementation without expanding the admin service with more JSON construction details. Multi-block configs let one client tab expose related files or alternate settings without forcing the UI to understand client-specific semantics.
+A separate crate gives this feature a clear ownership boundary. Future clients can add another `ClientConfigTemplate` implementation without expanding the admin service with more JSON construction details.
 
 ## Trade-offs
 
@@ -36,6 +35,12 @@ The server now ships presentation-oriented JSON snippets. That is intentional fo
 Anthropic thinking policy currently relies on conservative model-name inference because the catalog does not yet expose a first-class typed thinking policy flag. This is acceptable for the initial Anthropic-only slice, but it should move to explicit metadata when the provider/model policy surface is stable.
 
 The list payload becomes larger for supported rows because snippets are embedded. Each row includes only the clicked model's configurations, so the payload remains bounded by the visible page size and avoids another request path.
+
+## 2026-06-11 Update: Claude Code Multi-Block Snippets
+
+Claude Code is now implemented as another `ClientConfigTemplate`. Client configurations now contain one or more code blocks so a single client tab can expose related files or alternate settings without the UI understanding client-specific semantics. OpenCode and Pi still emit one block. Claude Code emits a gateway `settings.json` block and a separate lower-token-usage `settings.json` block.
+
+Claude Code uses an Anthropic-compatible gateway base URL and appends endpoints such as `/v1/messages` and `/v1/models`. The template derives that base from the OpenAI-compatible `/v1` gateway URL used by OpenCode and Pi so copied Claude Code settings do not point at the OpenAI client base.
 
 ## Follow-ups
 

--- a/docs/adr/2026-05-02-server-generated-client-config-snippets.md
+++ b/docs/adr/2026-05-02-server-generated-client-config-snippets.md
@@ -7,7 +7,7 @@
 
 The admin Models page exposes the resolved model catalog, selected route metadata, pricing, token limits, and model capabilities that end users need when configuring local coding agents against the gateway's OpenAI-compatible endpoint.
 
-OpenCode and Pi both support custom provider/model configuration, but their file shapes and thinking controls differ. Anthropic models add another layer of policy: newer Claude safe-effort families can use effort-style thinking values, while older Claude models require caller-supplied manual budget tokens. Generating snippets directly in the browser would duplicate this policy in TypeScript and make it harder to keep client instructions aligned with gateway routing behavior.
+OpenCode, Pi, and Claude Code support custom model configuration, but their file shapes and thinking controls differ. Anthropic models add another layer of policy: newer Claude safe-effort families can use effort-style thinking values, while older Claude models require caller-supplied manual budget tokens. Generating snippets directly in the browser would duplicate this policy in TypeScript and make it harder to keep client instructions aligned with gateway routing behavior.
 
 ## Decision
 
@@ -17,7 +17,8 @@ Implementation points:
 
 - `crates/gateway-client-config` owns the config templating boundary.
 - `ClientConfigTemplate` is the shared interface for client-specific renderers.
-- OpenCode and Pi are implemented as separate templates with their own JSON shapes.
+- OpenCode, Pi, and Claude Code are implemented as separate templates with their own JSON shapes.
+- Each client configuration contains one or more code blocks. OpenCode and Pi currently emit one block. Claude Code emits a gateway `settings.json` block and a separate lower-token-usage `settings.json` block.
 - `AdminModelsService` builds snippets only for Anthropic-labeled rows.
 - The admin model list payload includes `client_configurations`, so the UI does not need a second endpoint.
 - The crate centralizes Anthropic thinking policy for this feature: safe-effort variants are emitted only for Claude 4.6/4.7/Mythos-style families, while manual-budget Claude models remain reasoning-capable without generated variants.
@@ -26,7 +27,7 @@ Implementation points:
 
 Server-side generation keeps pricing, model ids, token limits, route/provider labels, and thinking policy close to the source of truth. It also keeps the UI focused on presentation and copy behavior instead of embedding provider-specific config semantics in React code.
 
-A separate crate gives this feature a clear ownership boundary. Future clients can add another `ClientConfigTemplate` implementation without expanding the admin service with more JSON construction details.
+A separate crate gives this feature a clear ownership boundary. Future clients can add another `ClientConfigTemplate` implementation without expanding the admin service with more JSON construction details. Multi-block configs let one client tab expose related files or alternate settings without forcing the UI to understand client-specific semantics.
 
 ## Trade-offs
 
@@ -40,5 +41,6 @@ The list payload becomes larger for supported rows because snippets are embedded
 
 - Replace Anthropic model-name inference with typed provider/model metadata when available.
 - Consider validating OpenCode output against a pinned OpenCode config schema.
+- Consider validating Claude Code output against the SchemaStore `claude-code-settings.json` schema.
 - Add more client templates only through the `ClientConfigTemplate` boundary.
 - Revisit whether deployment-specific base URL/API key defaults should be configurable instead of fixed placeholders.

--- a/docs/configuration/client-harness-configuration.md
+++ b/docs/configuration/client-harness-configuration.md
@@ -1,11 +1,43 @@
 # Client Harness Configuration
 
-`See also`: [Model Routing and API Behavior](model-routing-and-api-behavior.md)
+`See also`: [Model Routing and API Behavior](model-routing-and-api-behavior.md), [Budgets](../access/budgets.md), [Budgets and Spending](../operations/budgets-and-spending.md)
 
 ![Model Config Page](../public/images/screenshot-model-client-config.png)
 
-To aid in user experience, Oceans has the ability to generate config for popular client harnesses such as [OpenCode] and [Pi].
+Oceans generates client configuration snippets from the live model catalog so users can point local agent harnesses at the gateway without hand-writing model metadata.
 
+Open `/admin/models`, choose a model, then click **Client config**. Supported Anthropic-backed models show snippets for:
+
+- [OpenCode]
+- [Pi]
+- [Claude Code]
+
+The snippets use the gateway model id shown in the Models table. API keys are still created and governed in Oceans; the local client config only tells the harness which gateway URL, key variable, and model id to use.
+
+## Claude Code
+
+The Claude Code tab emits `.claude/settings.json` content with the SchemaStore Claude Code schema URL. The gateway settings block includes:
+
+- `ANTHROPIC_AUTH_TOKEN`, set to the gateway API key placeholder
+- `ANTHROPIC_BASE_URL`, set to the gateway OpenAI-compatible base URL
+- `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`, so Claude Code can discover gateway-routed models
+- `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, and the matching default model class variable
+- `modelOverrides`, mapping Claude Code's Anthropic model id to the selected gateway model id
+
+The same dialog also shows a second `settings.json` block for a smaller local Claude Code experience. It disables telemetry, experimental betas, 1M context, and related UI/reporting behavior, and sets a lower auto-compact window.
+
+## Budgets And Access
+
+Client snippets do not grant access by themselves. A request is accepted only when the gateway API key is active, the caller has model access, and any applicable hard budget still has room.
+
+Budget scopes are independent of the client harness:
+
+- human users can have an overall user budget
+- service accounts must have an active service-account budget before active service-account API keys can be used
+- human users can also have user model budgets for one gateway model or one upstream model name
+
+Use `/admin/spend-controls` to configure those budgets. For the full taxonomy and setup workflow, see [Budgets](../access/budgets.md).
 
 [opencode]: https://opencode.ai/
 [pi]: https://pi.dev/
+[claude code]: https://code.claude.com/docs/en/settings

--- a/docs/configuration/client-harness-configuration.md
+++ b/docs/configuration/client-harness-configuration.md
@@ -18,11 +18,13 @@ The snippets use the gateway model id shown in the Models table. API keys are st
 
 The Claude Code tab emits `.claude/settings.json` content with the SchemaStore Claude Code schema URL. The gateway settings block includes:
 
-- `ANTHROPIC_AUTH_TOKEN`, set to the gateway API key placeholder
-- `ANTHROPIC_BASE_URL`, set to the gateway OpenAI-compatible base URL
+- `ANTHROPIC_AUTH_TOKEN`, set to a replaceable gateway API token placeholder
+- `ANTHROPIC_BASE_URL`, set to the Claude-compatible gateway base URL
 - `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`, so Claude Code can discover gateway-routed models
 - `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, and the matching default model class variable
 - `modelOverrides`, mapping Claude Code's Anthropic model id to the selected gateway model id
+
+Claude Code appends Anthropic endpoints such as `/v1/messages` and `/v1/models` to `ANTHROPIC_BASE_URL`. Do not include `/v1/messages` in the value. OpenCode and Pi still use the OpenAI-compatible `/v1` base URL.
 
 The same dialog also shows a second `settings.json` block for a smaller local Claude Code experience. It disables telemetry, experimental betas, 1M context, and related UI/reporting behavior, and sets a lower auto-compact window.
 

--- a/docs/reference/screenshots.md
+++ b/docs/reference/screenshots.md
@@ -18,7 +18,7 @@ Shows configured models, provider identity, model metadata, and routing context.
 
 ## Model Client Config
 
-Shows generated client configuration snippets for a selected model.
+Shows generated client configuration snippets for a selected model, including multi-block clients such as Claude Code `settings.json`.
 
 ![Model client config](../public/images/screenshot-model-client-config.png)
 


### PR DESCRIPTION
## Description

Adds Claude Code `settings.json` snippets to the Models page Client Config dialog.

- Summary of changes
  - Adds a server-side Claude Code client config template alongside OpenCode and Pi.
  - Changes client config payloads to `blocks[]` so one client tab can show multiple JSON snippets.
  - Renders multi-block snippets in the admin UI with per-block copy buttons.
  - Updates OpenAPI/generated admin API types, tests, and documentation.
- Why this approach was chosen
  - Keeps client config generation inside `crates/gateway-client-config`, matching the existing server-generated snippet ADR and avoiding provider/client policy in React.
  - Represents Claude Code's full gateway settings and lower-token-usage settings as separate code blocks instead of concatenating unrelated JSON into one string.
- How it works
  - Anthropic-labeled models now receive OpenCode, Pi, and Claude Code configs from `render_default_configs`.
  - Claude Code config emits SchemaStore-backed `settings.json` content with gateway auth/base URL/model env vars and `modelOverrides`.
  - The second Claude Code block emits lower-token-usage settings.
- Risks, tradeoffs, and alternatives considered
  - API shape changes from single `filename/content` to `blocks[]`; this removes the old single-block assumption rather than carrying a compatibility shim.
  - Contract artifacts were manually aligned after generation initially ran out of disk; `mise run admin-contract-check` passes after alignment.
- Additional context for reviewers
  - Docs were split between user-facing client harness setup and maintainer-facing ADR/reference updates. Budget docs were cross-linked but not changed semantically because this feature does not alter budget taxonomy or enforcement.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional focused checks run:

- [x] `cargo test -p gateway-client-config`
- [x] `cargo test -p gateway-service admin_models`
- [x] `bun run --cwd crates/admin-ui/web test src/test/routes/models-route.test.tsx`
- [x] `mise run docs:check`
- [x] `mise run admin-contract-check`
