### PR TITLE
fix(gateway): include usage in Anthropic stream deltas

### DIFF
--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -1577,6 +1577,38 @@ fn map_anthropic_usage(value: &Value) -> Option<Value> {
     }))
 }
 
+fn map_anthropic_stream_usage(value: &Value) -> Option<Value> {
+    let usage = value
+        .get("usage")
+        .or_else(|| {
+            value
+                .get("message")
+                .and_then(|message| message.get("usage"))
+        })?
+        .as_object()?;
+    let mut mapped = Map::new();
+    if let Some(prompt) = usage.get("input_tokens").and_then(Value::as_i64) {
+        mapped.insert("prompt_tokens".to_string(), json!(prompt));
+    }
+    if let Some(completion) = usage.get("output_tokens").and_then(Value::as_i64) {
+        mapped.insert("completion_tokens".to_string(), json!(completion));
+    }
+    if let Some(total) = usage.get("total_tokens").and_then(Value::as_i64) {
+        mapped.insert("total_tokens".to_string(), json!(total));
+    } else if let (Some(prompt), Some(completion)) = (
+        mapped.get("prompt_tokens").and_then(Value::as_i64),
+        mapped.get("completion_tokens").and_then(Value::as_i64),
+    ) {
+        mapped.insert("total_tokens".to_string(), json!(prompt + completion));
+    }
+
+    if mapped.is_empty() {
+        None
+    } else {
+        Some(Value::Object(mapped))
+    }
+}
+
 fn extract_google_candidate_text(candidate: &Value) -> String {
     candidate
         .get("content")
@@ -1804,7 +1836,7 @@ where
 
                 match kind {
                     "message_start" if !role_emitted => {
-                        let delta = openai_chunk(
+                        let mut delta = openai_chunk(
                             &stream_id,
                             created,
                             &model,
@@ -1812,6 +1844,9 @@ where
                             None,
                             None,
                         );
+                        if let Some(usage) = map_anthropic_stream_usage(&payload) {
+                            delta["usage"] = usage;
+                        }
                         yield Ok(openai_sse_chunk(&delta));
                         role_emitted = true;
                     }
@@ -1971,13 +2006,14 @@ where
                         }
                     }
                     "message_delta" => {
+                        let usage = map_anthropic_stream_usage(&payload);
                         if let Some(reason) = payload
                             .get("delta")
                             .and_then(Value::as_object)
                             .and_then(|delta| delta.get("stop_reason"))
                             .and_then(Value::as_str)
                         {
-                            let finish = openai_chunk(
+                            let mut finish = openai_chunk(
                                 &stream_id,
                                 created,
                                 &model,
@@ -1985,8 +2021,18 @@ where
                                 None,
                                 Some(map_anthropic_finish_reason(reason)),
                             );
+                            if let Some(usage) = usage {
+                                finish["usage"] = usage;
+                            }
                             yield Ok(openai_sse_chunk(&finish));
                             finish_emitted = true;
+                        } else if let Some(usage) = usage {
+                            yield Ok(openai_sse_chunk(&openai_usage_chunk(
+                                &stream_id,
+                                created,
+                                &model,
+                                usage,
+                            )));
                         }
                     }
                     "message_stop" if !finish_emitted => {
@@ -2158,6 +2204,17 @@ fn openai_delta_chunk(
             "delta": delta,
             "finish_reason": finish_reason
         }]
+    })
+}
+
+fn openai_usage_chunk(id: &str, created: i64, model: &str, usage: Value) -> Value {
+    json!({
+        "id": id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [],
+        "usage": usage
     })
 }
 
@@ -3247,6 +3304,40 @@ data: {"type":"vertex_event"}
         assert!(rendered.contains("data: [DONE]"));
     }
 
+    #[tokio::test]
+    async fn anthropic_stream_preserves_usage_events() {
+        let upstream = stream::iter(vec![Ok(Bytes::from(concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":9,\"output_tokens\":0}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n"
+        )))]);
+        let stream = super::normalize_anthropic_stream(
+            upstream,
+            "chatcmpl-test".to_string(),
+            1,
+            "fast".to_string(),
+        );
+        let bytes: Vec<_> = stream.collect().await;
+        let rendered = bytes
+            .into_iter()
+            .map(|item| String::from_utf8(item.expect("chunk").to_vec()).expect("utf8"))
+            .collect::<String>();
+        let events = openai_stream_events(&rendered);
+
+        assert!(events.iter().any(|event| {
+            event["usage"]["prompt_tokens"] == json!(9)
+                && event["usage"]["completion_tokens"] == json!(0)
+                && event["usage"]["total_tokens"] == json!(9)
+        }));
+        assert!(events.iter().any(|event| {
+            event["choices"][0]["finish_reason"] == json!("stop")
+                && event["usage"]["completion_tokens"] == json!(2)
+        }));
+    }
+
     fn vertex_provider_for_test(api_host: String) -> VertexProvider {
         VertexProvider::new(VertexProviderConfig {
             provider_key: "vertex-prod".to_string(),
@@ -3278,6 +3369,19 @@ data: {"type":"vertex_event"}
             axum::serve(listener, app).await.expect("serve");
         });
         addr.to_string()
+    }
+
+    fn openai_stream_events(rendered: &str) -> Vec<Value> {
+        rendered
+            .split("\n\n")
+            .filter_map(|frame| {
+                frame
+                    .lines()
+                    .find_map(|line| line.strip_prefix("data: "))
+                    .filter(|data| *data != "[DONE]")
+                    .and_then(|data| serde_json::from_str::<Value>(data).ok())
+            })
+            .collect()
     }
 
     #[tokio::test]

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -1609,6 +1609,45 @@ fn map_anthropic_stream_usage(value: &Value) -> Option<Value> {
     }
 }
 
+fn merge_openai_stream_usage(latest: &mut Option<Value>, usage: &Value) -> Value {
+    let usage = openai_usage_with_known_fields(usage.clone(), latest.as_ref());
+    *latest = Some(usage.clone());
+    usage
+}
+
+fn openai_usage_with_known_fields(usage: Value, latest: Option<&Value>) -> Value {
+    let prompt_tokens = merged_usage_counter(&usage, latest, "prompt_tokens");
+    let completion_tokens = merged_usage_counter(&usage, latest, "completion_tokens");
+    let total_tokens = match (prompt_tokens, completion_tokens) {
+        (Some(prompt), Some(completion)) => prompt.saturating_add(completion),
+        _ => merged_usage_counter(&usage, latest, "total_tokens").unwrap_or(0),
+    };
+
+    let mut object = usage.as_object().cloned().unwrap_or_default();
+    if let Some(prompt_tokens) = prompt_tokens {
+        object.insert("prompt_tokens".to_string(), json!(prompt_tokens));
+    }
+    if let Some(completion_tokens) = completion_tokens {
+        object.insert("completion_tokens".to_string(), json!(completion_tokens));
+    }
+    object.insert("total_tokens".to_string(), json!(total_tokens));
+    Value::Object(object)
+}
+
+fn merged_usage_counter(usage: &Value, latest: Option<&Value>, field: &str) -> Option<i64> {
+    let incoming = usage.get(field).and_then(Value::as_i64);
+    let previous = latest
+        .and_then(|latest| latest.get(field))
+        .and_then(Value::as_i64);
+
+    match (incoming, previous) {
+        (Some(incoming), Some(previous)) => Some(incoming.max(previous)),
+        (Some(incoming), None) => Some(incoming),
+        (None, Some(previous)) => Some(previous),
+        (None, None) => None,
+    }
+}
+
 fn extract_google_candidate_text(candidate: &Value) -> String {
     candidate
         .get("content")
@@ -1792,12 +1831,15 @@ fn normalize_anthropic_stream<S>(
 where
     S: futures_util::stream::Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
 {
+    // Split plan: move Anthropic SSE state, usage merging, and event mapping into
+    // a focused Vertex Anthropic stream module when this normalizer next grows.
     Box::pin(stream! {
         let mut parser = SseEventParser::default();
         let mut role_emitted = false;
         let mut finish_emitted = false;
         let mut stream_failed = false;
         let mut tool_block_indexes = BTreeMap::<i64, i64>::new();
+        let mut latest_usage = None;
         futures_util::pin_mut!(upstream);
 
         'stream_loop: while let Some(chunk) = upstream.next().await {
@@ -1845,6 +1887,7 @@ where
                             None,
                         );
                         if let Some(usage) = map_anthropic_stream_usage(&payload) {
+                            let usage = merge_openai_stream_usage(&mut latest_usage, &usage);
                             delta["usage"] = usage;
                         }
                         yield Ok(openai_sse_chunk(&delta));
@@ -2006,7 +2049,8 @@ where
                         }
                     }
                     "message_delta" => {
-                        let usage = map_anthropic_stream_usage(&payload);
+                        let usage = map_anthropic_stream_usage(&payload)
+                            .map(|usage| merge_openai_stream_usage(&mut latest_usage, &usage));
                         if let Some(reason) = payload
                             .get("delta")
                             .and_then(Value::as_object)
@@ -3334,7 +3378,9 @@ data: {"type":"vertex_event"}
         }));
         assert!(events.iter().any(|event| {
             event["choices"][0]["finish_reason"] == json!("stop")
+                && event["usage"]["prompt_tokens"] == json!(9)
                 && event["usage"]["completion_tokens"] == json!(2)
+                && event["usage"]["total_tokens"] == json!(11)
         }));
     }
 

--- a/crates/gateway-service/src/request_logging.rs
+++ b/crates/gateway-service/src/request_logging.rs
@@ -298,11 +298,31 @@ fn stream_failure_from_value(value: &Value) -> Option<StreamFailureSummary> {
 }
 
 fn usage_value_from_stream_event(value: &Value) -> Option<&Value> {
-    value.get("usage").or_else(|| {
+    let usage = value.get("usage").or_else(|| {
         value
             .get("response")
             .and_then(|response| response.get("usage"))
-    })
+    })?;
+    if is_synthetic_anthropic_zero_usage(value, usage) {
+        return None;
+    }
+    Some(usage)
+}
+
+fn is_synthetic_anthropic_zero_usage(value: &Value, usage: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("message_delta")
+        && value
+            .get("delta")
+            .and_then(|delta| delta.get("stop_reason"))
+            .and_then(Value::as_str)
+            .is_some()
+        && usage.get("input_tokens").and_then(Value::as_i64) == Some(0)
+        && usage.get("output_tokens").and_then(Value::as_i64) == Some(0)
+        && usage
+            .get("total_tokens")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            == 0
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2149,6 +2169,24 @@ data: {"usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9}}
                 "total_tokens": 9
             }))
         );
+    }
+
+    #[test]
+    fn collector_ignores_synthetic_anthropic_zero_usage_fallback() {
+        let mut collector = StreamResponseCollector::default();
+
+        collector.observe_chunk(
+            br#"event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#,
+        );
+        collector.finish();
+
+        assert_eq!(collector.usage(), None);
     }
 
     #[test]

--- a/crates/gateway/src/http/anthropic_stream.rs
+++ b/crates/gateway/src/http/anthropic_stream.rs
@@ -26,6 +26,7 @@ pub(super) fn anthropic_messages_stream_from_openai(
         let mut parser = SseEventParser::default();
         let mut state = AnthropicStreamState::default();
         let mut failed = false;
+        let mut completed = false;
         futures_util::pin_mut!(upstream);
 
         while let Some(chunk) = upstream.next().await {
@@ -48,8 +49,12 @@ pub(super) fn anthropic_messages_stream_from_openai(
 
             for event in events {
                 let payload = event.data.trim();
-                if payload.is_empty() || payload == "[DONE]" {
+                if payload.is_empty() {
                     continue;
+                }
+                if payload == "[DONE]" {
+                    completed = true;
+                    break;
                 }
                 let Ok(value) = serde_json::from_str::<Value>(payload) else {
                     continue;
@@ -63,7 +68,7 @@ pub(super) fn anthropic_messages_stream_from_openai(
                     yield Ok(outbound);
                 }
             }
-            if failed {
+            if failed || completed {
                 break;
             }
         }
@@ -243,29 +248,26 @@ fn merge_anthropic_stream_usage(latest: &mut Option<Value>, usage: &Value) {
 }
 
 fn usage_with_known_fields(usage: Value, latest: Option<&Value>) -> Value {
-    let input_tokens = usage
-        .get("input_tokens")
-        .and_then(Value::as_i64)
-        .or_else(|| {
-            latest
-                .and_then(|latest| latest.get("input_tokens"))
-                .and_then(Value::as_i64)
-        })
-        .unwrap_or(0);
-    let output_tokens = usage
-        .get("output_tokens")
-        .and_then(Value::as_i64)
-        .or_else(|| {
-            latest
-                .and_then(|latest| latest.get("output_tokens"))
-                .and_then(Value::as_i64)
-        })
-        .unwrap_or(0);
-
+    let input_tokens = merged_counter(&usage, latest, "input_tokens");
+    let output_tokens = merged_counter(&usage, latest, "output_tokens");
     let mut object = usage.as_object().cloned().unwrap_or_default();
     object.insert("input_tokens".to_string(), json!(input_tokens));
     object.insert("output_tokens".to_string(), json!(output_tokens));
     Value::Object(object)
+}
+
+fn merged_counter(usage: &Value, latest: Option<&Value>, field: &str) -> i64 {
+    let incoming = usage.get(field).and_then(Value::as_i64);
+    let previous = latest
+        .and_then(|latest| latest.get(field))
+        .and_then(Value::as_i64);
+
+    match (incoming, previous) {
+        (Some(incoming), Some(previous)) => incoming.max(previous),
+        (Some(incoming), None) => incoming,
+        (None, Some(previous)) => previous,
+        (None, None) => 0,
+    }
 }
 
 fn fallback_anthropic_stream_usage() -> Value {
@@ -490,11 +492,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn anthropic_messages_stream_adapter_finalizes_on_done_marker() {
+        let upstream: ProviderStream = Box::pin(
+            stream::iter(vec![Ok(Bytes::from(concat!(
+                "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n",
+                "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                "data: [DONE]\n\n"
+            )))])
+            .chain(stream::pending()),
+        );
+
+        let rendered = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            render_stream(upstream),
+        )
+        .await
+        .expect("adapter should finalize on [DONE]");
+
+        assert!(rendered.contains("event: message_delta"));
+        assert!(rendered.contains("event: message_stop"));
+    }
+
+    #[tokio::test]
     async fn anthropic_messages_stream_adapter_merges_partial_usage_for_final_delta() {
         let upstream: ProviderStream = Box::pin(stream::iter(vec![Ok(Bytes::from(concat!(
             "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":0,\"total_tokens\":11}}\n\n",
             "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
-            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":3}}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":0,\"completion_tokens\":3}}\n\n",
             "data: [DONE]\n\n"
         )))]));
 

--- a/crates/gateway/src/http/anthropic_stream.rs
+++ b/crates/gateway/src/http/anthropic_stream.rs
@@ -14,6 +14,8 @@ struct AnthropicStreamState {
     next_block_index: i64,
     text_block_index: Option<i64>,
     tool_block_indexes: BTreeMap<i64, i64>,
+    latest_usage: Option<Value>,
+    pending_stop_reason: Option<String>,
 }
 
 pub(super) fn anthropic_messages_stream_from_openai(
@@ -73,6 +75,9 @@ pub(super) fn anthropic_messages_stream_from_openai(
                 for outbound in finish_anthropic_stream_blocks(&mut state) {
                     yield Ok(outbound);
                 }
+                if let Some(outbound) = pending_anthropic_message_delta(&mut state) {
+                    yield Ok(outbound);
+                }
                 yield Ok(anthropic_sse_chunk("message_stop", json!({"type":"message_stop"})));
             }
         }
@@ -86,13 +91,16 @@ fn anthropic_events_from_openai_chunk(
 ) -> Vec<Bytes> {
     let mut events = Vec::new();
     let usage = anthropic_stream_usage_from_openai(value.get("usage"));
+    if let Some(usage) = usage.as_ref() {
+        merge_anthropic_stream_usage(&mut state.latest_usage, usage);
+    }
     let Some(choice) = value
         .get("choices")
         .and_then(Value::as_array)
         .and_then(|choices| choices.first())
     else {
         if state.message_started {
-            append_anthropic_usage_delta(usage, &mut events);
+            append_anthropic_usage_delta(usage, state, &mut events);
         }
         return events;
     };
@@ -155,19 +163,9 @@ fn anthropic_events_from_openai_chunk(
 
     if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str) {
         events.extend(finish_anthropic_stream_blocks(state));
-        let mut message_delta = json!({
-                "type":"message_delta",
-                "delta": {
-                    "stop_reason": openai_finish_reason_to_anthropic(reason),
-                    "stop_sequence": null
-                }
-        });
-        if let Some(usage) = usage {
-            message_delta["usage"] = usage;
-        }
-        events.push(anthropic_sse_chunk("message_delta", message_delta));
+        state.pending_stop_reason = Some(openai_finish_reason_to_anthropic(reason).to_string());
     } else {
-        append_anthropic_usage_delta(usage, &mut events);
+        append_anthropic_usage_delta(usage, state, &mut events);
     }
 
     events
@@ -202,16 +200,23 @@ fn anthropic_error_event_from_openai_chunk(value: &Value) -> Option<Bytes> {
     ))
 }
 
-fn append_anthropic_usage_delta(usage: Option<Value>, events: &mut Vec<Bytes>) {
+fn append_anthropic_usage_delta(
+    usage: Option<Value>,
+    state: &AnthropicStreamState,
+    events: &mut Vec<Bytes>,
+) {
     let Some(usage) = usage else {
         return;
     };
+    if state.pending_stop_reason.is_some() {
+        return;
+    }
     events.push(anthropic_sse_chunk(
         "message_delta",
         json!({
             "type": "message_delta",
             "delta": {},
-            "usage": usage
+            "usage": usage_with_known_fields(usage, state.latest_usage.as_ref())
         }),
     ));
 }
@@ -230,6 +235,59 @@ fn anthropic_stream_usage_from_openai(value: Option<&Value>) -> Option<Value> {
     } else {
         Some(Value::Object(anthropic_usage))
     }
+}
+
+fn merge_anthropic_stream_usage(latest: &mut Option<Value>, usage: &Value) {
+    let usage = usage_with_known_fields(usage.clone(), latest.as_ref());
+    *latest = Some(usage);
+}
+
+fn usage_with_known_fields(usage: Value, latest: Option<&Value>) -> Value {
+    let input_tokens = usage
+        .get("input_tokens")
+        .and_then(Value::as_i64)
+        .or_else(|| {
+            latest
+                .and_then(|latest| latest.get("input_tokens"))
+                .and_then(Value::as_i64)
+        })
+        .unwrap_or(0);
+    let output_tokens = usage
+        .get("output_tokens")
+        .and_then(Value::as_i64)
+        .or_else(|| {
+            latest
+                .and_then(|latest| latest.get("output_tokens"))
+                .and_then(Value::as_i64)
+        })
+        .unwrap_or(0);
+
+    let mut object = usage.as_object().cloned().unwrap_or_default();
+    object.insert("input_tokens".to_string(), json!(input_tokens));
+    object.insert("output_tokens".to_string(), json!(output_tokens));
+    Value::Object(object)
+}
+
+fn fallback_anthropic_stream_usage() -> Value {
+    json!({
+        "input_tokens": 0,
+        "output_tokens": 0
+    })
+}
+
+fn pending_anthropic_message_delta(state: &mut AnthropicStreamState) -> Option<Bytes> {
+    let stop_reason = state.pending_stop_reason.take()?;
+    Some(anthropic_sse_chunk(
+        "message_delta",
+        json!({
+            "type":"message_delta",
+            "delta": {
+                "stop_reason": stop_reason,
+                "stop_sequence": null
+            },
+            "usage": state.latest_usage.clone().unwrap_or_else(fallback_anthropic_stream_usage)
+        }),
+    ))
 }
 
 fn append_anthropic_tool_delta(
@@ -414,6 +472,35 @@ mod tests {
             collector.usage(),
             Some(&json!({"input_tokens": 3, "output_tokens": 4}))
         );
+    }
+
+    #[tokio::test]
+    async fn anthropic_messages_stream_adapter_final_delta_has_fallback_usage() {
+        let upstream: ProviderStream = Box::pin(stream::iter(vec![Ok(Bytes::from(concat!(
+            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        )))]));
+
+        let rendered = render_stream(upstream).await;
+
+        assert!(rendered.contains("event: message_delta"));
+        assert!(rendered.contains("\"stop_reason\":\"end_turn\""));
+        assert!(rendered.contains("\"usage\":{\"input_tokens\":0,\"output_tokens\":0}"));
+    }
+
+    #[tokio::test]
+    async fn anthropic_messages_stream_adapter_merges_partial_usage_for_final_delta() {
+        let upstream: ProviderStream = Box::pin(stream::iter(vec![Ok(Bytes::from(concat!(
+            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":0,\"total_tokens\":11}}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":3}}\n\n",
+            "data: [DONE]\n\n"
+        )))]));
+
+        let rendered = render_stream(upstream).await;
+
+        assert!(rendered.contains("\"usage\":{\"input_tokens\":11,\"output_tokens\":3}"));
     }
 
     async fn render_stream(upstream: ProviderStream) -> String {


### PR DESCRIPTION
## Description

Fixes Anthropic Messages streaming compatibility for clients that expect `message_delta.usage` on the terminal event.

- Summary of changes
  - Preserve Anthropic/Vertex stream usage from `message_start.message.usage` and `message_delta.usage` in the Vertex normalizer.
  - Track and merge usage in the `/v1/messages` OpenAI-to-Anthropic SSE adapter.
  - Buffer the terminal `message_delta` until stream completion so late usage can be attached.
  - Emit fallback `{ "input_tokens": 0, "output_tokens": 0 }` usage when upstream streams omit usage entirely.
  - Add regression tests for fallback usage, partial usage merging, and Vertex usage preservation.

- Why this approach was chosen
  - The gateway already normalizes provider streams through an OpenAI-shaped intermediate format. Preserving usage there keeps the existing boundary and lets the Anthropic adapter produce a client-compatible final SSE shape.

- How it works
  - Vertex Anthropic SSE usage is mapped to OpenAI-style `usage` chunks.
  - The Anthropic Messages adapter keeps the latest known usage and emits the stop `message_delta` once final stream usage has been observed.

- Risks, tradeoffs, and alternatives considered
  - If an upstream omits usage, the gateway reports zero-valued usage on the terminal Anthropic event. This preserves client compatibility without inventing token counts.
  - Real usage is preserved when the provider sends it.

- Additional context for reviewers
  - This fixes the pi crash: `undefined is not an object (evaluating event.usage.input_tokens)` after an otherwise successful streamed response.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres` (not run; stream-shape-only change, no store or migration behavior)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres` (not run; stream-shape-only change, no store or migration behavior)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke` (not run; stream-shape-only change, no store or migration behavior)
