### PR TITLE
feat(gateway): restrict github oauth email domains

### DIFF
--- a/crates/gateway-core/src/domain.rs
+++ b/crates/gateway-core/src/domain.rs
@@ -568,6 +568,7 @@ pub struct OauthProviderRecord {
     pub client_id: String,
     pub client_secret_ref: String,
     pub scopes: Vec<String>,
+    pub allowed_email_domains: Vec<String>,
     pub enabled: bool,
     pub jit: OauthJitPolicy,
     pub created_at: OffsetDateTime,
@@ -2439,6 +2440,7 @@ pub struct SeedOauthProvider {
     pub client_id: String,
     pub client_secret_ref: String,
     pub scopes: Vec<String>,
+    pub allowed_email_domains: Vec<String>,
     pub enabled: bool,
     pub jit: OauthJitPolicy,
 }

--- a/crates/gateway-store/migrations/V32__oauth_provider_allowed_email_domains.sql
+++ b/crates/gateway-store/migrations/V32__oauth_provider_allowed_email_domains.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_providers
+    ADD COLUMN allowed_email_domains_json TEXT NOT NULL DEFAULT '[]';

--- a/crates/gateway-store/migrations/postgres/V32__oauth_provider_allowed_email_domains.sql
+++ b/crates/gateway-store/migrations/postgres/V32__oauth_provider_allowed_email_domains.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_providers
+    ADD COLUMN allowed_email_domains_json TEXT NOT NULL DEFAULT '[]';

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -4301,20 +4301,30 @@ mod tests {
         let store = LibsqlStore::new_local(db_path.to_str().expect("db path"))
             .await
             .expect("store");
-        let initial_provider = SeedOauthProvider {
-            provider_key: "github".to_string(),
-            provider_type: "github".to_string(),
-            label: "GitHub".to_string(),
-            client_id: "client-id".to_string(),
-            client_secret_ref: "literal.secret".to_string(),
-            scopes: vec!["read:user".to_string(), "user:email".to_string()],
-            allowed_email_domains: vec!["test.com".to_string()],
-            enabled: true,
-            jit: OauthJitPolicy::default(),
-        };
+        fn github_provider_with_domains(domains: Vec<&str>) -> SeedOauthProvider {
+            SeedOauthProvider {
+                provider_key: "github".to_string(),
+                provider_type: "github".to_string(),
+                label: "GitHub".to_string(),
+                client_id: "client-id".to_string(),
+                client_secret_ref: "literal.secret".to_string(),
+                scopes: vec!["read:user".to_string(), "user:email".to_string()],
+                allowed_email_domains: domains.into_iter().map(str::to_string).collect(),
+                enabled: true,
+                jit: OauthJitPolicy::default(),
+            }
+        }
 
         store
-            .seed_from_inputs(&[], &[], &[], &[], &[initial_provider], &[], &[])
+            .seed_from_inputs(
+                &[],
+                &[],
+                &[],
+                &[],
+                &[github_provider_with_domains(vec!["test.com"])],
+                &[],
+                &[],
+            )
             .await
             .expect("seed provider");
         let providers = store
@@ -4327,20 +4337,19 @@ mod tests {
             vec!["test.com".to_string()]
         );
 
-        let updated_provider = SeedOauthProvider {
-            provider_key: "github".to_string(),
-            provider_type: "github".to_string(),
-            label: "GitHub".to_string(),
-            client_id: "client-id".to_string(),
-            client_secret_ref: "literal.secret".to_string(),
-            scopes: vec!["read:user".to_string(), "user:email".to_string()],
-            allowed_email_domains: vec!["example.com".to_string(), "team.example.com".to_string()],
-            enabled: true,
-            jit: OauthJitPolicy::default(),
-        };
-
         store
-            .seed_from_inputs(&[], &[], &[], &[], &[updated_provider], &[], &[])
+            .seed_from_inputs(
+                &[],
+                &[],
+                &[],
+                &[],
+                &[github_provider_with_domains(vec![
+                    "example.com",
+                    "team.example.com",
+                ])],
+                &[],
+                &[],
+            )
             .await
             .expect("update provider");
         let provider = store

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -42,16 +42,17 @@ mod tests {
         McpToolPolicyResult, McpUpstreamCredentialMaterialKind,
         McpUpstreamCredentialOwnerScopeKind, McpUpstreamCredentialRepository,
         McpUpstreamSecretStorageKind, MembershipRole, ModelPricingRecord, ModelRepository, Money4,
-        NewExternalMcpServerRecord, OidcLoginStateRecord, OpenAiCompatDeveloperRole,
-        OpenAiCompatMaxTokensField, OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility,
-        PricingCatalogCacheRecord, PricingCatalogRepository, PricingLimits, PricingModalities,
-        PricingProvenance, ProviderCapabilities, RequestAttemptRecord, RequestAttemptStatus,
-        RequestLogPayloadRecord, RequestLogQuery, RequestLogRecord, RequestLogRepository,
-        RequestTag, RequestTags, RequestToolCardinality, RouteCompatibility, SeedApiKey,
-        SeedBudget, SeedModel, SeedModelRoute, SeedProvider, SeedTeam, SeedUser,
-        SeedUserMembership, StoreError, StoreHealth, UpdateExternalMcpServerRecord,
-        UpsertExternalMcpToolRecord, UpsertMcpUpstreamCredentialBindingRecord, UsageLedgerRecord,
-        UsagePricingStatus, UserStatus,
+        NewExternalMcpServerRecord, OauthJitPolicy, OidcLoginStateRecord,
+        OpenAiCompatDeveloperRole, OpenAiCompatMaxTokensField, OpenAiCompatReasoningEffort,
+        OpenAiCompatRouteCompatibility, PricingCatalogCacheRecord, PricingCatalogRepository,
+        PricingLimits, PricingModalities, PricingProvenance, ProviderCapabilities,
+        RequestAttemptRecord, RequestAttemptStatus, RequestLogPayloadRecord, RequestLogQuery,
+        RequestLogRecord, RequestLogRepository, RequestTag, RequestTags, RequestToolCardinality,
+        RouteCompatibility, SeedApiKey, SeedBudget, SeedModel, SeedModelRoute, SeedOauthProvider,
+        SeedProvider, SeedTeam, SeedUser, SeedUserMembership, StoreError, StoreHealth,
+        UpdateExternalMcpServerRecord, UpsertExternalMcpToolRecord,
+        UpsertMcpUpstreamCredentialBindingRecord, UsageLedgerRecord, UsagePricingStatus,
+        UserStatus,
     };
     use serde_json::{Map, json};
     use serial_test::serial;
@@ -4288,6 +4289,69 @@ mod tests {
             .expect("reload user")
             .expect("user should exist");
         assert!(!refreshed.must_change_password);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn libsql_seed_round_trips_oauth_provider_allowed_email_domains() {
+        let tmp = tempdir().expect("tempdir");
+        let db_path = tmp.path().join("gateway.db");
+        run_migrations(&db_path).await.expect("migrations");
+
+        let store = LibsqlStore::new_local(db_path.to_str().expect("db path"))
+            .await
+            .expect("store");
+        let initial_provider = SeedOauthProvider {
+            provider_key: "github".to_string(),
+            provider_type: "github".to_string(),
+            label: "GitHub".to_string(),
+            client_id: "client-id".to_string(),
+            client_secret_ref: "literal.secret".to_string(),
+            scopes: vec!["read:user".to_string(), "user:email".to_string()],
+            allowed_email_domains: vec!["test.com".to_string()],
+            enabled: true,
+            jit: OauthJitPolicy::default(),
+        };
+
+        store
+            .seed_from_inputs(&[], &[], &[], &[], &[initial_provider], &[], &[])
+            .await
+            .expect("seed provider");
+        let providers = store
+            .list_enabled_oauth_providers()
+            .await
+            .expect("list oauth providers");
+        assert_eq!(providers.len(), 1);
+        assert_eq!(
+            providers[0].allowed_email_domains,
+            vec!["test.com".to_string()]
+        );
+
+        let updated_provider = SeedOauthProvider {
+            provider_key: "github".to_string(),
+            provider_type: "github".to_string(),
+            label: "GitHub".to_string(),
+            client_id: "client-id".to_string(),
+            client_secret_ref: "literal.secret".to_string(),
+            scopes: vec!["read:user".to_string(), "user:email".to_string()],
+            allowed_email_domains: vec!["example.com".to_string(), "team.example.com".to_string()],
+            enabled: true,
+            jit: OauthJitPolicy::default(),
+        };
+
+        store
+            .seed_from_inputs(&[], &[], &[], &[], &[updated_provider], &[], &[])
+            .await
+            .expect("update provider");
+        let provider = store
+            .get_enabled_oauth_provider_by_key("github")
+            .await
+            .expect("get oauth provider")
+            .expect("provider exists");
+        assert_eq!(
+            provider.allowed_email_domains,
+            vec!["example.com".to_string(), "team.example.com".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -90,6 +90,20 @@ mod tests {
         }]
     }
 
+    fn seed_github_oauth_provider_with_domains(domains: Vec<&str>) -> SeedOauthProvider {
+        SeedOauthProvider {
+            provider_key: "github".to_string(),
+            provider_type: "github".to_string(),
+            label: "GitHub".to_string(),
+            client_id: "client-id".to_string(),
+            client_secret_ref: "literal.secret".to_string(),
+            scopes: vec!["read:user".to_string(), "user:email".to_string()],
+            allowed_email_domains: domains.into_iter().map(str::to_string).collect(),
+            enabled: true,
+            jit: OauthJitPolicy::default(),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn build_usage_ledger_record(
         request_id: &str,
@@ -4301,19 +4315,6 @@ mod tests {
         let store = LibsqlStore::new_local(db_path.to_str().expect("db path"))
             .await
             .expect("store");
-        fn github_provider_with_domains(domains: Vec<&str>) -> SeedOauthProvider {
-            SeedOauthProvider {
-                provider_key: "github".to_string(),
-                provider_type: "github".to_string(),
-                label: "GitHub".to_string(),
-                client_id: "client-id".to_string(),
-                client_secret_ref: "literal.secret".to_string(),
-                scopes: vec!["read:user".to_string(), "user:email".to_string()],
-                allowed_email_domains: domains.into_iter().map(str::to_string).collect(),
-                enabled: true,
-                jit: OauthJitPolicy::default(),
-            }
-        }
 
         store
             .seed_from_inputs(
@@ -4321,7 +4322,7 @@ mod tests {
                 &[],
                 &[],
                 &[],
-                &[github_provider_with_domains(vec!["test.com"])],
+                &[seed_github_oauth_provider_with_domains(vec!["test.com"])],
                 &[],
                 &[],
             )
@@ -4343,7 +4344,77 @@ mod tests {
                 &[],
                 &[],
                 &[],
-                &[github_provider_with_domains(vec![
+                &[seed_github_oauth_provider_with_domains(vec![
+                    "example.com",
+                    "team.example.com",
+                ])],
+                &[],
+                &[],
+            )
+            .await
+            .expect("update provider");
+        let provider = store
+            .get_enabled_oauth_provider_by_key("github")
+            .await
+            .expect("get oauth provider")
+            .expect("provider exists");
+        assert_eq!(
+            provider.allowed_email_domains,
+            vec!["example.com".to_string(), "team.example.com".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn postgres_seed_round_trips_oauth_provider_allowed_email_domains() {
+        let Some(test_db) = create_postgres_test_database().await else {
+            eprintln!(
+                "skipping postgres oauth provider allowed email domains test because TEST_POSTGRES_URL is not set"
+            );
+            return;
+        };
+
+        let options = StoreConnectionOptions::Postgres {
+            url: test_db.database_url.clone(),
+            max_connections: 4,
+        };
+        run_migrations_with_options(&options)
+            .await
+            .expect("postgres migrations");
+
+        let store = PostgresStore::connect(&test_db.database_url, 4)
+            .await
+            .expect("postgres store");
+
+        store
+            .seed_from_inputs(
+                &[],
+                &[],
+                &[],
+                &[],
+                &[seed_github_oauth_provider_with_domains(vec!["test.com"])],
+                &[],
+                &[],
+            )
+            .await
+            .expect("seed provider");
+        let providers = store
+            .list_enabled_oauth_providers()
+            .await
+            .expect("list oauth providers");
+        assert_eq!(providers.len(), 1);
+        assert_eq!(
+            providers[0].allowed_email_domains,
+            vec!["test.com".to_string()]
+        );
+
+        store
+            .seed_from_inputs(
+                &[],
+                &[],
+                &[],
+                &[],
+                &[seed_github_oauth_provider_with_domains(vec![
                     "example.com",
                     "team.example.com",
                 ])],

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -4432,6 +4432,9 @@ mod tests {
             provider.allowed_email_domains,
             vec!["example.com".to_string(), "team.example.com".to_string()]
         );
+
+        store.pool().close().await;
+        drop_postgres_test_database(&test_db).await;
     }
 
     #[tokio::test]

--- a/crates/gateway-store/src/libsql_store/identity.rs
+++ b/crates/gateway-store/src/libsql_store/identity.rs
@@ -503,7 +503,8 @@ impl LibsqlStore {
                 SELECT oauth_provider_id, provider_key, provider_type, client_id,
                        scopes_json, enabled, label, client_secret_ref, jit_enabled,
                        jit_global_role, jit_team_key, jit_team_role,
-                       jit_request_logging_enabled, created_at, updated_at
+                       jit_request_logging_enabled, allowed_email_domains_json,
+                       created_at, updated_at
                 FROM oauth_providers
                 WHERE enabled = 1
                 ORDER BY provider_key ASC
@@ -532,7 +533,8 @@ impl LibsqlStore {
                 SELECT oauth_provider_id, provider_key, provider_type, client_id,
                        scopes_json, enabled, label, client_secret_ref, jit_enabled,
                        jit_global_role, jit_team_key, jit_team_role,
-                       jit_request_logging_enabled, created_at, updated_at
+                       jit_request_logging_enabled, allowed_email_domains_json,
+                       created_at, updated_at
                 FROM oauth_providers
                 WHERE provider_key = ?1 AND enabled = 1
                 LIMIT 1

--- a/crates/gateway-store/src/libsql_store/seed.rs
+++ b/crates/gateway-store/src/libsql_store/seed.rs
@@ -149,6 +149,7 @@ impl LibsqlStore {
 
         for provider in oauth_providers {
             let scopes_json = serialize_json(&provider.scopes)?;
+            let allowed_email_domains_json = serialize_json(&provider.allowed_email_domains)?;
             let oauth_provider_id = crate::seed::oauth_provider_uuid(&provider.provider_key);
             self.connection
                 .execute(
@@ -157,8 +158,9 @@ impl LibsqlStore {
                         oauth_provider_id, provider_key, provider_type, client_id,
                         scopes_json, enabled, label, client_secret_ref, jit_enabled,
                         jit_global_role, jit_team_key, jit_team_role,
-                        jit_request_logging_enabled, created_at, updated_at
-                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)
+                        jit_request_logging_enabled, allowed_email_domains_json,
+                        created_at, updated_at
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
                     ON CONFLICT(provider_key) DO UPDATE SET
                         provider_type = excluded.provider_type,
                         client_id = excluded.client_id,
@@ -171,6 +173,7 @@ impl LibsqlStore {
                         jit_team_key = excluded.jit_team_key,
                         jit_team_role = excluded.jit_team_role,
                         jit_request_logging_enabled = excluded.jit_request_logging_enabled,
+                        allowed_email_domains_json = excluded.allowed_email_domains_json,
                         updated_at = excluded.updated_at
                     "#,
                     libsql::params![
@@ -199,6 +202,7 @@ impl LibsqlStore {
                         } else {
                             0_i64
                         },
+                        allowed_email_domains_json,
                         now_unix,
                     ],
                 )

--- a/crates/gateway-store/src/libsql_store/support.rs
+++ b/crates/gateway-store/src/libsql_store/support.rs
@@ -335,8 +335,9 @@ pub(super) fn decode_oauth_provider_record(
     let jit_team_key: Option<String> = row.get(10).map_err(to_query_error)?;
     let jit_team_role: Option<String> = row.get(11).map_err(to_query_error)?;
     let jit_request_logging_enabled: i64 = row.get(12).map_err(to_query_error)?;
-    let created_at: i64 = row.get(13).map_err(to_query_error)?;
-    let updated_at: i64 = row.get(14).map_err(to_query_error)?;
+    let allowed_email_domains_json: String = row.get(13).map_err(to_query_error)?;
+    let created_at: i64 = row.get(14).map_err(to_query_error)?;
+    let updated_at: i64 = row.get(15).map_err(to_query_error)?;
     let provider_key: String = row.get(1).map_err(to_query_error)?;
     let label: Option<String> = row.get(6).map_err(to_query_error)?;
 
@@ -351,6 +352,8 @@ pub(super) fn decode_oauth_provider_record(
         client_id: row.get(3).map_err(to_query_error)?,
         client_secret_ref: row.get(7).map_err(to_query_error)?,
         scopes: serde_json::from_str(&scopes_json)
+            .map_err(|error| StoreError::Serialization(error.to_string()))?,
+        allowed_email_domains: serde_json::from_str(&allowed_email_domains_json)
             .map_err(|error| StoreError::Serialization(error.to_string()))?,
         enabled: enabled == 1,
         jit: OauthJitPolicy {

--- a/crates/gateway-store/src/migration_registry.rs
+++ b/crates/gateway-store/src/migration_registry.rs
@@ -134,6 +134,15 @@ pub(crate) const MIGRATION_REGISTRY: &[MigrationManifest] = &[
             "../migrations/postgres/V31__mcp_upstream_credential_bindings.sql"
         ),
     },
+    MigrationManifest {
+        version: 32,
+        name: "oauth_provider_allowed_email_domains",
+        checksum: "V32__oauth_provider_allowed_email_domains.sql",
+        libsql_sql: include_str!("../migrations/V32__oauth_provider_allowed_email_domains.sql"),
+        postgres_sql: include_str!(
+            "../migrations/postgres/V32__oauth_provider_allowed_email_domains.sql"
+        ),
+    },
 ];
 
 #[cfg(test)]

--- a/crates/gateway-store/src/postgres_store/identity.rs
+++ b/crates/gateway-store/src/postgres_store/identity.rs
@@ -435,7 +435,8 @@ impl PostgresStore {
             SELECT oauth_provider_id, provider_key, provider_type, client_id,
                    scopes_json, enabled, label, client_secret_ref, jit_enabled,
                    jit_global_role, jit_team_key, jit_team_role,
-                   jit_request_logging_enabled, created_at, updated_at
+                   jit_request_logging_enabled, allowed_email_domains_json,
+                   created_at, updated_at
             FROM oauth_providers
             WHERE enabled = 1
             ORDER BY provider_key ASC
@@ -457,7 +458,8 @@ impl PostgresStore {
             SELECT oauth_provider_id, provider_key, provider_type, client_id,
                    scopes_json, enabled, label, client_secret_ref, jit_enabled,
                    jit_global_role, jit_team_key, jit_team_role,
-                   jit_request_logging_enabled, created_at, updated_at
+                   jit_request_logging_enabled, allowed_email_domains_json,
+                   created_at, updated_at
             FROM oauth_providers
             WHERE provider_key = $1 AND enabled = 1
             LIMIT 1

--- a/crates/gateway-store/src/postgres_store/seed.rs
+++ b/crates/gateway-store/src/postgres_store/seed.rs
@@ -147,6 +147,7 @@ impl PostgresStore {
 
         for provider in oauth_providers {
             let scopes_json = serialize_json(&provider.scopes)?;
+            let allowed_email_domains_json = serialize_json(&provider.allowed_email_domains)?;
             let oauth_provider_id = crate::seed::oauth_provider_uuid(&provider.provider_key);
             sqlx::query(
                 r#"
@@ -154,8 +155,9 @@ impl PostgresStore {
                     oauth_provider_id, provider_key, provider_type, client_id,
                     scopes_json, enabled, label, client_secret_ref, jit_enabled,
                     jit_global_role, jit_team_key, jit_team_role,
-                    jit_request_logging_enabled, created_at, updated_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $14)
+                    jit_request_logging_enabled, allowed_email_domains_json,
+                    created_at, updated_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $15)
                 ON CONFLICT(provider_key) DO UPDATE SET
                     provider_type = excluded.provider_type,
                     client_id = excluded.client_id,
@@ -168,6 +170,7 @@ impl PostgresStore {
                     jit_team_key = excluded.jit_team_key,
                     jit_team_role = excluded.jit_team_role,
                     jit_request_logging_enabled = excluded.jit_request_logging_enabled,
+                    allowed_email_domains_json = excluded.allowed_email_domains_json,
                     updated_at = excluded.updated_at
                 "#,
             )
@@ -200,6 +203,7 @@ impl PostgresStore {
             } else {
                 0_i64
             })
+            .bind(allowed_email_domains_json)
             .bind(now_unix)
             .execute(&self.pool)
             .await

--- a/crates/gateway-store/src/postgres_store/support.rs
+++ b/crates/gateway-store/src/postgres_store/support.rs
@@ -309,8 +309,9 @@ pub(super) fn decode_oauth_provider_record(row: &PgRow) -> Result<OauthProviderR
     let jit_team_key: Option<String> = row.try_get(10).map_err(to_query_error)?;
     let jit_team_role: Option<String> = row.try_get(11).map_err(to_query_error)?;
     let jit_request_logging_enabled: i64 = row.try_get(12).map_err(to_query_error)?;
-    let created_at: i64 = row.try_get(13).map_err(to_query_error)?;
-    let updated_at: i64 = row.try_get(14).map_err(to_query_error)?;
+    let allowed_email_domains_json: String = row.try_get(13).map_err(to_query_error)?;
+    let created_at: i64 = row.try_get(14).map_err(to_query_error)?;
+    let updated_at: i64 = row.try_get(15).map_err(to_query_error)?;
     let provider_key: String = row.try_get(1).map_err(to_query_error)?;
     let label: Option<String> = row.try_get(6).map_err(to_query_error)?;
 
@@ -325,6 +326,8 @@ pub(super) fn decode_oauth_provider_record(row: &PgRow) -> Result<OauthProviderR
         client_id: row.try_get(3).map_err(to_query_error)?,
         client_secret_ref: row.try_get(7).map_err(to_query_error)?,
         scopes: serde_json::from_str(&scopes_json)
+            .map_err(|error| StoreError::Serialization(error.to_string()))?,
+        allowed_email_domains: serde_json::from_str(&allowed_email_domains_json)
             .map_err(|error| StoreError::Serialization(error.to_string()))?,
         enabled: enabled == 1,
         jit: OauthJitPolicy {

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1309,6 +1309,10 @@ impl AuthOauthConfig {
             if !provider.scopes.iter().any(|scope| scope == "user:email") {
                 bail!("oauth provider `{provider_key}` scopes must include `user:email`");
             }
+            let _ = normalize_allowed_email_domains(
+                &provider.allowed_email_domains,
+                &format!("oauth provider `{provider_key}` allowed_email_domains"),
+            )?;
             if let Some(membership) = provider.jit.membership.as_ref() {
                 let team_key = normalize_config_team_key(&membership.team)
                     .with_context(|| format!("oauth provider `{provider_key}` jit team"))?;
@@ -1397,6 +1401,8 @@ pub struct OauthProviderConfig {
     pub client_secret: String,
     #[serde(default = "default_github_oauth_scopes")]
     pub scopes: Vec<String>,
+    #[serde(default)]
+    pub allowed_email_domains: Vec<String>,
     #[serde(default = "default_enabled")]
     pub enabled: bool,
     #[serde(default)]
@@ -1421,6 +1427,10 @@ impl OauthProviderConfig {
             },
             client_secret_ref: self.client_secret.clone(),
             scopes: self.scopes.clone(),
+            allowed_email_domains: normalize_allowed_email_domains(
+                &self.allowed_email_domains,
+                "auth.oauth.providers[].allowed_email_domains",
+            )?,
             enabled: self.enabled,
             jit: self.jit.seed_policy()?,
         })
@@ -2450,6 +2460,63 @@ fn normalize_config_oauth_provider_key(provider_key: &str) -> anyhow::Result<Str
     if normalized.is_empty() {
         bail!("cannot be empty");
     }
+    Ok(normalized)
+}
+
+fn normalize_allowed_email_domains(
+    domains: &[String],
+    context: &str,
+) -> anyhow::Result<Vec<String>> {
+    let mut normalized_domains = Vec::with_capacity(domains.len());
+    let mut seen = std::collections::BTreeSet::new();
+
+    for domain in domains {
+        let normalized = normalize_allowed_email_domain(domain)
+            .with_context(|| format!("{context} entry `{domain}`"))?;
+        if !seen.insert(normalized.clone()) {
+            bail!("{context} contains duplicate domain `{normalized}`");
+        }
+        normalized_domains.push(normalized);
+    }
+
+    Ok(normalized_domains)
+}
+
+fn normalize_allowed_email_domain(domain: &str) -> anyhow::Result<String> {
+    let normalized = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+    if normalized.is_empty() {
+        bail!("cannot be empty");
+    }
+    if normalized.contains('@')
+        || normalized.contains('/')
+        || normalized.contains(':')
+        || normalized.contains('*')
+        || normalized.chars().any(char::is_whitespace)
+    {
+        bail!("must be a domain name, not an email address, URL, or wildcard");
+    }
+    if normalized.starts_with('.') || normalized.ends_with('.') || normalized.contains("..") {
+        bail!("must be a valid domain name");
+    }
+
+    let mut label_count = 0;
+    for label in normalized.split('.') {
+        label_count += 1;
+        if label.is_empty() || label.starts_with('-') || label.ends_with('-') {
+            bail!("must be a valid domain name");
+        }
+        if !label
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+        {
+            bail!("must be a valid domain name");
+        }
+    }
+
+    if label_count < 2 {
+        bail!("must be a valid domain name");
+    }
+
     Ok(normalized)
 }
 
@@ -4489,6 +4556,101 @@ auth:
         let error_text = format!("{error:#}");
         assert!(
             error_text.contains("must include `user:email`"),
+            "unexpected error: {error_text}"
+        );
+    }
+
+    #[test]
+    fn parses_github_oauth_allowed_email_domains_into_seed() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+auth:
+  oauth:
+    public_base_url: literal.https://gateway.example.com
+    providers:
+      - key: github
+        label: GitHub
+        provider_type: github
+        client_id: github-client-id
+        client_secret: literal.secret
+        scopes: [read:user, user:email]
+        allowed_email_domains:
+          - Test.com
+          - Engineering.Example.com.
+"#,
+        );
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let oauth_providers = config.seed_oauth_providers().expect("seed oauth providers");
+        assert_eq!(
+            oauth_providers[0].allowed_email_domains,
+            vec!["test.com", "engineering.example.com"]
+        );
+    }
+
+    #[test]
+    fn rejects_github_oauth_duplicate_allowed_email_domains() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+auth:
+  oauth:
+    public_base_url: literal.https://gateway.example.com
+    providers:
+      - key: github
+        label: GitHub
+        provider_type: github
+        client_id: github-client-id
+        client_secret: literal.secret
+        scopes: [read:user, user:email]
+        allowed_email_domains:
+          - Test.com
+          - test.com
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("contains duplicate domain `test.com`"),
+            "unexpected error: {error_text}"
+        );
+    }
+
+    #[test]
+    fn rejects_github_oauth_invalid_allowed_email_domain() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+auth:
+  oauth:
+    public_base_url: literal.https://gateway.example.com
+    providers:
+      - key: github
+        label: GitHub
+        provider_type: github
+        client_id: github-client-id
+        client_secret: literal.secret
+        scopes: [read:user, user:email]
+        allowed_email_domains:
+          - alice@test.com
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("must be a domain name"),
             "unexpected error: {error_text}"
         );
     }

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -2483,15 +2483,7 @@ fn normalize_allowed_email_domains(
 }
 
 fn validate_allowed_email_domains(domains: &[String], context: &str) -> anyhow::Result<()> {
-    let mut seen = std::collections::BTreeSet::new();
-    for domain in domains {
-        let normalized = normalize_allowed_email_domain(domain)
-            .with_context(|| format!("{context} entry `{domain}`"))?;
-        if !seen.insert(normalized.clone()) {
-            bail!("{context} contains duplicate domain `{normalized}`");
-        }
-    }
-    Ok(())
+    normalize_allowed_email_domains(domains, context).map(|_| ())
 }
 
 fn normalize_allowed_email_domain(domain: &str) -> anyhow::Result<String> {

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1309,7 +1309,7 @@ impl AuthOauthConfig {
             if !provider.scopes.iter().any(|scope| scope == "user:email") {
                 bail!("oauth provider `{provider_key}` scopes must include `user:email`");
             }
-            let _ = normalize_allowed_email_domains(
+            validate_allowed_email_domains(
                 &provider.allowed_email_domains,
                 &format!("oauth provider `{provider_key}` allowed_email_domains"),
             )?;
@@ -2480,6 +2480,18 @@ fn normalize_allowed_email_domains(
     }
 
     Ok(normalized_domains)
+}
+
+fn validate_allowed_email_domains(domains: &[String], context: &str) -> anyhow::Result<()> {
+    let mut seen = std::collections::BTreeSet::new();
+    for domain in domains {
+        let normalized = normalize_allowed_email_domain(domain)
+            .with_context(|| format!("{context} entry `{domain}`"))?;
+        if !seen.insert(normalized.clone()) {
+            bail!("{context} contains duplicate domain `{normalized}`");
+        }
+    }
+    Ok(())
 }
 
 fn normalize_allowed_email_domain(domain: &str) -> anyhow::Result<String> {

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -1567,6 +1567,14 @@ pub async fn oauth_callback_github(
             return Ok(oidc_error_redirect("unmatched_identity"));
         }
     };
+    if !github_email_domain_allowed(&email, &provider.allowed_email_domains) {
+        tracing::warn!(
+            provider_key = %provider.provider_key,
+            email_domain = %email_domain_for_log(&email),
+            "github oauth email domain is not allowed"
+        );
+        return Ok(oidc_error_redirect("unmatched_identity"));
+    }
 
     let user = if let Some(oauth_auth) = state
         .store
@@ -1804,6 +1812,26 @@ async fn github_primary_verified_email(access_token: &str) -> Result<String, App
         })?;
 
     normalize_email(&selected.email)
+}
+
+fn github_email_domain_allowed(email: &str, allowed_domains: &[String]) -> bool {
+    if allowed_domains.is_empty() {
+        return true;
+    }
+
+    let Some(domain) = email.rsplit_once('@').map(|(_, domain)| domain) else {
+        return false;
+    };
+    allowed_domains
+        .iter()
+        .any(|allowed| domain.eq_ignore_ascii_case(allowed))
+}
+
+fn email_domain_for_log(email: &str) -> String {
+    email
+        .rsplit_once('@')
+        .map(|(_, domain)| domain.to_string())
+        .unwrap_or_else(|| "<invalid>".to_string())
 }
 
 async fn create_jit_oidc_user(
@@ -3020,4 +3048,24 @@ pub async fn list_public_oauth_providers(
             })
             .collect(),
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::github_email_domain_allowed;
+
+    #[test]
+    fn github_email_domain_policy_allows_empty_policy() {
+        assert!(github_email_domain_allowed("alice@anywhere.example", &[]));
+    }
+
+    #[test]
+    fn github_email_domain_policy_matches_exact_domain_case_insensitively() {
+        let allowed = vec!["test.com".to_string()];
+
+        assert!(github_email_domain_allowed("alice@Test.com", &allowed));
+        assert!(!github_email_domain_allowed("alice@not-test.com", &allowed));
+        assert!(!github_email_domain_allowed("alice@eviltest.com", &allowed));
+        assert!(!github_email_domain_allowed("invalid-email", &allowed));
+    }
 }

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -1567,10 +1567,11 @@ pub async fn oauth_callback_github(
             return Ok(oidc_error_redirect("unmatched_identity"));
         }
     };
-    if !github_email_domain_allowed(&email, &provider.allowed_email_domains) {
+    let email_domain = github_email_domain(&email);
+    if !github_email_domain_allowed_domain(email_domain, &provider.allowed_email_domains) {
         tracing::warn!(
             provider_key = %provider.provider_key,
-            email_domain = %email_domain_for_log(&email),
+            email_domain = %email_domain.unwrap_or("<invalid>"),
             "github oauth email domain is not allowed"
         );
         return Ok(oidc_error_redirect("unmatched_identity"));
@@ -1814,12 +1815,20 @@ async fn github_primary_verified_email(access_token: &str) -> Result<String, App
     normalize_email(&selected.email)
 }
 
+#[cfg(test)]
 fn github_email_domain_allowed(email: &str, allowed_domains: &[String]) -> bool {
+    github_email_domain_allowed_domain(github_email_domain(email), allowed_domains)
+}
+
+fn github_email_domain_allowed_domain(
+    email_domain: Option<&str>,
+    allowed_domains: &[String],
+) -> bool {
     if allowed_domains.is_empty() {
         return true;
     }
 
-    let Some(domain) = email.rsplit_once('@').map(|(_, domain)| domain) else {
+    let Some(domain) = email_domain else {
         return false;
     };
     allowed_domains
@@ -1827,11 +1836,8 @@ fn github_email_domain_allowed(email: &str, allowed_domains: &[String]) -> bool 
         .any(|allowed| domain.eq_ignore_ascii_case(allowed))
 }
 
-fn email_domain_for_log(email: &str) -> String {
-    email
-        .rsplit_once('@')
-        .map(|(_, domain)| domain.to_string())
-        .unwrap_or_else(|| "<invalid>".to_string())
+fn github_email_domain(email: &str) -> Option<&str> {
+    email.rsplit_once('@').map(|(_, domain)| domain)
 }
 
 async fn create_jit_oidc_user(

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -3072,6 +3072,7 @@ mod tests {
         assert!(github_email_domain_allowed("alice@Test.com", &allowed));
         assert!(!github_email_domain_allowed("alice@not-test.com", &allowed));
         assert!(!github_email_domain_allowed("alice@eviltest.com", &allowed));
+        assert!(!github_email_domain_allowed("alice@sub.test.com", &allowed));
         assert!(!github_email_domain_allowed("invalid-email", &allowed));
     }
 }

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -1837,7 +1837,9 @@ fn github_email_domain_allowed_domain(
 }
 
 fn github_email_domain(email: &str) -> Option<&str> {
-    email.rsplit_once('@').map(|(_, domain)| domain)
+    email
+        .rsplit_once('@')
+        .and_then(|(_, domain)| (!domain.is_empty()).then_some(domain))
 }
 
 async fn create_jit_oidc_user(
@@ -3073,6 +3075,7 @@ mod tests {
         assert!(!github_email_domain_allowed("alice@not-test.com", &allowed));
         assert!(!github_email_domain_allowed("alice@eviltest.com", &allowed));
         assert!(!github_email_domain_allowed("alice@sub.test.com", &allowed));
+        assert!(!github_email_domain_allowed("alice@", &allowed));
         assert!(!github_email_domain_allowed("invalid-email", &allowed));
     }
 }

--- a/deploy/config/gateway.local.yaml
+++ b/deploy/config/gateway.local.yaml
@@ -46,6 +46,10 @@ auth:
         scopes:
           - read:user
           - user:email
+        # Optional: restrict GitHub JIT/invite activation to verified primary
+        # email domains owned by your organization.
+        # allowed_email_domains:
+        #   - example.com
         enabled: false
         jit:
           enabled: false
@@ -63,11 +67,6 @@ request_logging:
 teams:
   - key: platform
     name: Platform
-    budget:
-      cadence: monthly
-      amount_usd: "500.0000"
-      hard_limit: true
-      timezone: UTC
 
 users:
   - name: Platform Admin

--- a/deploy/config/gateway.local.yaml
+++ b/deploy/config/gateway.local.yaml
@@ -46,8 +46,8 @@ auth:
         scopes:
           - read:user
           - user:email
-        # Optional: restrict GitHub JIT/invite activation to verified primary
-        # email domains owned by your organization.
+        # Optional: restrict GitHub OAuth sign-in, invite activation, and JIT
+        # provisioning to verified primary email domains owned by your organization.
         # allowed_email_domains:
         #   - example.com
         enabled: false

--- a/deploy/config/gateway.yaml
+++ b/deploy/config/gateway.yaml
@@ -46,6 +46,10 @@ auth:
         scopes:
           - read:user
           - user:email
+        # Optional: restrict GitHub JIT/invite activation to verified primary
+        # email domains owned by your organization.
+        # allowed_email_domains:
+        #   - example.com
         enabled: false
         jit:
           enabled: false
@@ -63,11 +67,6 @@ request_logging:
 teams:
   - key: platform
     name: Platform
-    budget:
-      cadence: monthly
-      amount_usd: "500.0000"
-      hard_limit: true
-      timezone: UTC
 
 users:
   - name: Platform Admin

--- a/deploy/config/gateway.yaml
+++ b/deploy/config/gateway.yaml
@@ -46,8 +46,8 @@ auth:
         scopes:
           - read:user
           - user:email
-        # Optional: restrict GitHub JIT/invite activation to verified primary
-        # email domains owned by your organization.
+        # Optional: restrict GitHub OAuth sign-in, invite activation, and JIT
+        # provisioning to verified primary email domains owned by your organization.
         # allowed_email_domains:
         #   - example.com
         enabled: false

--- a/docs/access/github-oauth-admin-setup.md
+++ b/docs/access/github-oauth-admin-setup.md
@@ -48,6 +48,8 @@ auth:
         scopes:
           - read:user
           - user:email
+        allowed_email_domains:
+          - example.com
         enabled: true
         jit:
           enabled: false
@@ -55,17 +57,23 @@ auth:
           request_logging_enabled: true
 ```
 
+`allowed_email_domains` is optional. Leave it empty or omit it to allow the existing invite/JIT rules to decide access without an email-domain guardrail. When it is set, GitHub OAuth can only complete for accounts whose verified primary email domain exactly matches one of the configured domains.
+
 ## Identity Mapping Behavior
 
 Direct GitHub OAuth uses:
 
 - provider subject: GitHub numeric user id (`/user`)
 - email for invite/JIT matching: verified primary email (`/user/emails`)
+- optional domain restriction: exact domain part of the verified primary email
 
 Oceans does **not** auto-link existing password users by email.
 
 ## Security Notes
 
 - Keep `jit.enabled: false` unless you explicitly want auto-provisioning.
+- When `jit.enabled: true`, set `allowed_email_domains` unless every verified GitHub email address should be eligible for JIT provisioning.
+- Domain checks run after GitHub returns the verified primary email and before OAuth link creation, invited-user activation, JIT user creation, or session cookie issuance.
+- Domain matching is case-insensitive and exact on the email domain. `alice@example.com` matches `example.com`; `alice@evil-example.com` does not.
 - Do not grant broad admin roles through JIT unless constrained by your org policy.
 - Rotate GitHub client secrets if leaked.

--- a/docs/access/oidc-and-sso-status.md
+++ b/docs/access/oidc-and-sso-status.md
@@ -17,6 +17,7 @@ The OIDC/OAuth flow includes:
 - `/api/v1/auth/oauth/callback/github` consumes one-time state, exchanges the code with GitHub, resolves verified email + numeric subject, and issues `ogw_session`
 - invited/config-declared OIDC users activate on first successful provider login
 - provider-specific JIT user creation can assign explicit global role, team membership, and request logging defaults
+- direct GitHub OAuth can restrict sign-in and JIT provisioning to configured verified email domains
 - local Authentik compose profiles provide a repeatable manual IdP fixture
 
 ## Security Boundary
@@ -28,6 +29,7 @@ Account linking is intentionally conservative:
 - existing `(provider, sub)` links win
 - invited/config-declared OIDC users with matching normalized email and provider link are activated and linked
 - unmatched identities use the provider's explicit JIT policy
+- GitHub OAuth `allowed_email_domains` is enforced before account linking, invite activation, JIT creation, or session issuance
 - existing password/local users with the same email are rejected instead of auto-linked
 
 ## Practical Admin Impact

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -330,8 +330,8 @@ Important GitHub OAuth provider fields:
 - `allowed_email_domains`
   - optional
   - defaults to an empty list, which keeps the existing invite/JIT behavior without a domain restriction
-  - entries are normalized to lowercase
-  - empty entries, email addresses, URLs, wildcards, invalid domain names, and duplicates after normalization are rejected at startup
+  - entries are normalized by trimming whitespace, converting to lowercase, and removing trailing dots
+  - empty entries, email addresses, URLs, wildcards, single-label values, names with invalid DNS characters, and duplicates after normalization are rejected at startup
   - matching is case-insensitive and exact on the verified primary email's domain part
 - `enabled`
 - `jit`

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -101,11 +101,6 @@ providers:
 teams:
   - key: platform
     name: Platform
-    budget:
-      cadence: monthly
-      amount_usd: "500.0000"
-      hard_limit: true
-      timezone: UTC
 
 users:
   - name: Platform Admin
@@ -317,10 +312,29 @@ auth:
         client_id: env.GITHUB_OAUTH_CLIENT_ID
         client_secret: env.GITHUB_OAUTH_CLIENT_SECRET
         scopes: [read:user, user:email]
+        allowed_email_domains:
+          - example.com
         enabled: true
         jit:
           enabled: false
 ```
+
+Important GitHub OAuth provider fields:
+
+- `key`: gateway-local provider key used by invited OAuth users
+- `label`: admin-login display label
+- `provider_type`: must be `github`
+- `client_id`
+- `client_secret`
+- `scopes`: must include `user:email`
+- `allowed_email_domains`
+  - optional
+  - defaults to an empty list, which keeps the existing invite/JIT behavior without a domain restriction
+  - entries are normalized to lowercase
+  - empty entries, email addresses, URLs, wildcards, invalid domain names, and duplicates after normalization are rejected at startup
+  - matching is case-insensitive and exact on the verified primary email's domain part
+- `enabled`
+- `jit`
 
 For GitHub setup steps and callback URL rules, see [GitHub OAuth SSO Setup for Admins](../access/github-oauth-admin-setup.md).
 
@@ -334,7 +348,6 @@ Important `teams` fields:
 
 - `key`
 - `name`
-- `budget`
 
 Important `users` fields:
 
@@ -361,14 +374,15 @@ Validation rules that matter:
 - membership roles can be `admin` or `member`
 - membership role `owner` is rejected
 - budget amounts must be non-negative
+- teams are not budget principals
 
 Seed semantics that matter:
 
 - listed teams are upserted by `teams[*].key`
 - listed users are upserted by normalized email
 - new config-seeded users are created as `invited`
-- listed membership and active-budget state is reconciled for listed users and teams
-- omitting a `budget` block for a listed user or team deactivates that owner's active budget
+- listed membership and active-budget state is reconciled for listed users
+- omitting a `budget` block for a listed user deactivates that user's active budget
 - unlisted teams and users are left untouched
 
 OIDC and OAuth provider existence is validated at seed time against enabled runtime providers, not YAML parse time.

--- a/docs/reference/data-relationships.md
+++ b/docs/reference/data-relationships.md
@@ -84,8 +84,14 @@ Compatibility metadata is not a provider config fallback and is not an `extra_bo
 - `user_oidc_auth`
   - Key columns: `user_id`, `oidc_provider_id`, `subject`, `email_claim`
   - Notes: unique `(oidc_provider_id, subject)`
+- `oauth_providers`
+  - Key columns: `oauth_provider_id`, `provider_key`, `provider_type`, `client_id`, `scopes_json`, `allowed_email_domains_json`, `enabled`
+  - Notes: direct OAuth currently supports GitHub; `allowed_email_domains_json` stores the normalized verified-email-domain allowlist enforced before OAuth link creation, invite activation, JIT creation, or session issuance
+- `user_oauth_links`
+  - Purpose: pre-provisioned relationship between a user and the OAuth provider they are allowed to activate against
 - `user_oauth_auth`
-  - Key columns: `user_id`, `oauth_provider`, `subject`
+  - Key columns: `user_id`, `oauth_provider_id`, `subject`, `email_claim`
+  - Notes: unique `(oauth_provider_id, subject)`
 - `user_oidc_links`
   - Purpose: pre-provisioned relationship between a user and the OIDC provider they are allowed to activate against
 


### PR DESCRIPTION
## Description

Add a configurable GitHub OAuth email-domain guardrail for direct SSO providers.

- Summary of changes
  - Adds `auth.oauth.providers[].allowed_email_domains` for GitHub OAuth providers.
  - Normalizes configured domains, rejects invalid or duplicate entries at startup, and persists the policy in OAuth provider rows for libsql and PostgreSQL.
  - Enforces the policy after GitHub returns the verified primary email and before OAuth linking, invite activation, JIT user creation, or session issuance.
  - Updates GitHub SSO, configuration, SSO overview, data relationship docs, and deploy config examples.
  - Removes stale team-budget examples from config docs/deploy samples so user-facing budget docs stay aligned with the current user/service-account/user-model taxonomy.

- Why this approach was chosen
  - The policy belongs to the OAuth provider record so the callback can enforce the same seeded runtime state used for client credentials, scopes, and JIT policy.
  - The enforcement point keeps current invited-user and JIT behavior unchanged for empty allowlists while preventing disallowed domains from mutating identity state.
  - Duplicate domains are treated as startup errors because this is security policy input.

- How it works
  - Config parsing accepts an optional `allowed_email_domains` list.
  - Startup validation normalizes domains to lowercase, trims a trailing dot, and rejects empty, email-shaped, URL-shaped, wildcard, invalid, or duplicate values.
  - A V32 forward migration adds `allowed_email_domains_json` to `oauth_providers` for both supported backends.
  - GitHub callback compares the exact domain part of the normalized verified primary email against the provider allowlist.

- Risks, tradeoffs, and alternatives considered
  - This is an email-domain boundary, not GitHub organization or team membership verification.
  - Disallowed domains reuse the existing `unmatched_identity` redirect reason to avoid exposing extra policy detail in the login redirect.
  - Postgres migration/runtime coverage still needs the repository's Postgres-specific suites before merge.

- Additional context for reviewers
  - Addresses GitHub issue #182.
  - A read-only multi-agent review found no correctness, architecture, security, or performance findings. Low simplification notes were addressed in follow-up commit `00d41e6`.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional checks run:

- [x] `cargo test -p gateway --lib allowed_email_domain --quiet`
- [x] `cargo test -p gateway --lib github_oauth --quiet`
- [x] `cargo test -p gateway-store libsql_seed_round_trips_oauth_provider_allowed_email_domains --quiet`
- [x] `cargo test -p gateway-store migration_registry_versions_are_unique_and_sorted --quiet`
- [x] `cd docs && mise run check`
