### PR TITLE
feat(gateway): add multi-model client configs

### DIFF
--- a/crates/admin-ui/web/src/generated/admin-api.ts
+++ b/crates/admin-ui/web/src/generated/admin-api.ts
@@ -500,6 +500,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/models/client-configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["generate_model_client_configs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/observability/harness-usage": {
         parameters: {
             query?: never;
@@ -967,6 +983,7 @@ export interface components {
             blocks: components["schemas"]["AdminModelClientConfigBlockView"][];
             key: string;
             label: string;
+            model_ids: string[];
             notes: string[];
         };
         AdminModelPageView: {
@@ -1412,6 +1429,12 @@ export interface components {
             };
             meta: components["schemas"]["ResponseMeta"];
         };
+        Envelope_GenerateModelClientConfigsResponse: {
+            data: {
+                client_configurations: components["schemas"]["AdminModelClientConfigView"][];
+            };
+            meta: components["schemas"]["ResponseMeta"];
+        };
         Envelope_HarnessUsageView: {
             data: {
                 /** Format: int32 */
@@ -1652,6 +1675,12 @@ export interface components {
                 scope_key: string;
             };
             meta: components["schemas"]["ResponseMeta"];
+        };
+        GenerateModelClientConfigsRequest: {
+            model_keys: string[];
+        };
+        GenerateModelClientConfigsResponse: {
+            client_configurations: components["schemas"]["AdminModelClientConfigView"][];
         };
         HarnessUsageChartHarnessView: {
             agent_harness_key: string;
@@ -3328,6 +3357,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Envelope_AdminModelPageView"];
+                };
+            };
+        };
+    };
+    generate_model_client_configs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GenerateModelClientConfigsRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Envelope_GenerateModelClientConfigsResponse"];
                 };
             };
         };

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -76,14 +76,16 @@ export function ModelsPage() {
     activeKey: string
     clientConfigurations: ModelView['client_configurations']
   } | null>(null)
-  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([])
+  const [selectedModelsById, setSelectedModelsById] = useState<Record<string, ModelView>>({})
   const [isGeneratingConfig, setIsGeneratingConfig] = useState(false)
   const totalPages = Math.max(1, Math.ceil(modelPage.total / modelPage.page_size))
   const selectableModels = modelPage.items.filter((model) => model.client_configurations.length > 0)
-  const selectedModels = modelPage.items.filter((model) => selectedModelIds.includes(model.id))
+  const selectedModels = Object.values(selectedModelsById)
+  const selectedModelIds = Object.keys(selectedModelsById)
   const selectedModelIdSet = new Set(selectedModelIds)
   const allSelectableSelected =
-    selectableModels.length > 0 && selectableModels.every((model) => selectedModelIdSet.has(model.id))
+    selectableModels.length > 0 &&
+    selectableModels.every((model) => selectedModelIdSet.has(model.id))
 
   function navigateToPage(page: number) {
     void router.navigate({
@@ -109,19 +111,30 @@ export function ModelsPage() {
     if (model.client_configurations.length === 0) {
       return
     }
-    setSelectedModelIds((current) =>
-      current.includes(model.id) ? current.filter((id) => id !== model.id) : [...current, model.id],
-    )
+    setSelectedModelsById((current) => {
+      if (current[model.id]) {
+        const { [model.id]: _removed, ...remaining } = current
+        return remaining
+      }
+
+      return { ...current, [model.id]: model }
+    })
   }
 
   function toggleAllSelectableModels() {
-    setSelectedModelIds((current) => {
-      const selectableIds = selectableModels.map((model) => model.id)
-      if (selectableIds.every((id) => current.includes(id))) {
-        return current.filter((id) => !selectableIds.includes(id))
+    setSelectedModelsById((current) => {
+      if (selectableModels.every((model) => current[model.id])) {
+        return Object.fromEntries(
+          Object.entries(current).filter(
+            ([id]) => !selectableModels.some((model) => model.id === id),
+          ),
+        )
       }
 
-      return Array.from(new Set([...current, ...selectableIds]))
+      return Object.fromEntries([
+        ...Object.entries(current),
+        ...selectableModels.map((model) => [model.id, model] as const),
+      ])
     })
   }
 
@@ -181,7 +194,7 @@ export function ModelsPage() {
               Page {modelPage.page} of {totalPages}
             </span>
           </div>
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[color:var(--color-border)] px-3 py-2">
+          <div className="hidden flex-wrap items-center justify-between gap-3 rounded-md border border-[color:var(--color-border)] px-3 py-2 md:flex">
             <span className="text-sm text-[var(--color-text-muted)]">
               {selectedModelIds.length} selected for client config
             </span>
@@ -190,7 +203,7 @@ export function ModelsPage() {
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => setSelectedModelIds([])}
+                onClick={() => setSelectedModelsById({})}
                 disabled={selectedModelIds.length === 0 || isGeneratingConfig}
               >
                 Clear

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -42,7 +42,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { requireAdminSession } from '@/routes/-admin-guard'
-import { getModels } from '@/server/admin-data.functions'
+import { getModelClientConfigs, getModels } from '@/server/admin-data.functions'
 import type { ModelView } from '@/types/api'
 
 const DEFAULT_PAGE = 1
@@ -72,10 +72,18 @@ export function ModelsPage() {
   const search = Route.useSearch()
   const router = useRouter()
   const [configDialog, setConfigDialog] = useState<{
-    model: ModelView
+    models: ModelView[]
     activeKey: string
+    clientConfigurations: ModelView['client_configurations']
   } | null>(null)
+  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([])
+  const [isGeneratingConfig, setIsGeneratingConfig] = useState(false)
   const totalPages = Math.max(1, Math.ceil(modelPage.total / modelPage.page_size))
+  const selectableModels = modelPage.items.filter((model) => model.client_configurations.length > 0)
+  const selectedModels = modelPage.items.filter((model) => selectedModelIds.includes(model.id))
+  const selectedModelIdSet = new Set(selectedModelIds)
+  const allSelectableSelected =
+    selectableModels.length > 0 && selectableModels.every((model) => selectedModelIdSet.has(model.id))
 
   function navigateToPage(page: number) {
     void router.navigate({
@@ -97,19 +105,62 @@ export function ModelsPage() {
     }
   }
 
-  function openClientConfig(model: ModelView) {
-    const firstConfig = model.client_configurations[0]
-    if (!firstConfig) {
+  function toggleModelSelection(model: ModelView) {
+    if (model.client_configurations.length === 0) {
       return
     }
-    setConfigDialog({ model, activeKey: firstConfig.key })
+    setSelectedModelIds((current) =>
+      current.includes(model.id) ? current.filter((id) => id !== model.id) : [...current, model.id],
+    )
+  }
+
+  function toggleAllSelectableModels() {
+    setSelectedModelIds((current) => {
+      const selectableIds = selectableModels.map((model) => model.id)
+      if (selectableIds.every((id) => current.includes(id))) {
+        return current.filter((id) => !selectableIds.includes(id))
+      }
+
+      return Array.from(new Set([...current, ...selectableIds]))
+    })
+  }
+
+  async function openClientConfig(models: ModelView[]) {
+    const modelKeys = models.map((model) => model.id)
+    if (modelKeys.length === 0) {
+      return
+    }
+    setIsGeneratingConfig(true)
+    try {
+      const response = await getModelClientConfigs({ data: { model_keys: modelKeys } })
+      const firstConfig = response.data.client_configurations[0]
+      if (!firstConfig) {
+        toast.error('No client config is available for the selected models')
+        return
+      }
+      setConfigDialog({
+        models,
+        activeKey: firstConfig.key,
+        clientConfigurations: response.data.client_configurations,
+      })
+    } catch {
+      toast.error('Client config generation failed')
+    } finally {
+      setIsGeneratingConfig(false)
+    }
+  }
+
+  function openSelectedClientConfig() {
+    void openClientConfig(selectedModels)
+  }
+
+  function openSingleClientConfig(model: ModelView) {
+    void openClientConfig([model])
   }
 
   const activeClientConfig =
-    configDialog?.model.client_configurations.find(
-      (config) => config.key === configDialog.activeKey,
-    ) ??
-    configDialog?.model.client_configurations[0] ??
+    configDialog?.clientConfigurations.find((config) => config.key === configDialog.activeKey) ??
+    configDialog?.clientConfigurations[0] ??
     null
 
   return (
@@ -129,6 +180,33 @@ export function ModelsPage() {
             <span>
               Page {modelPage.page} of {totalPages}
             </span>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[color:var(--color-border)] px-3 py-2">
+            <span className="text-sm text-[var(--color-text-muted)]">
+              {selectedModelIds.length} selected for client config
+            </span>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setSelectedModelIds([])}
+                disabled={selectedModelIds.length === 0 || isGeneratingConfig}
+              >
+                Clear
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="gap-2"
+                onClick={openSelectedClientConfig}
+                disabled={selectedModelIds.length === 0 || isGeneratingConfig}
+              >
+                <AppIcon icon={CodeIcon} size={14} stroke={1.5} />
+                Generate config
+              </Button>
+            </div>
           </div>
 
           {modelPage.items.length === 0 ? (
@@ -156,31 +234,64 @@ export function ModelsPage() {
                     key={model.id}
                     model={model}
                     onCopy={(modelId) => handleCopyValue(modelId, 'Model ID copied')}
-                    onOpenClientConfig={openClientConfig}
+                    onOpenClientConfig={openSingleClientConfig}
                   />
                 ))}
               </div>
 
-              <div className="hidden min-w-0 md:block" data-testid="models-desktop-table">
+              <div
+                className="hidden min-w-0 overflow-hidden rounded-md border border-[color:var(--color-border)] md:block"
+                data-testid="models-desktop-table"
+              >
                 <Table className="min-w-[92rem] table-fixed">
-                  <TableHeader>
+                  <TableHeader className="bg-[color:var(--color-surface-muted)]">
                     <TableRow>
-                      <TableHead className="bg-card sticky left-0 z-20 w-[16rem] min-w-[16rem] px-4">
-                        Model ID
+                      <TableHead className="w-[3rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        <input
+                          type="checkbox"
+                          aria-label="Select all configurable models"
+                          checked={allSelectableSelected}
+                          disabled={selectableModels.length === 0}
+                          onChange={toggleAllSelectableModels}
+                        />
                       </TableHead>
-                      <TableHead className="w-[16rem] px-4">Upstream Model</TableHead>
-                      <TableHead className="w-[16rem] px-4">Provider</TableHead>
-                      <TableHead className="w-[12rem] px-4">Cost / 1M Tokens</TableHead>
-                      <TableHead className="w-[12rem] px-4">Context Window</TableHead>
-                      <TableHead className="w-[18rem] px-4">Capabilities</TableHead>
-                      <TableHead className="w-[10rem] px-4">Client Config</TableHead>
+                      <TableHead className="sticky left-[3rem] z-20 w-[16rem] min-w-[16rem] bg-[color:var(--color-surface-muted)] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Model id
+                      </TableHead>
+                      <TableHead className="w-[16rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Upstream model
+                      </TableHead>
+                      <TableHead className="w-[16rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Provider
+                      </TableHead>
+                      <TableHead className="w-[12rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Cost / 1M tokens
+                      </TableHead>
+                      <TableHead className="w-[12rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Context window
+                      </TableHead>
+                      <TableHead className="w-[18rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Capabilities
+                      </TableHead>
+                      <TableHead className="w-[10rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
+                        Client config
+                      </TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {modelPage.items.map((model) => (
-                      <TableRow key={model.id} className="align-top">
+                      <TableRow key={model.id} className="align-middle">
+                        <TableCell className="px-3 py-3">
+                          <input
+                            type="checkbox"
+                            aria-label={`Select model ${model.id}`}
+                            checked={selectedModelIdSet.has(model.id)}
+                            disabled={model.client_configurations.length === 0}
+                            onChange={() => toggleModelSelection(model)}
+                          />
+                        </TableCell>
                         <TableCell
-                          className="bg-card sticky left-0 z-10 px-4 shadow-[8px_0_12px_-12px_rgba(0,0,0,0.8)]"
+                          className="bg-card sticky left-[3rem] z-10 px-3 py-3 shadow-[8px_0_12px_-12px_rgba(0,0,0,0.8)]"
                           data-testid={`models-desktop-cell-${model.id}`}
                         >
                           <div className="flex min-w-0 flex-col gap-2 py-1">
@@ -216,7 +327,7 @@ export function ModelsPage() {
                             </div>
                           </div>
                         </TableCell>
-                        <TableCell className="px-4">
+                        <TableCell className="px-3 py-3">
                           <div className="flex min-w-0 flex-col gap-2 py-1">
                             <div className="flex min-w-0 items-center gap-2">
                               <BrandIcon iconKey={model.model_icon_key} size={14} />
@@ -226,7 +337,7 @@ export function ModelsPage() {
                             </div>
                           </div>
                         </TableCell>
-                        <TableCell className="px-4">
+                        <TableCell className="px-3 py-3">
                           <div className="flex min-w-0 flex-col gap-2 py-1">
                             <div className="flex min-w-0 items-center gap-2">
                               <BrandIcon iconKey={model.provider_icon_key} size={14} />
@@ -241,7 +352,7 @@ export function ModelsPage() {
                             ) : null}
                           </div>
                         </TableCell>
-                        <TableCell className="px-4 whitespace-normal">
+                        <TableCell className="px-3 py-3 whitespace-normal">
                           <StackedMetric
                             topLabel="Input"
                             topValue={formatCost(model.input_cost_per_million_tokens_usd_10000)}
@@ -249,7 +360,7 @@ export function ModelsPage() {
                             bottomValue={formatCost(model.output_cost_per_million_tokens_usd_10000)}
                           />
                         </TableCell>
-                        <TableCell className="px-4 whitespace-normal">
+                        <TableCell className="px-3 py-3 whitespace-normal">
                           <StackedMetric
                             topLabel="Input"
                             topValue={formatWindow(
@@ -259,11 +370,11 @@ export function ModelsPage() {
                             bottomValue={formatWindow(model.output_window_tokens)}
                           />
                         </TableCell>
-                        <TableCell className="px-4 whitespace-normal">
+                        <TableCell className="px-3 py-3 whitespace-normal">
                           <CapabilityBadges model={model} />
                         </TableCell>
-                        <TableCell className="px-4 whitespace-normal">
-                          <ClientConfigButton model={model} onOpen={openClientConfig} />
+                        <TableCell className="px-3 py-3 whitespace-normal">
+                          <ClientConfigButton model={model} onOpen={openSingleClientConfig} compact />
                         </TableCell>
                       </TableRow>
                     ))}
@@ -295,9 +406,10 @@ export function ModelsPage() {
       </Card>
 
       <ClientConfigDialog
-        model={configDialog?.model ?? null}
+        models={configDialog?.models ?? []}
         activeKey={configDialog?.activeKey ?? null}
         activeConfig={activeClientConfig}
+        clientConfigurations={configDialog?.clientConfigurations ?? []}
         onActiveKeyChange={(activeKey) =>
           setConfigDialog((current) => (current ? { ...current, activeKey } : current))
         }
@@ -387,9 +499,11 @@ function ModelCard({
 }
 
 function ClientConfigButton({
+  compact = false,
   model,
   onOpen,
 }: {
+  compact?: boolean
   model: ModelView
   onOpen: (model: ModelView) => void
 }) {
@@ -397,47 +511,76 @@ function ClientConfigButton({
     return <span className="text-[var(--color-text-soft)]">—</span>
   }
 
+  const label = `Generate client config for ${model.id}`
+
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      className="gap-2"
-      onClick={() => onOpen(model)}
-    >
-      <AppIcon icon={CodeIcon} size={14} stroke={1.5} />
-      Client config
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant={compact ? 'secondary' : 'outline'}
+          size={compact ? 'icon-sm' : 'sm'}
+          className={compact ? '' : 'gap-2'}
+          aria-label={compact ? label : undefined}
+          onClick={() => onOpen(model)}
+        >
+          <AppIcon icon={CodeIcon} size={14} stroke={1.5} />
+          {compact ? null : 'Client config'}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent sideOffset={6}>{label}</TooltipContent>
+    </Tooltip>
   )
 }
 
 function ClientConfigDialog({
-  model,
+  models,
   activeKey,
   activeConfig,
+  clientConfigurations,
   onActiveKeyChange,
   onCopy,
   onOpenChange,
 }: {
-  model: ModelView | null
+  models: ModelView[]
   activeKey: string | null
   activeConfig: ModelView['client_configurations'][number] | null
+  clientConfigurations: ModelView['client_configurations']
   onActiveKeyChange: (key: string) => void
   onCopy: (content: string) => void
   onOpenChange: (open: boolean) => void
 }) {
+  const isOpen = models.length > 0
+  const firstModel = models[0] ?? null
+  const description =
+    models.length === 1 && firstModel
+      ? `${firstModel.id} via ${providerTypeLabel(firstModel)}`
+      : `${models.length} selected models`
+  const activeModelCount = activeConfig?.model_ids.length ?? 0
+  const activeModelSummary =
+    activeModelCount === 1
+      ? activeConfig?.model_ids[0]
+      : activeModelCount > 1
+        ? `${activeModelCount} models`
+        : 'No applicable models'
+
   return (
-    <Dialog open={model !== null} onOpenChange={onOpenChange}>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-[min(920px,calc(100vw-2rem))] md:min-w-[35vw]">
         <DialogHeader>
           <DialogTitle>Client config</DialogTitle>
-          <DialogDescription>
-            {model ? `${model.id} via ${providerTypeLabel(model)}` : 'Local client configuration'}
-          </DialogDescription>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
-        {model && activeConfig ? (
+        {isOpen && activeConfig ? (
           <div className="flex min-w-0 flex-col gap-4">
+            <div className="flex flex-wrap gap-2">
+              {models.map((model) => (
+                <Badge key={model.id} variant="secondary">
+                  {model.id}
+                </Badge>
+              ))}
+            </div>
             <div className="flex flex-wrap items-center justify-between gap-3">
               <ToggleGroup
                 type="single"
@@ -452,7 +595,7 @@ function ClientConfigDialog({
                 spacing={0}
                 aria-label="Client config"
               >
-                {model.client_configurations.map((config) => (
+                {clientConfigurations.map((config) => (
                   <ToggleGroupItem key={config.key} value={config.key} aria-label={config.label}>
                     {config.label}
                   </ToggleGroupItem>
@@ -470,7 +613,7 @@ function ClientConfigDialog({
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
                       <Badge variant="secondary">{block.filename}</Badge>
                       {block.label !== block.filename ? <span>{block.label}</span> : null}
-                      <span>{model.upstream_model ?? model.resolved_model_key}</span>
+                      <span>{activeModelSummary}</span>
                     </div>
                     <Button
                       type="button"

--- a/crates/admin-ui/web/src/server/admin-data.functions.ts
+++ b/crates/admin-ui/web/src/server/admin-data.functions.ts
@@ -2,6 +2,7 @@ import { createServerFn } from '@tanstack/react-start'
 
 import {
   addTeamMembers,
+  generateModelClientConfigs,
   listApiKeys,
   listModels,
   deactivateUser,
@@ -92,6 +93,12 @@ export const updateGatewayApiKey = createServerFn({ method: 'POST' }).handler(
 export const getModels = createServerFn({ method: 'GET' }).handler(
   async ({ data }: { data?: Parameters<typeof listModels>[0] }) => {
     return listModels(data)
+  },
+)
+
+export const getModelClientConfigs = createServerFn({ method: 'POST' }).handler(
+  async ({ data }: { data: Parameters<typeof generateModelClientConfigs>[0] }) => {
+    return generateModelClientConfigs(data)
   },
 )
 

--- a/crates/admin-ui/web/src/server/admin-data.server.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.ts
@@ -44,6 +44,7 @@ import type {
   McpToolsetToolsPayload,
   McpToolsPayload,
   RecommendedMcpServersPayload,
+  GenerateModelClientConfigsResponse,
   ModelPageView,
   PasswordInviteResult,
   PasswordLoginInput,
@@ -134,6 +135,17 @@ export async function listModels(params?: {
           page_size: params?.page_size,
         },
       },
+    }),
+  )
+}
+
+export async function generateModelClientConfigs(input: {
+  model_keys: string[]
+}): Promise<ApiEnvelope<GenerateModelClientConfigsResponse>> {
+  const client = createGatewayApiClient()
+  return unwrapGatewayResponse(
+    await client.POST('/api/v1/admin/models/client-configs', {
+      body: input,
     }),
   )
 }

--- a/crates/admin-ui/web/src/server/admin-data.server.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.ts
@@ -44,6 +44,7 @@ import type {
   McpToolsetToolsPayload,
   McpToolsPayload,
   RecommendedMcpServersPayload,
+  GenerateModelClientConfigsInput,
   GenerateModelClientConfigsResponse,
   ModelPageView,
   PasswordInviteResult,
@@ -139,9 +140,9 @@ export async function listModels(params?: {
   )
 }
 
-export async function generateModelClientConfigs(input: {
-  model_keys: string[]
-}): Promise<ApiEnvelope<GenerateModelClientConfigsResponse>> {
+export async function generateModelClientConfigs(
+  input: GenerateModelClientConfigsInput,
+): Promise<ApiEnvelope<GenerateModelClientConfigsResponse>> {
   const client = createGatewayApiClient()
   return unwrapGatewayResponse(
     await client.POST('/api/v1/admin/models/client-configs', {

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { ModelPageView } from '@/types/api'
 
 const navigateMock = vi.fn()
+const getModelClientConfigsMock = vi.hoisted(() => vi.fn())
 
 const routeMock = {
   useLoaderData: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('@/server/admin-data.functions', () => ({
   getModels: vi.fn(),
+  getModelClientConfigs: getModelClientConfigsMock,
   getAuthSession: vi.fn(),
 }))
 
@@ -78,6 +80,7 @@ const modelPage: ModelPageView = {
         {
           key: 'opencode',
           label: 'OpenCode',
+          model_ids: ['claude-sonnet'],
           blocks: [
             {
               label: 'opencode.json',
@@ -90,6 +93,7 @@ const modelPage: ModelPageView = {
         {
           key: 'pi',
           label: 'Pi',
+          model_ids: ['claude-sonnet'],
           blocks: [
             {
               label: 'models.json',
@@ -102,6 +106,7 @@ const modelPage: ModelPageView = {
         {
           key: 'claude-code',
           label: 'Claude Code',
+          model_ids: ['claude-sonnet'],
           blocks: [
             {
               label: 'Gateway model settings',
@@ -121,6 +126,7 @@ const modelPage: ModelPageView = {
         {
           key: 'codex',
           label: 'Codex',
+          model_ids: ['claude-sonnet'],
           blocks: [
             {
               label: 'config.toml',
@@ -166,9 +172,11 @@ const modelPage: ModelPageView = {
 
 describe('ModelsPage', () => {
   beforeEach(() => {
+    cleanup()
     routeMock.useLoaderData.mockReset()
     routeMock.useSearch.mockReset()
     navigateMock.mockReset()
+    getModelClientConfigsMock.mockReset()
     routeMock.useSearch.mockReturnValue({ page: 1, page_size: 30 })
   })
 
@@ -208,13 +216,14 @@ describe('ModelsPage', () => {
 
     expect(within(table).queryByText('Resolved')).not.toBeInTheDocument()
     expect(headers).toEqual([
-      'Model ID',
-      'Upstream Model',
+      '',
+      'Model id',
+      'Upstream model',
       'Provider',
-      'Cost / 1M Tokens',
-      'Context Window',
+      'Cost / 1M tokens',
+      'Context window',
       'Capabilities',
-      'Client Config',
+      'Client config',
     ])
 
     const identityCell = screen.getAllByTestId('models-desktop-cell-backup-fast')[0]
@@ -227,17 +236,17 @@ describe('ModelsPage', () => {
     const backupCells = within(backupRow as HTMLElement).getAllByRole('cell')
 
     expect(
-      within(backupCells[1] as HTMLElement).getByText('google/gemini-2.0-flash'),
+      within(backupCells[2] as HTMLElement).getByText('google/gemini-2.0-flash'),
     ).toBeInTheDocument()
-    expect(within(backupCells[2] as HTMLElement).getByText('Google Vertex AI')).toBeInTheDocument()
-    expect(within(backupCells[2] as HTMLElement).getByText('vertex-gemini')).toBeInTheDocument()
-    expect(within(backupCells[3] as HTMLElement).getByText('Input')).toBeInTheDocument()
-    expect(within(backupCells[3] as HTMLElement).getByText('Output')).toBeInTheDocument()
+    expect(within(backupCells[3] as HTMLElement).getByText('Google Vertex AI')).toBeInTheDocument()
+    expect(within(backupCells[3] as HTMLElement).getByText('vertex-gemini')).toBeInTheDocument()
     expect(within(backupCells[4] as HTMLElement).getByText('Input')).toBeInTheDocument()
     expect(within(backupCells[4] as HTMLElement).getByText('Output')).toBeInTheDocument()
-    expect(within(backupCells[5] as HTMLElement).getByText('Streaming')).toBeInTheDocument()
-    expect(within(backupCells[5] as HTMLElement).getByText('Vision')).toBeInTheDocument()
-    expect(within(backupCells[6] as HTMLElement).getByText('—')).toBeInTheDocument()
+    expect(within(backupCells[5] as HTMLElement).getByText('Input')).toBeInTheDocument()
+    expect(within(backupCells[5] as HTMLElement).getByText('Output')).toBeInTheDocument()
+    expect(within(backupCells[6] as HTMLElement).getByText('Streaming')).toBeInTheDocument()
+    expect(within(backupCells[6] as HTMLElement).getByText('Vision')).toBeInTheDocument()
+    expect(within(backupCells[7] as HTMLElement).getByText('—')).toBeInTheDocument()
   })
 
   it('does not render the notes column in the desktop table', async () => {
@@ -262,6 +271,10 @@ describe('ModelsPage', () => {
     Object.assign(navigator, {
       clipboard: { writeText },
     })
+    getModelClientConfigsMock.mockResolvedValue({
+      data: { client_configurations: modelPage.items[1]?.client_configurations ?? [] },
+      meta: {},
+    })
     routeMock.useLoaderData.mockReturnValue({ data: modelPage })
 
     const { ModelsPage } = await import('@/routes/models')
@@ -277,9 +290,14 @@ describe('ModelsPage', () => {
     expect(claudeRow).not.toBeNull()
 
     fireEvent.click(
-      within(claudeRow as HTMLElement).getByRole('button', { name: /Client config/i }),
+      within(claudeRow as HTMLElement).getByRole('button', {
+        name: /Generate client config for claude-sonnet/i,
+      }),
     )
-    expect(screen.getByRole('dialog', { name: 'Client config' })).toBeInTheDocument()
+    expect(getModelClientConfigsMock).toHaveBeenCalledWith({
+      data: { model_keys: ['claude-sonnet'] },
+    })
+    expect(await screen.findByRole('dialog', { name: 'Client config' })).toBeInTheDocument()
     expect(screen.getByText('opencode.json')).toBeInTheDocument()
     expect(screen.getByText(/"provider": "opencode"/)).toBeInTheDocument()
 
@@ -313,5 +331,118 @@ describe('ModelsPage', () => {
     expect(writeText).toHaveBeenLastCalledWith(
       'model = "claude-sonnet"\nmodel_provider = "oceans-llm"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nwire_api = "responses"\n',
     )
+  })
+
+  it('selects multiple models and opens generated client config for the selected set', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    })
+    const mixedPage: ModelPageView = {
+      ...modelPage,
+      items: modelPage.items.map((item) =>
+        item.id === 'fast'
+          ? {
+              ...item,
+              client_configurations: [
+                {
+                  key: 'opencode',
+                  label: 'OpenCode',
+                  model_ids: ['fast'],
+                  blocks: [
+                    {
+                      label: 'opencode.json',
+                      filename: 'opencode.json',
+                      content: '{\n  "provider": "fast-only"\n}',
+                    },
+                  ],
+                  notes: [],
+                },
+              ],
+            }
+          : item,
+      ),
+    }
+    const generatedConfigs = [
+      {
+        key: 'opencode',
+        label: 'OpenCode',
+        model_ids: ['fast', 'claude-sonnet'],
+        blocks: [
+          {
+            label: 'opencode.json',
+            filename: 'opencode.json',
+            content:
+              '{\n  "provider": {\n    "oceans-llm-openai-compatible": {},\n    "oceans-llm-anthropic-messages": {}\n  }\n}',
+          },
+        ],
+        notes: [],
+      },
+      {
+        key: 'pi',
+        label: 'Pi',
+        model_ids: ['fast', 'claude-sonnet'],
+        blocks: [
+          {
+            label: 'models.json',
+            filename: 'models.json',
+            content:
+              '{\n  "providers": {\n    "oceans-llm-openai-compatible": {},\n    "oceans-llm-anthropic-messages": {}\n  }\n}',
+          },
+        ],
+        notes: [],
+      },
+      {
+        key: 'claude-code',
+        label: 'Claude Code',
+        model_ids: ['claude-sonnet'],
+        blocks: [
+          {
+            label: 'Gateway model settings',
+            filename: 'settings.json',
+            content: '{\n  "modelOverrides": {\n    "claude-sonnet-4-6": "claude-sonnet"\n  }\n}',
+          },
+        ],
+        notes: [],
+      },
+    ]
+    getModelClientConfigsMock.mockResolvedValue({
+      data: { client_configurations: generatedConfigs },
+      meta: {},
+    })
+    routeMock.useLoaderData.mockReturnValue({ data: mixedPage })
+
+    const { ModelsPage } = await import('@/routes/models')
+
+    render(
+      <TooltipProvider>
+        <ModelsPage />
+      </TooltipProvider>,
+    )
+
+    const table = screen.getAllByTestId('models-desktop-table')[0]
+    fireEvent.click(within(table).getByLabelText('Select model fast'))
+    fireEvent.click(within(table).getByLabelText('Select model claude-sonnet'))
+    expect(screen.getByText('2 selected for client config')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate config' }))
+    expect(getModelClientConfigsMock).toHaveBeenCalledWith({
+      data: { model_keys: ['fast', 'claude-sonnet'] },
+    })
+    const dialog = await screen.findByRole('dialog', { name: 'Client config' })
+    expect(dialog).toBeInTheDocument()
+    expect(within(dialog).getByText('fast')).toBeInTheDocument()
+    expect(within(dialog).getByText('claude-sonnet')).toBeInTheDocument()
+    expect(within(dialog).getByText(/oceans-llm-openai-compatible/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Pi' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Copy JSON' }))
+    expect(writeText).toHaveBeenCalledWith(
+      '{\n  "providers": {\n    "oceans-llm-openai-compatible": {},\n    "oceans-llm-anthropic-messages": {}\n  }\n}',
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Claude Code' }))
+    expect(within(dialog).getByText(/claude-sonnet-4-6/)).toBeInTheDocument()
+    expect(within(dialog).getAllByText('claude-sonnet')).toHaveLength(2)
   })
 })

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -445,4 +445,87 @@ describe('ModelsPage', () => {
     expect(within(dialog).getByText(/claude-sonnet-4-6/)).toBeInTheDocument()
     expect(within(dialog).getAllByText('claude-sonnet')).toHaveLength(2)
   })
+
+  it('keeps selected models available when generating after pagination', async () => {
+    const configurableFast = {
+      ...(modelPage.items[0] as ModelPageView['items'][number]),
+      client_configurations: [
+        {
+          key: 'opencode',
+          label: 'OpenCode',
+          model_ids: ['fast'],
+          blocks: [
+            {
+              label: 'opencode.json',
+              filename: 'opencode.json',
+              content: '{\n  "provider": "fast-only"\n}',
+            },
+          ],
+          notes: [],
+        },
+      ],
+    }
+    const pageOne: ModelPageView = {
+      ...modelPage,
+      items: [modelPage.items[1] as ModelPageView['items'][number]],
+      page: 1,
+      page_size: 1,
+      total: 2,
+    }
+    const pageTwo: ModelPageView = {
+      ...modelPage,
+      items: [configurableFast],
+      page: 2,
+      page_size: 1,
+      total: 2,
+    }
+    getModelClientConfigsMock.mockResolvedValue({
+      data: {
+        client_configurations: [
+          {
+            key: 'opencode',
+            label: 'OpenCode',
+            model_ids: ['claude-sonnet', 'fast'],
+            blocks: [
+              {
+                label: 'opencode.json',
+                filename: 'opencode.json',
+                content: '{\n  "provider": "mixed"\n}',
+              },
+            ],
+            notes: [],
+          },
+        ],
+      },
+      meta: {},
+    })
+    routeMock.useLoaderData.mockReturnValue({ data: pageOne })
+
+    const { ModelsPage } = await import('@/routes/models')
+
+    const { rerender } = render(
+      <TooltipProvider>
+        <ModelsPage />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByLabelText('Select model claude-sonnet'))
+    routeMock.useLoaderData.mockReturnValue({ data: pageTwo })
+    rerender(
+      <TooltipProvider>
+        <ModelsPage />
+      </TooltipProvider>,
+    )
+    fireEvent.click(screen.getByLabelText('Select model fast'))
+
+    expect(screen.getByText('2 selected for client config')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Generate config' }))
+
+    expect(getModelClientConfigsMock).toHaveBeenCalledWith({
+      data: { model_keys: ['claude-sonnet', 'fast'] },
+    })
+    const dialog = await screen.findByRole('dialog', { name: 'Client config' })
+    expect(within(dialog).getByText('claude-sonnet')).toBeInTheDocument()
+    expect(within(dialog).getByText('fast')).toBeInTheDocument()
+  })
 })

--- a/crates/admin-ui/web/src/types/live-api.ts
+++ b/crates/admin-ui/web/src/types/live-api.ts
@@ -56,6 +56,10 @@ export type DeactivateBudgetResultView = components['schemas']['DeactivateBudget
 export type ModelView = components['schemas']['AdminModelView']
 export type ModelPageView = components['schemas']['AdminModelPageView']
 export type ModelListQuery = NonNullable<operations['list_models']['parameters']['query']>
+export type GenerateModelClientConfigsInput =
+  components['schemas']['GenerateModelClientConfigsRequest']
+export type GenerateModelClientConfigsResponse =
+  components['schemas']['GenerateModelClientConfigsResponse']
 export type RequestTagView = components['schemas']['RequestTagView']
 export type RequestLogTagsView = components['schemas']['RequestTagsView']
 export type RequestLogView = components['schemas']['RequestLogSummaryView']

--- a/crates/gateway-client-config/src/api_style.rs
+++ b/crates/gateway-client-config/src/api_style.rs
@@ -2,6 +2,12 @@ use serde_json::{Value, json};
 
 use crate::types::{AnthropicThinkingPolicy, ClientConfigInput};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ClientApiStyle {
+    OpenAiCompatible,
+    AnthropicMessages,
+}
+
 pub(crate) fn uses_anthropic_messages_api(input: &ClientConfigInput) -> bool {
     let joined = [
         input.model_id.as_str(),
@@ -13,22 +19,25 @@ pub(crate) fn uses_anthropic_messages_api(input: &ClientConfigInput) -> bool {
     joined.contains("anthropic") || joined.contains("claude")
 }
 
-// When multi-model config rendering lands, group models by this client API style first.
-// OpenCode and Pi put the API adapter at provider scope, so a mixed Anthropic
-// Messages + OpenAI-compatible selection needs one generated provider per style.
-pub(crate) fn opencode_provider_package(input: &ClientConfigInput) -> &'static str {
+pub(crate) fn client_api_style(input: &ClientConfigInput) -> ClientApiStyle {
     if uses_anthropic_messages_api(input) {
-        "@ai-sdk/anthropic"
+        ClientApiStyle::AnthropicMessages
     } else {
-        "@ai-sdk/openai-compatible"
+        ClientApiStyle::OpenAiCompatible
     }
 }
 
-pub(crate) fn pi_provider_api(input: &ClientConfigInput) -> &'static str {
-    if uses_anthropic_messages_api(input) {
-        "anthropic-messages"
-    } else {
-        "openai-completions"
+pub(crate) const fn opencode_provider_package_for_style(style: ClientApiStyle) -> &'static str {
+    match style {
+        ClientApiStyle::OpenAiCompatible => "@ai-sdk/openai-compatible",
+        ClientApiStyle::AnthropicMessages => "@ai-sdk/anthropic",
+    }
+}
+
+pub(crate) const fn pi_provider_api_for_style(style: ClientApiStyle) -> &'static str {
+    match style {
+        ClientApiStyle::OpenAiCompatible => "openai-completions",
+        ClientApiStyle::AnthropicMessages => "anthropic-messages",
     }
 }
 
@@ -37,7 +46,7 @@ pub(crate) fn pi_api_key_env_reference(input: &ClientConfigInput) -> String {
 }
 
 pub(crate) fn pi_provider_compat(input: &ClientConfigInput) -> Option<Value> {
-    if uses_anthropic_messages_api(input) {
+    if client_api_style(input) == ClientApiStyle::AnthropicMessages {
         return (input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort))
             .then(|| json!({"forceAdaptiveThinking": true}));
     }

--- a/crates/gateway-client-config/src/lib.rs
+++ b/crates/gateway-client-config/src/lib.rs
@@ -7,12 +7,12 @@ mod types;
 
 pub use templates::{
     ClaudeCodeConfigTemplate, CodexConfigTemplate, OpenCodeConfigTemplate, PiConfigTemplate,
-    render_default_configs,
+    render_default_configs, render_default_configs_for_models,
 };
 pub use thinking::infer_anthropic_thinking_policy;
 pub use types::{
     AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
-    ClientConfigTemplate, ClientModelCapabilities, DEFAULT_API_KEY_ENV_VAR,
+    ClientConfigInputSet, ClientConfigTemplate, ClientModelCapabilities, DEFAULT_API_KEY_ENV_VAR,
     DEFAULT_GATEWAY_BASE_URL, DEFAULT_PROVIDER_ID,
 };
 

--- a/crates/gateway-client-config/src/templates/claude_code.rs
+++ b/crates/gateway-client-config/src/templates/claude_code.rs
@@ -1,9 +1,13 @@
 use serde_json::{Map, Value, json};
 
 use crate::{
+    api_style::uses_anthropic_messages_api,
     format::to_pretty_json,
-    templates::notes::claude_code_notes,
-    types::{ClientConfig, ClientConfigCodeBlock, ClientConfigInput, ClientConfigTemplate},
+    templates::notes::{claude_code_notes, thinking_notes},
+    types::{
+        ClientConfig, ClientConfigCodeBlock, ClientConfigInput, ClientConfigInputSet,
+        ClientConfigTemplate,
+    },
 };
 
 pub(crate) const CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER: &str = "<gateway api token>";
@@ -27,11 +31,26 @@ pub struct ClaudeCodeConfigTemplate;
 
 impl ClientConfigTemplate for ClaudeCodeConfigTemplate {
     fn render(&self, input: &ClientConfigInput) -> ClientConfig {
-        let config = claude_code_gateway_model_config(input);
+        self.render_many(&ClientConfigInputSet::new(vec![input.clone()]))
+            .expect("single Claude Code rendering requires an Anthropic Messages model")
+    }
+}
 
-        ClientConfig {
+impl ClaudeCodeConfigTemplate {
+    #[must_use]
+    pub fn render_many(&self, input_set: &ClientConfigInputSet) -> Option<ClientConfig> {
+        let inputs = input_set
+            .models
+            .iter()
+            .filter(|input| uses_anthropic_messages_api(input))
+            .collect::<Vec<_>>();
+        let first = inputs.first()?;
+        let config = claude_code_gateway_model_config(&inputs);
+
+        Some(ClientConfig {
             key: "claude-code".to_string(),
             label: "Claude Code".to_string(),
+            model_ids: inputs.iter().map(|input| input.model_id.clone()).collect(),
             blocks: vec![
                 ClientConfigCodeBlock {
                     label: "Gateway model settings".to_string(),
@@ -44,23 +63,21 @@ impl ClientConfigTemplate for ClaudeCodeConfigTemplate {
                     content: to_pretty_json(&claude_code_minimal_experience_config()),
                 },
             ],
-            notes: claude_code_notes(input),
-        }
+            notes: claude_code_notes_for_models(&inputs, first),
+        })
     }
 }
 
-fn claude_code_gateway_model_config(input: &ClientConfigInput) -> Value {
-    let model_override_key = claude_code_model_override_key(input);
+fn claude_code_gateway_model_config(inputs: &[&ClientConfigInput]) -> Value {
     json!({
         "$schema": CLAUDE_CODE_SETTINGS_SCHEMA,
-        "env": Value::Object(claude_code_gateway_env(input)),
-        "modelOverrides": {
-            model_override_key.as_str(): input.model_id.as_str(),
-        },
+        "env": Value::Object(claude_code_gateway_env(inputs)),
+        "modelOverrides": Value::Object(claude_code_model_overrides(inputs)),
     })
 }
 
-fn claude_code_gateway_env(input: &ClientConfigInput) -> Map<String, Value> {
+fn claude_code_gateway_env(inputs: &[&ClientConfigInput]) -> Map<String, Value> {
+    let input = inputs[0];
     let mut env = Map::from_iter([
         (
             "ANTHROPIC_AUTH_TOKEN".to_string(),
@@ -81,11 +98,26 @@ fn claude_code_gateway_env(input: &ClientConfigInput) -> Map<String, Value> {
         ),
     ]);
 
-    if let Some(env_var) = claude_code_default_model_env_var(input) {
-        env.insert(env_var.to_string(), json!(input.model_id));
+    for input in inputs {
+        if let Some(env_var) = claude_code_default_model_env_var(input) {
+            env.entry(env_var.to_string())
+                .or_insert_with(|| json!(input.model_id));
+        }
     }
 
     env
+}
+
+fn claude_code_model_overrides(inputs: &[&ClientConfigInput]) -> Map<String, Value> {
+    inputs
+        .iter()
+        .map(|input| {
+            (
+                claude_code_model_override_key(input),
+                json!(input.model_id.as_str()),
+            )
+        })
+        .collect()
 }
 
 fn claude_code_gateway_base_url(input: &ClientConfigInput) -> String {
@@ -149,6 +181,22 @@ fn claude_code_minimal_experience_config() -> Value {
         "$schema": CLAUDE_CODE_SETTINGS_SCHEMA,
         "env": env_from_pairs(&CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV),
     })
+}
+
+fn claude_code_notes_for_models(
+    inputs: &[&ClientConfigInput],
+    first: &ClientConfigInput,
+) -> Vec<String> {
+    let mut notes = inputs
+        .iter()
+        .flat_map(|input| thinking_notes(input))
+        .collect::<Vec<_>>();
+    notes.extend(
+        claude_code_notes(first)
+            .into_iter()
+            .filter(|note| !note.contains("thinking variants")),
+    );
+    notes
 }
 
 fn env_from_pairs(pairs: &[(&str, &str)]) -> Value {

--- a/crates/gateway-client-config/src/templates/claude_code.rs
+++ b/crates/gateway-client-config/src/templates/claude_code.rs
@@ -1,9 +1,11 @@
+use std::collections::{BTreeSet, HashSet};
+
 use serde_json::{Map, Value, json};
 
 use crate::{
     api_style::uses_anthropic_messages_api,
     format::to_pretty_json,
-    templates::notes::{claude_code_notes, thinking_notes},
+    templates::notes::{ClientConfigNote, claude_code_note_items, thinking_note_items},
     types::{
         ClientConfig, ClientConfigCodeBlock, ClientConfigInput, ClientConfigInputSet,
         ClientConfigTemplate,
@@ -31,8 +33,7 @@ pub struct ClaudeCodeConfigTemplate;
 
 impl ClientConfigTemplate for ClaudeCodeConfigTemplate {
     fn render(&self, input: &ClientConfigInput) -> ClientConfig {
-        self.render_many(&ClientConfigInputSet::new(vec![input.clone()]))
-            .expect("single Claude Code rendering requires an Anthropic Messages model")
+        self.render_inputs(vec![input])
     }
 }
 
@@ -44,10 +45,19 @@ impl ClaudeCodeConfigTemplate {
             .iter()
             .filter(|input| uses_anthropic_messages_api(input))
             .collect::<Vec<_>>();
-        let first = inputs.first()?;
+        if inputs.is_empty() {
+            return None;
+        }
+
+        Some(self.render_inputs(inputs))
+    }
+
+    fn render_inputs(&self, inputs: Vec<&ClientConfigInput>) -> ClientConfig {
+        let inputs = unique_claude_code_inputs(inputs);
+        let first = inputs[0];
         let config = claude_code_gateway_model_config(&inputs);
 
-        Some(ClientConfig {
+        ClientConfig {
             key: "claude-code".to_string(),
             label: "Claude Code".to_string(),
             model_ids: inputs.iter().map(|input| input.model_id.clone()).collect(),
@@ -64,8 +74,16 @@ impl ClaudeCodeConfigTemplate {
                 },
             ],
             notes: claude_code_notes_for_models(&inputs, first),
-        })
+        }
     }
+}
+
+fn unique_claude_code_inputs(inputs: Vec<&ClientConfigInput>) -> Vec<&ClientConfigInput> {
+    let mut seen_override_keys = BTreeSet::new();
+    inputs
+        .into_iter()
+        .filter(|input| seen_override_keys.insert(claude_code_model_override_key(input)))
+        .collect()
 }
 
 fn claude_code_gateway_model_config(inputs: &[&ClientConfigInput]) -> Value {
@@ -187,16 +205,24 @@ fn claude_code_notes_for_models(
     inputs: &[&ClientConfigInput],
     first: &ClientConfigInput,
 ) -> Vec<String> {
-    let mut notes = inputs
+    let mut note_items = inputs
         .iter()
-        .flat_map(|input| thinking_notes(input))
+        .flat_map(|input| thinking_note_items(input))
         .collect::<Vec<_>>();
-    notes.extend(
-        claude_code_notes(first)
+
+    let mut seen_kinds = note_items
+        .iter()
+        .map(ClientConfigNote::kind)
+        .collect::<HashSet<_>>();
+    note_items.extend(
+        claude_code_note_items(first)
             .into_iter()
-            .filter(|note| !note.contains("thinking variants")),
+            .filter(|note| seen_kinds.insert(note.kind())),
     );
-    notes
+    note_items
+        .into_iter()
+        .map(ClientConfigNote::into_message)
+        .collect()
 }
 
 fn env_from_pairs(pairs: &[(&str, &str)]) -> Value {

--- a/crates/gateway-client-config/src/templates/codex.rs
+++ b/crates/gateway-client-config/src/templates/codex.rs
@@ -35,6 +35,7 @@ impl ClientConfigTemplate for CodexConfigTemplate {
         ClientConfig {
             key: "codex".to_string(),
             label: "Codex".to_string(),
+            model_ids: vec![input.model_id.clone()],
             blocks: vec![ClientConfigCodeBlock {
                 label: "config.toml".to_string(),
                 filename: "config.toml".to_string(),

--- a/crates/gateway-client-config/src/templates/mod.rs
+++ b/crates/gateway-client-config/src/templates/mod.rs
@@ -33,6 +33,13 @@ pub fn render_default_configs_for_models(input_set: ClientConfigInputSet) -> Vec
 
     if let Some(input) = codex_input(&input_set) {
         configs.push(CodexConfigTemplate.render(input));
+    } else if codex_requires_single_model_selection(&input_set) {
+        for config in &mut configs {
+            config.notes.push(
+                "Codex config snippets require a single responses-capable model selection; select one model and generate config again to include Codex."
+                    .to_string(),
+            );
+        }
     }
 
     configs
@@ -42,4 +49,12 @@ fn codex_input(input_set: &ClientConfigInputSet) -> Option<&ClientConfigInput> {
     input_set
         .first()
         .filter(|input| input_set.models.len() == 1 && input.capabilities.responses)
+}
+
+fn codex_requires_single_model_selection(input_set: &ClientConfigInputSet) -> bool {
+    input_set.models.len() > 1
+        && input_set
+            .models
+            .iter()
+            .any(|input| input.capabilities.responses)
 }

--- a/crates/gateway-client-config/src/templates/mod.rs
+++ b/crates/gateway-client-config/src/templates/mod.rs
@@ -9,19 +9,37 @@ pub use codex::CodexConfigTemplate;
 pub use opencode::OpenCodeConfigTemplate;
 pub use pi::PiConfigTemplate;
 
-use crate::types::{ClientConfig, ClientConfigInput, ClientConfigTemplate};
+use crate::types::{ClientConfig, ClientConfigInput, ClientConfigInputSet, ClientConfigTemplate};
 
 #[must_use]
 pub fn render_default_configs(input: &ClientConfigInput) -> Vec<ClientConfig> {
+    render_default_configs_for_models(ClientConfigInputSet::new(vec![input.clone()]))
+}
+
+#[must_use]
+pub fn render_default_configs_for_models(input_set: ClientConfigInputSet) -> Vec<ClientConfig> {
+    if input_set.is_empty() {
+        return Vec::new();
+    }
+
     let mut configs = vec![
-        OpenCodeConfigTemplate.render(input),
-        PiConfigTemplate.render(input),
-        ClaudeCodeConfigTemplate.render(input),
+        OpenCodeConfigTemplate.render_many(&input_set),
+        PiConfigTemplate.render_many(&input_set),
     ];
 
-    if input.capabilities.responses {
+    if let Some(config) = ClaudeCodeConfigTemplate.render_many(&input_set) {
+        configs.push(config);
+    }
+
+    if let Some(input) = codex_input(&input_set) {
         configs.push(CodexConfigTemplate.render(input));
     }
 
     configs
+}
+
+fn codex_input(input_set: &ClientConfigInputSet) -> Option<&ClientConfigInput> {
+    input_set
+        .first()
+        .filter(|input| input_set.models.len() == 1 && input.capabilities.responses)
 }

--- a/crates/gateway-client-config/src/templates/notes.rs
+++ b/crates/gateway-client-config/src/templates/notes.rs
@@ -3,32 +3,77 @@ use crate::{
     types::{AnthropicThinkingPolicy, ClientConfigInput},
 };
 
-pub(crate) fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
-    match input.thinking_policy {
-        Some(AnthropicThinkingPolicy::ManualBudget) => {
-            vec![
-                "This Anthropic model is marked as reasoning-capable, but no thinking variants are generated because it requires caller-supplied manual budget tokens.".to_string(),
-            ]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ClientConfigNoteKind {
+    ThinkingPolicy,
+    ClaudeCodeAuth,
+    ClaudeCodeBaseUrl,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ClientConfigNote {
+    kind: ClientConfigNoteKind,
+    message: String,
+}
+
+impl ClientConfigNote {
+    fn new(kind: ClientConfigNoteKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
         }
+    }
+
+    pub(crate) fn kind(&self) -> ClientConfigNoteKind {
+        self.kind
+    }
+
+    pub(crate) fn into_message(self) -> String {
+        self.message
+    }
+}
+
+pub(crate) fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
+    thinking_note_items(input)
+        .into_iter()
+        .map(ClientConfigNote::into_message)
+        .collect()
+}
+
+pub(crate) fn thinking_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
+    match input.thinking_policy {
+        Some(AnthropicThinkingPolicy::ManualBudget) => vec![ClientConfigNote::new(
+            ClientConfigNoteKind::ThinkingPolicy,
+            "This Anthropic model is marked as reasoning-capable, but no thinking variants are generated because it requires caller-supplied manual budget tokens.",
+        )],
         _ => Vec::new(),
     }
 }
 
-pub(crate) fn claude_code_notes(input: &ClientConfigInput) -> Vec<String> {
-    let mut notes = thinking_notes(input);
-    notes.push(format!(
-        "Replace {} with a gateway API key before using Claude Code settings.",
-        super::claude_code::CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER
+pub(crate) fn claude_code_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
+    let mut notes = thinking_note_items(input);
+    notes.push(ClientConfigNote::new(
+        ClientConfigNoteKind::ClaudeCodeAuth,
+        format!(
+            "Replace {} with a gateway API key before using Claude Code settings.",
+            super::claude_code::CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER
+        ),
     ));
     if uses_anthropic_messages_api(input) {
-        notes.push(format!(
+        notes.push(ClientConfigNote::new(
+            ClientConfigNoteKind::ClaudeCodeBaseUrl,
+            format!(
             "ANTHROPIC_BASE_URL is set to the Claude-compatible gateway base URL; Claude Code appends Anthropic endpoints such as /v1/messages and /v1/models. OpenCode and Pi also use Anthropic Messages for this model via {}.",
             input.gateway_base_url
+            ),
         ));
     } else {
-        notes.push(format!(
+        notes.push(ClientConfigNote::new(
+            ClientConfigNoteKind::ClaudeCodeBaseUrl,
+            format!(
             "ANTHROPIC_BASE_URL is set to the Claude-compatible gateway base URL; Claude Code appends Anthropic endpoints such as /v1/messages and /v1/models. Keep the OpenAI-compatible base URL ({}) for OpenCode and Pi.",
             input.gateway_base_url
+            ),
         ));
     }
     notes

--- a/crates/gateway-client-config/src/templates/opencode.rs
+++ b/crates/gateway-client-config/src/templates/opencode.rs
@@ -1,13 +1,15 @@
+use std::collections::BTreeMap;
+
 use serde_json::{Map, Value, json};
 
 use crate::{
-    api_style::opencode_provider_package,
+    api_style::{ClientApiStyle, client_api_style, opencode_provider_package_for_style},
     cost::opencode_cost,
     format::to_pretty_json,
     templates::notes::thinking_notes,
     types::{
         AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
-        ClientConfigTemplate,
+        ClientConfigInputSet, ClientConfigTemplate,
     },
 };
 
@@ -16,70 +18,147 @@ pub struct OpenCodeConfigTemplate;
 
 impl ClientConfigTemplate for OpenCodeConfigTemplate {
     fn render(&self, input: &ClientConfigInput) -> ClientConfig {
-        let mut model = Map::from_iter([
-            ("name".to_string(), json!(input.display_name)),
-            (
-                "reasoning".to_string(),
-                json!(input.thinking_policy.is_some()),
-            ),
-            (
-                "tool_call".to_string(),
-                json!(input.capabilities.tool_calling),
-            ),
-            (
-                "limit".to_string(),
-                json!({
-                    "context": input.context_window(),
-                    "output": input.output_window(),
-                }),
-            ),
-            ("cost".to_string(), opencode_cost(input)),
-        ]);
+        self.render_many(&ClientConfigInputSet::new(vec![input.clone()]))
+    }
+}
 
-        if input.capabilities.attachments || input.capabilities.vision {
-            model.insert("attachment".to_string(), json!(true));
-        }
-        if input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort) {
-            model.insert(
-                "variants".to_string(),
-                json!({
-                    "high": {
-                        "reasoningEffort": "high",
-                    },
-                    "max": {
-                        "reasoningEffort": "xhigh",
-                    },
-                }),
-            );
+impl OpenCodeConfigTemplate {
+    #[must_use]
+    pub fn render_many(&self, input_set: &ClientConfigInputSet) -> ClientConfig {
+        let first = input_set
+            .first()
+            .expect("OpenCode config rendering requires at least one model");
+        let groups = grouped_models(input_set);
+        let has_multiple_styles = groups.len() > 1;
+        let default_provider_id =
+            provider_id_for_style(first, client_api_style(first), has_multiple_styles);
+        let mut providers = Map::new();
+
+        for (style, inputs) in &groups {
+            let provider_id = provider_id_for_style(inputs[0], *style, has_multiple_styles);
+            let provider = json!({
+                "npm": opencode_provider_package_for_style(*style),
+                "name": provider_name_for_style(inputs[0], *style, has_multiple_styles),
+                "options": {
+                    "baseURL": inputs[0].gateway_base_url,
+                    "apiKey": format!("{{env:{}}}", inputs[0].api_key_env_var),
+                },
+                "models": Value::Object(opencode_models(inputs)),
+            });
+            providers.insert(provider_id, provider);
         }
 
         let config = json!({
             "$schema": "https://opencode.ai/config.json",
-            "provider": {
-                input.provider_id.as_str(): {
-                    "npm": opencode_provider_package(input),
-                    "name": input.provider_name,
-                    "options": {
-                        "baseURL": input.gateway_base_url,
-                        "apiKey": format!("{{env:{}}}", input.api_key_env_var),
-                    },
-                    "models": {
-                        input.model_id.as_str(): Value::Object(model),
-                    },
-                },
-            },
-            "model": format!("{}/{}", input.provider_id, input.model_id),
+            "provider": Value::Object(providers),
+            "model": format!("{}/{}", default_provider_id, first.model_id),
         });
 
         ClientConfig {
             key: "opencode".to_string(),
             label: "OpenCode".to_string(),
+            model_ids: input_set
+                .models
+                .iter()
+                .map(|input| input.model_id.clone())
+                .collect(),
             blocks: vec![ClientConfigCodeBlock {
                 label: "opencode.json".to_string(),
                 filename: "opencode.json".to_string(),
                 content: to_pretty_json(&config),
             }],
-            notes: thinking_notes(input),
+            notes: input_set.models.iter().flat_map(thinking_notes).collect(),
         }
+    }
+}
+
+fn grouped_models(
+    input_set: &ClientConfigInputSet,
+) -> BTreeMap<ClientApiStyle, Vec<&ClientConfigInput>> {
+    let mut groups: BTreeMap<ClientApiStyle, Vec<&ClientConfigInput>> = BTreeMap::new();
+    for input in &input_set.models {
+        groups
+            .entry(client_api_style(input))
+            .or_default()
+            .push(input);
+    }
+    groups
+}
+
+fn opencode_models(inputs: &[&ClientConfigInput]) -> Map<String, Value> {
+    inputs
+        .iter()
+        .map(|input| (input.model_id.clone(), Value::Object(opencode_model(input))))
+        .collect()
+}
+
+fn opencode_model(input: &ClientConfigInput) -> Map<String, Value> {
+    let mut model = Map::from_iter([
+        ("name".to_string(), json!(input.display_name)),
+        (
+            "reasoning".to_string(),
+            json!(input.thinking_policy.is_some()),
+        ),
+        (
+            "tool_call".to_string(),
+            json!(input.capabilities.tool_calling),
+        ),
+        (
+            "limit".to_string(),
+            json!({
+                "context": input.context_window(),
+                "output": input.output_window(),
+            }),
+        ),
+        ("cost".to_string(), opencode_cost(input)),
+    ]);
+
+    if input.capabilities.attachments || input.capabilities.vision {
+        model.insert("attachment".to_string(), json!(true));
+    }
+    if input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort) {
+        model.insert(
+            "variants".to_string(),
+            json!({
+                "high": {
+                    "reasoningEffort": "high",
+                },
+                "max": {
+                    "reasoningEffort": "xhigh",
+                },
+            }),
+        );
+    }
+
+    model
+}
+
+fn provider_id_for_style(
+    input: &ClientConfigInput,
+    style: ClientApiStyle,
+    has_multiple_styles: bool,
+) -> String {
+    if !has_multiple_styles {
+        return input.provider_id.clone();
+    }
+
+    match style {
+        ClientApiStyle::OpenAiCompatible => format!("{}-openai-compatible", input.provider_id),
+        ClientApiStyle::AnthropicMessages => format!("{}-anthropic-messages", input.provider_id),
+    }
+}
+
+fn provider_name_for_style(
+    input: &ClientConfigInput,
+    style: ClientApiStyle,
+    has_multiple_styles: bool,
+) -> String {
+    if !has_multiple_styles {
+        return input.provider_name.clone();
+    }
+
+    match style {
+        ClientApiStyle::OpenAiCompatible => format!("{} OpenAI-compatible", input.provider_name),
+        ClientApiStyle::AnthropicMessages => format!("{} Anthropic Messages", input.provider_name),
     }
 }

--- a/crates/gateway-client-config/src/templates/pi.rs
+++ b/crates/gateway-client-config/src/templates/pi.rs
@@ -32,18 +32,19 @@ impl PiConfigTemplate {
         let has_multiple_styles = groups.len() > 1;
         let mut providers = Map::new();
 
-        for (style, inputs) in &groups {
-            let provider_id = provider_id_for_style(inputs[0], *style, has_multiple_styles);
+        for (group, inputs) in &groups {
+            let style = group.api_style();
+            let provider_id = provider_id_for_group(inputs[0], *group, has_multiple_styles);
             let mut provider = Map::from_iter([
                 ("baseUrl".to_string(), json!(inputs[0].gateway_base_url)),
-                ("api".to_string(), json!(pi_provider_api_for_style(*style))),
+                ("api".to_string(), json!(pi_provider_api_for_style(style))),
                 (
                     "apiKey".to_string(),
                     json!(pi_api_key_env_reference(inputs[0])),
                 ),
                 ("models".to_string(), Value::Array(pi_models(inputs))),
             ]);
-            if let Some(compat) = pi_group_compat(*style, inputs) {
+            if let Some(compat) = pi_group_compat(*group, inputs) {
                 provider.insert("compat".to_string(), compat);
             }
             providers.insert(provider_id, Value::Object(provider));
@@ -71,13 +72,43 @@ impl PiConfigTemplate {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum PiProviderGroup {
+    OpenAiCompatible,
+    AnthropicMessages,
+    AnthropicMessagesAdaptiveThinking,
+}
+
+impl PiProviderGroup {
+    fn for_input(input: &ClientConfigInput) -> Self {
+        match client_api_style(input) {
+            ClientApiStyle::OpenAiCompatible => Self::OpenAiCompatible,
+            ClientApiStyle::AnthropicMessages
+                if input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort) =>
+            {
+                Self::AnthropicMessagesAdaptiveThinking
+            }
+            ClientApiStyle::AnthropicMessages => Self::AnthropicMessages,
+        }
+    }
+
+    const fn api_style(self) -> ClientApiStyle {
+        match self {
+            Self::OpenAiCompatible => ClientApiStyle::OpenAiCompatible,
+            Self::AnthropicMessages | Self::AnthropicMessagesAdaptiveThinking => {
+                ClientApiStyle::AnthropicMessages
+            }
+        }
+    }
+}
+
 fn grouped_models(
     input_set: &ClientConfigInputSet,
-) -> BTreeMap<ClientApiStyle, Vec<&ClientConfigInput>> {
-    let mut groups: BTreeMap<ClientApiStyle, Vec<&ClientConfigInput>> = BTreeMap::new();
+) -> BTreeMap<PiProviderGroup, Vec<&ClientConfigInput>> {
+    let mut groups: BTreeMap<PiProviderGroup, Vec<&ClientConfigInput>> = BTreeMap::new();
     for input in &input_set.models {
         groups
-            .entry(client_api_style(input))
+            .entry(PiProviderGroup::for_input(input))
             .or_default()
             .push(input);
     }
@@ -122,27 +153,29 @@ fn pi_model(input: &ClientConfigInput) -> Map<String, Value> {
     model
 }
 
-fn pi_group_compat(style: ClientApiStyle, inputs: &[&ClientConfigInput]) -> Option<Value> {
-    match style {
-        ClientApiStyle::OpenAiCompatible => pi_provider_compat(inputs[0]),
-        ClientApiStyle::AnthropicMessages => inputs
-            .iter()
-            .find(|input| input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort))
-            .and_then(|input| pi_provider_compat(input)),
+fn pi_group_compat(group: PiProviderGroup, inputs: &[&ClientConfigInput]) -> Option<Value> {
+    match group {
+        PiProviderGroup::OpenAiCompatible | PiProviderGroup::AnthropicMessagesAdaptiveThinking => {
+            pi_provider_compat(inputs[0])
+        }
+        PiProviderGroup::AnthropicMessages => None,
     }
 }
 
-fn provider_id_for_style(
+fn provider_id_for_group(
     input: &ClientConfigInput,
-    style: ClientApiStyle,
+    group: PiProviderGroup,
     has_multiple_styles: bool,
 ) -> String {
     if !has_multiple_styles {
         return input.provider_id.clone();
     }
 
-    match style {
-        ClientApiStyle::OpenAiCompatible => format!("{}-openai-compatible", input.provider_id),
-        ClientApiStyle::AnthropicMessages => format!("{}-anthropic-messages", input.provider_id),
+    match group {
+        PiProviderGroup::OpenAiCompatible => format!("{}-openai-compatible", input.provider_id),
+        PiProviderGroup::AnthropicMessages => format!("{}-anthropic-messages", input.provider_id),
+        PiProviderGroup::AnthropicMessagesAdaptiveThinking => {
+            format!("{}-anthropic-messages-adaptive-thinking", input.provider_id)
+        }
     }
 }

--- a/crates/gateway-client-config/src/templates/pi.rs
+++ b/crates/gateway-client-config/src/templates/pi.rs
@@ -1,13 +1,18 @@
+use std::collections::BTreeMap;
+
 use serde_json::{Map, Value, json};
 
 use crate::{
-    api_style::{pi_api_key_env_reference, pi_provider_api, pi_provider_compat},
+    api_style::{
+        ClientApiStyle, client_api_style, pi_api_key_env_reference, pi_provider_api_for_style,
+        pi_provider_compat,
+    },
     cost::pi_cost,
     format::to_pretty_json,
     templates::notes::thinking_notes,
     types::{
         AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
-        ClientConfigTemplate,
+        ClientConfigInputSet, ClientConfigTemplate,
     },
 };
 
@@ -16,58 +21,128 @@ pub struct PiConfigTemplate;
 
 impl ClientConfigTemplate for PiConfigTemplate {
     fn render(&self, input: &ClientConfigInput) -> ClientConfig {
-        let mut model = Map::from_iter([
-            ("id".to_string(), json!(input.model_id)),
-            ("name".to_string(), json!(input.display_name)),
-            (
-                "reasoning".to_string(),
-                json!(input.thinking_policy.is_some()),
-            ),
-            ("input".to_string(), json!(input.input_modalities())),
-            ("contextWindow".to_string(), json!(input.context_window())),
-            ("maxTokens".to_string(), json!(input.output_window())),
-            ("cost".to_string(), pi_cost(input)),
-        ]);
+        self.render_many(&ClientConfigInputSet::new(vec![input.clone()]))
+    }
+}
 
-        if input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort) {
-            model.insert(
-                "thinkingLevelMap".to_string(),
-                json!({
-                    "off": null,
-                    "minimal": null,
-                    "low": "low",
-                    "medium": "medium",
-                    "high": "high",
-                    "xhigh": "xhigh",
-                }),
-            );
-        }
+impl PiConfigTemplate {
+    #[must_use]
+    pub fn render_many(&self, input_set: &ClientConfigInputSet) -> ClientConfig {
+        let groups = grouped_models(input_set);
+        let has_multiple_styles = groups.len() > 1;
+        let mut providers = Map::new();
 
-        let mut provider = Map::from_iter([
-            ("baseUrl".to_string(), json!(input.gateway_base_url)),
-            ("api".to_string(), json!(pi_provider_api(input))),
-            ("apiKey".to_string(), json!(pi_api_key_env_reference(input))),
-            ("models".to_string(), json!([Value::Object(model)])),
-        ]);
-        if let Some(compat) = pi_provider_compat(input) {
-            provider.insert("compat".to_string(), compat);
+        for (style, inputs) in &groups {
+            let provider_id = provider_id_for_style(inputs[0], *style, has_multiple_styles);
+            let mut provider = Map::from_iter([
+                ("baseUrl".to_string(), json!(inputs[0].gateway_base_url)),
+                ("api".to_string(), json!(pi_provider_api_for_style(*style))),
+                (
+                    "apiKey".to_string(),
+                    json!(pi_api_key_env_reference(inputs[0])),
+                ),
+                ("models".to_string(), Value::Array(pi_models(inputs))),
+            ]);
+            if let Some(compat) = pi_group_compat(*style, inputs) {
+                provider.insert("compat".to_string(), compat);
+            }
+            providers.insert(provider_id, Value::Object(provider));
         }
 
         let config = json!({
-            "providers": {
-                input.provider_id.as_str(): Value::Object(provider),
-            },
+            "providers": Value::Object(providers),
         });
 
         ClientConfig {
             key: "pi".to_string(),
             label: "Pi".to_string(),
+            model_ids: input_set
+                .models
+                .iter()
+                .map(|input| input.model_id.clone())
+                .collect(),
             blocks: vec![ClientConfigCodeBlock {
                 label: "models.json".to_string(),
                 filename: "models.json".to_string(),
                 content: to_pretty_json(&config),
             }],
-            notes: thinking_notes(input),
+            notes: input_set.models.iter().flat_map(thinking_notes).collect(),
         }
+    }
+}
+
+fn grouped_models(
+    input_set: &ClientConfigInputSet,
+) -> BTreeMap<ClientApiStyle, Vec<&ClientConfigInput>> {
+    let mut groups: BTreeMap<ClientApiStyle, Vec<&ClientConfigInput>> = BTreeMap::new();
+    for input in &input_set.models {
+        groups
+            .entry(client_api_style(input))
+            .or_default()
+            .push(input);
+    }
+    groups
+}
+
+fn pi_models(inputs: &[&ClientConfigInput]) -> Vec<Value> {
+    inputs
+        .iter()
+        .map(|input| Value::Object(pi_model(input)))
+        .collect()
+}
+
+fn pi_model(input: &ClientConfigInput) -> Map<String, Value> {
+    let mut model = Map::from_iter([
+        ("id".to_string(), json!(input.model_id)),
+        ("name".to_string(), json!(input.display_name)),
+        (
+            "reasoning".to_string(),
+            json!(input.thinking_policy.is_some()),
+        ),
+        ("input".to_string(), json!(input.input_modalities())),
+        ("contextWindow".to_string(), json!(input.context_window())),
+        ("maxTokens".to_string(), json!(input.output_window())),
+        ("cost".to_string(), pi_cost(input)),
+    ]);
+
+    if input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort) {
+        model.insert(
+            "thinkingLevelMap".to_string(),
+            json!({
+                "off": null,
+                "minimal": null,
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "xhigh": "xhigh",
+            }),
+        );
+    }
+
+    model
+}
+
+fn pi_group_compat(style: ClientApiStyle, inputs: &[&ClientConfigInput]) -> Option<Value> {
+    match style {
+        ClientApiStyle::OpenAiCompatible => pi_provider_compat(inputs[0]),
+        ClientApiStyle::AnthropicMessages => inputs
+            .iter()
+            .find(|input| input.thinking_policy == Some(AnthropicThinkingPolicy::SafeEffort))
+            .and_then(|input| pi_provider_compat(input)),
+    }
+}
+
+fn provider_id_for_style(
+    input: &ClientConfigInput,
+    style: ClientApiStyle,
+    has_multiple_styles: bool,
+) -> String {
+    if !has_multiple_styles {
+        return input.provider_id.clone();
+    }
+
+    match style {
+        ClientApiStyle::OpenAiCompatible => format!("{}-openai-compatible", input.provider_id),
+        ClientApiStyle::AnthropicMessages => format!("{}-anthropic-messages", input.provider_id),
     }
 }

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -1,9 +1,10 @@
 use serde_json::Value;
 
 use crate::{
-    AnthropicThinkingPolicy, ClaudeCodeConfigTemplate, ClientConfigInput, ClientConfigTemplate,
-    ClientModelCapabilities, CodexConfigTemplate, OpenCodeConfigTemplate, PiConfigTemplate,
-    infer_anthropic_thinking_policy, render_default_configs,
+    AnthropicThinkingPolicy, ClaudeCodeConfigTemplate, ClientConfigInput, ClientConfigInputSet,
+    ClientConfigTemplate, ClientModelCapabilities, CodexConfigTemplate, OpenCodeConfigTemplate,
+    PiConfigTemplate, infer_anthropic_thinking_policy, render_default_configs,
+    render_default_configs_for_models,
 };
 
 fn input(policy: Option<AnthropicThinkingPolicy>) -> ClientConfigInput {
@@ -249,6 +250,99 @@ fn non_anthropic_models_use_openai_compatible_client_surfaces() {
     assert_eq!(
         pi["providers"]["oceans-llm"]["compat"]["maxTokensField"],
         "max_completion_tokens"
+    );
+}
+
+#[test]
+fn opencode_and_pi_group_mixed_api_styles_into_separate_providers() {
+    let rendered = render_default_configs_for_models(ClientConfigInputSet::new(vec![
+        input(Some(AnthropicThinkingPolicy::SafeEffort)),
+        non_anthropic_input(),
+    ]));
+
+    let opencode_config = rendered
+        .iter()
+        .find(|config| config.key == "opencode")
+        .expect("opencode config");
+    let opencode: Value = serde_json::from_str(&opencode_config.blocks[0].content).expect("json");
+    assert_eq!(
+        opencode["provider"]["oceans-llm-anthropic-messages"]["npm"],
+        "@ai-sdk/anthropic"
+    );
+    assert_eq!(
+        opencode["provider"]["oceans-llm-openai-compatible"]["npm"],
+        "@ai-sdk/openai-compatible"
+    );
+    assert!(
+        opencode["provider"]["oceans-llm-anthropic-messages"]["models"]
+            .get("claude-sonnet")
+            .is_some()
+    );
+    assert!(
+        opencode["provider"]["oceans-llm-openai-compatible"]["models"]
+            .get("qwen-coder")
+            .is_some()
+    );
+
+    let pi_config = rendered
+        .iter()
+        .find(|config| config.key == "pi")
+        .expect("pi config");
+    let pi: Value = serde_json::from_str(&pi_config.blocks[0].content).expect("json");
+    assert_eq!(
+        pi["providers"]["oceans-llm-anthropic-messages"]["api"],
+        "anthropic-messages"
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm-openai-compatible"]["api"],
+        "openai-completions"
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm-anthropic-messages"]["models"][0]["id"],
+        "claude-sonnet"
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm-openai-compatible"]["models"][0]["id"],
+        "qwen-coder"
+    );
+}
+
+#[test]
+fn claude_code_filters_non_anthropic_models_from_mixed_selection() {
+    let rendered = ClaudeCodeConfigTemplate
+        .render_many(&ClientConfigInputSet::new(vec![
+            input(Some(AnthropicThinkingPolicy::SafeEffort)),
+            non_anthropic_input(),
+        ]))
+        .expect("claude code config");
+    let gateway_settings: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
+
+    assert_eq!(
+        gateway_settings["modelOverrides"]["claude-sonnet-4-6"],
+        "claude-sonnet"
+    );
+    assert!(
+        gateway_settings["modelOverrides"]
+            .get("qwen/qwen3-coder")
+            .is_none()
+    );
+    assert_eq!(gateway_settings["env"]["ANTHROPIC_MODEL"], "claude-sonnet");
+}
+
+#[test]
+fn claude_code_is_omitted_when_no_anthropic_models_are_selected() {
+    let rendered =
+        render_default_configs_for_models(ClientConfigInputSet::new(vec![non_anthropic_input()]));
+    let keys = rendered
+        .iter()
+        .map(|config| config.key.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(keys, vec!["opencode", "pi"]);
+    assert!(
+        ClaudeCodeConfigTemplate
+            .render_many(&ClientConfigInputSet::new(vec![non_anthropic_input()]))
+            .is_none()
     );
 }
 

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -290,7 +290,7 @@ fn opencode_and_pi_group_mixed_api_styles_into_separate_providers() {
         .expect("pi config");
     let pi: Value = serde_json::from_str(&pi_config.blocks[0].content).expect("json");
     assert_eq!(
-        pi["providers"]["oceans-llm-anthropic-messages"]["api"],
+        pi["providers"]["oceans-llm-anthropic-messages-adaptive-thinking"]["api"],
         "anthropic-messages"
     );
     assert_eq!(
@@ -298,12 +298,42 @@ fn opencode_and_pi_group_mixed_api_styles_into_separate_providers() {
         "openai-completions"
     );
     assert_eq!(
-        pi["providers"]["oceans-llm-anthropic-messages"]["models"][0]["id"],
+        pi["providers"]["oceans-llm-anthropic-messages-adaptive-thinking"]["models"][0]["id"],
         "claude-sonnet"
     );
     assert_eq!(
         pi["providers"]["oceans-llm-openai-compatible"]["models"][0]["id"],
         "qwen-coder"
+    );
+}
+
+#[test]
+fn pi_splits_anthropic_models_by_thinking_compatibility() {
+    let safe_effort = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    let mut manual_budget = input(Some(AnthropicThinkingPolicy::ManualBudget));
+    manual_budget.model_id = "claude-haiku".to_string();
+    manual_budget.upstream_model = Some("anthropic/claude-haiku-3-5".to_string());
+
+    let rendered =
+        PiConfigTemplate.render_many(&ClientConfigInputSet::new(vec![safe_effort, manual_budget]));
+    let pi: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
+
+    assert_eq!(
+        pi["providers"]["oceans-llm-anthropic-messages-adaptive-thinking"]["compat"]["forceAdaptiveThinking"],
+        true
+    );
+    assert!(
+        pi["providers"]["oceans-llm-anthropic-messages"]
+            .get("compat")
+            .is_none()
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm-anthropic-messages-adaptive-thinking"]["models"][0]["id"],
+        "claude-sonnet"
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm-anthropic-messages"]["models"][0]["id"],
+        "claude-haiku"
     );
 }
 
@@ -330,6 +360,31 @@ fn claude_code_filters_non_anthropic_models_from_mixed_selection() {
 }
 
 #[test]
+fn claude_code_deduplicates_duplicate_override_keys() {
+    let first = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    let mut alias = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    alias.model_id = "claude-sonnet-alias".to_string();
+
+    let rendered = ClaudeCodeConfigTemplate
+        .render_many(&ClientConfigInputSet::new(vec![first, alias]))
+        .expect("claude code config");
+    let gateway_settings: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
+
+    assert_eq!(rendered.model_ids, vec!["claude-sonnet"]);
+    assert_eq!(
+        gateway_settings["modelOverrides"]
+            .as_object()
+            .expect("model overrides")
+            .len(),
+        1
+    );
+    assert_eq!(
+        gateway_settings["modelOverrides"]["claude-sonnet-4-6"],
+        "claude-sonnet"
+    );
+}
+
+#[test]
 fn claude_code_is_omitted_when_no_anthropic_models_are_selected() {
     let rendered =
         render_default_configs_for_models(ClientConfigInputSet::new(vec![non_anthropic_input()]));
@@ -344,6 +399,15 @@ fn claude_code_is_omitted_when_no_anthropic_models_are_selected() {
             .render_many(&ClientConfigInputSet::new(vec![non_anthropic_input()]))
             .is_none()
     );
+}
+
+#[test]
+fn claude_code_render_does_not_panic_for_non_anthropic_input() {
+    let rendered = ClaudeCodeConfigTemplate.render(&non_anthropic_input());
+    let gateway_settings: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
+
+    assert_eq!(rendered.model_ids, vec!["qwen-coder"]);
+    assert_eq!(gateway_settings["env"]["ANTHROPIC_MODEL"], "qwen-coder");
 }
 
 #[test]
@@ -470,4 +534,20 @@ fn default_configs_include_codex_only_for_responses_capable_models() {
         .collect::<Vec<_>>();
 
     assert_eq!(chat_only_keys, vec!["opencode", "pi", "claude-code"]);
+}
+
+#[test]
+fn multi_model_configs_explain_codex_single_model_requirement() {
+    let rendered = render_default_configs_for_models(ClientConfigInputSet::new(vec![
+        input(Some(AnthropicThinkingPolicy::SafeEffort)),
+        non_anthropic_input(),
+    ]));
+
+    assert!(!rendered.iter().any(|config| config.key == "codex"));
+    assert!(rendered.iter().any(|config| {
+        config
+            .notes
+            .iter()
+            .any(|note| note.contains("Codex config snippets require a single"))
+    }));
 }

--- a/crates/gateway-client-config/src/types.rs
+++ b/crates/gateway-client-config/src/types.rs
@@ -62,6 +62,28 @@ impl ClientConfigInput {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientConfigInputSet {
+    pub models: Vec<ClientConfigInput>,
+}
+
+impl ClientConfigInputSet {
+    #[must_use]
+    pub fn new(models: Vec<ClientConfigInput>) -> Self {
+        Self { models }
+    }
+
+    #[must_use]
+    pub fn first(&self) -> Option<&ClientConfigInput> {
+        self.models.first()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.models.is_empty()
+    }
+}
+
 impl Default for ClientConfigInput {
     fn default() -> Self {
         Self {
@@ -88,6 +110,7 @@ impl Default for ClientConfigInput {
 pub struct ClientConfig {
     pub key: String,
     pub label: String,
+    pub model_ids: Vec<String>,
     pub blocks: Vec<ClientConfigCodeBlock>,
     pub notes: Vec<String>,
 }

--- a/crates/gateway-service/src/admin_models.rs
+++ b/crates/gateway-service/src/admin_models.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
 use gateway_client_config::{
-    ClientConfig, ClientConfigInput, ClientModelCapabilities, DEFAULT_API_KEY_ENV_VAR,
-    DEFAULT_GATEWAY_BASE_URL, DEFAULT_PROVIDER_ID, infer_anthropic_thinking_policy,
-    render_default_configs,
+    ClientConfig, ClientConfigInput, ClientConfigInputSet, ClientModelCapabilities,
+    DEFAULT_API_KEY_ENV_VAR, DEFAULT_GATEWAY_BASE_URL, DEFAULT_PROVIDER_ID,
+    infer_anthropic_thinking_policy, render_default_configs, render_default_configs_for_models,
 };
 use gateway_core::{
     GatewayError, GatewayModel, ModelPricingRecord, ModelRepository, ModelRoute,
@@ -63,6 +63,7 @@ pub struct AdminModelSummary {
 #[derive(Debug, Clone)]
 pub struct AdminModelsService<R> {
     repo: Arc<R>,
+    client_config_gateway_base_url: String,
 }
 
 impl<R> AdminModelsService<R>
@@ -71,10 +72,66 @@ where
 {
     #[must_use]
     pub fn new(repo: Arc<R>) -> Self {
-        Self { repo }
+        Self {
+            repo,
+            client_config_gateway_base_url: DEFAULT_GATEWAY_BASE_URL.to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_client_config_gateway_base_url(
+        mut self,
+        gateway_base_url: impl Into<String>,
+    ) -> Self {
+        self.client_config_gateway_base_url = gateway_base_url.into();
+        self
     }
 
     pub async fn list_models(&self) -> Result<Vec<AdminModelSummary>, GatewayError> {
+        Ok(self
+            .list_model_items()
+            .await?
+            .into_iter()
+            .map(|item| item.summary)
+            .collect())
+    }
+
+    pub async fn render_client_configurations(
+        &self,
+        model_keys: &[String],
+    ) -> Result<Vec<ClientConfig>, GatewayError> {
+        if model_keys.is_empty() {
+            return Err(GatewayError::InvalidRequest(
+                "model_keys must include at least one model".to_string(),
+            ));
+        }
+
+        let inputs_by_key = self
+            .list_model_items()
+            .await?
+            .into_iter()
+            .filter_map(|item| {
+                item.client_config_input
+                    .map(|input| (item.summary.id, input))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut inputs = Vec::with_capacity(model_keys.len());
+        for model_key in model_keys {
+            let input = inputs_by_key.get(model_key).ok_or_else(|| {
+                GatewayError::InvalidRequest(format!(
+                    "model_key `{model_key}` is not available for client config generation"
+                ))
+            })?;
+            inputs.push(input.clone());
+        }
+
+        Ok(render_default_configs_for_models(
+            ClientConfigInputSet::new(inputs),
+        ))
+    }
+
+    async fn list_model_items(&self) -> Result<Vec<AdminModelItem>, GatewayError> {
         if let Err(error) = PricingCatalog::new(self.repo.clone())
             .sync_current_snapshot()
             .await
@@ -150,75 +207,88 @@ where
                     .into_iter()
                     .chain([execution_model.model_key.as_str(), model.model_key.as_str()]),
             );
-            let client_configurations = build_client_configurations(ClientConfigContext {
+            let client_config_input = build_client_config_input(ClientConfigContext {
                 model: &model,
                 execution_model: &execution_model,
                 primary_route,
                 primary_provider,
                 provider_display: provider_display.as_ref(),
-                model_icon_key,
                 pricing_record: pricing_record.as_ref(),
                 route_capabilities,
+                gateway_base_url: &self.client_config_gateway_base_url,
             });
+            let client_configurations = client_config_input
+                .as_ref()
+                .map(render_default_configs)
+                .unwrap_or_default();
 
-            items.push(AdminModelSummary {
-                id: model.model_key.clone(),
-                model_id: model.id.to_string(),
-                resolved_model_key: execution_model.model_key.clone(),
-                alias_of: model.alias_target_model_key.clone(),
-                description: model.description.clone(),
-                tags: model.tags.clone(),
-                status,
-                provider_key: primary_route.map(|route| route.provider_key.clone()),
-                provider_label: provider_display
-                    .as_ref()
-                    .map(|display| display.label.clone()),
-                provider_icon_key: provider_display.map(|display| display.icon_key),
-                upstream_model: primary_route.map(|route| route.upstream_model.clone()),
-                model_icon_key,
-                input_cost_per_million_tokens_usd_10000: pricing_record.as_ref().and_then(
-                    |record| {
-                        record
-                            .input_cost_per_million_tokens
-                            .map(|value| value.as_scaled_i64())
-                    },
-                ),
-                output_cost_per_million_tokens_usd_10000: pricing_record.as_ref().and_then(
-                    |record| {
-                        record
-                            .output_cost_per_million_tokens
-                            .map(|value| value.as_scaled_i64())
-                    },
-                ),
-                cache_read_cost_per_million_tokens_usd_10000: pricing_record.as_ref().and_then(
-                    |record| {
-                        record
-                            .cache_read_cost_per_million_tokens
-                            .map(|value| value.as_scaled_i64())
-                    },
-                ),
-                context_window_tokens: pricing_record
-                    .as_ref()
-                    .and_then(|record| record.limits.context),
-                input_window_tokens: pricing_record
-                    .as_ref()
-                    .and_then(|record| record.limits.input),
-                output_window_tokens: pricing_record
-                    .as_ref()
-                    .and_then(|record| record.limits.output),
-                supports_streaming: route_capabilities.map(|caps| caps.stream),
-                supports_vision: route_capabilities.map(|caps| caps.vision),
-                supports_tool_calling: route_capabilities.map(|caps| caps.tools),
-                supports_structured_output: route_capabilities.map(|caps| caps.json_schema),
-                supports_attachments: pricing_record
-                    .as_ref()
-                    .map(|record| supports_attachments(&record.modalities)),
-                client_configurations,
+            items.push(AdminModelItem {
+                summary: AdminModelSummary {
+                    id: model.model_key.clone(),
+                    model_id: model.id.to_string(),
+                    resolved_model_key: execution_model.model_key.clone(),
+                    alias_of: model.alias_target_model_key.clone(),
+                    description: model.description.clone(),
+                    tags: model.tags.clone(),
+                    status,
+                    provider_key: primary_route.map(|route| route.provider_key.clone()),
+                    provider_label: provider_display
+                        .as_ref()
+                        .map(|display| display.label.clone()),
+                    provider_icon_key: provider_display.map(|display| display.icon_key),
+                    upstream_model: primary_route.map(|route| route.upstream_model.clone()),
+                    model_icon_key,
+                    input_cost_per_million_tokens_usd_10000: pricing_record.as_ref().and_then(
+                        |record| {
+                            record
+                                .input_cost_per_million_tokens
+                                .map(|value| value.as_scaled_i64())
+                        },
+                    ),
+                    output_cost_per_million_tokens_usd_10000: pricing_record.as_ref().and_then(
+                        |record| {
+                            record
+                                .output_cost_per_million_tokens
+                                .map(|value| value.as_scaled_i64())
+                        },
+                    ),
+                    cache_read_cost_per_million_tokens_usd_10000: pricing_record.as_ref().and_then(
+                        |record| {
+                            record
+                                .cache_read_cost_per_million_tokens
+                                .map(|value| value.as_scaled_i64())
+                        },
+                    ),
+                    context_window_tokens: pricing_record
+                        .as_ref()
+                        .and_then(|record| record.limits.context),
+                    input_window_tokens: pricing_record
+                        .as_ref()
+                        .and_then(|record| record.limits.input),
+                    output_window_tokens: pricing_record
+                        .as_ref()
+                        .and_then(|record| record.limits.output),
+                    supports_streaming: route_capabilities.map(|caps| caps.stream),
+                    supports_vision: route_capabilities.map(|caps| caps.vision),
+                    supports_tool_calling: route_capabilities.map(|caps| caps.tools),
+                    supports_structured_output: route_capabilities.map(|caps| caps.json_schema),
+                    supports_attachments: pricing_record
+                        .as_ref()
+                        .map(|record| supports_attachments(&record.modalities)),
+                    client_configurations,
+                },
+                client_config_input,
             });
         }
 
         Ok(items)
     }
+}
+
+#[derive(Debug, Clone)]
+struct AdminModelItem {
+    summary: AdminModelSummary,
+    client_config_input: Option<ClientConfigInput>,
 }
 
 struct ClientConfigContext<'a> {
@@ -227,27 +297,16 @@ struct ClientConfigContext<'a> {
     primary_route: Option<&'a ModelRoute>,
     primary_provider: Option<&'a ProviderConnection>,
     provider_display: Option<&'a crate::ProviderDisplayIdentity>,
-    model_icon_key: Option<ModelIconKey>,
     pricing_record: Option<&'a ModelPricingRecord>,
     route_capabilities: Option<ProviderCapabilities>,
+    gateway_base_url: &'a str,
 }
 
-fn build_client_configurations(context: ClientConfigContext<'_>) -> Vec<ClientConfig> {
-    if !is_anthropic_labeled(
-        context.model,
-        context.execution_model,
-        context.primary_route,
-        context.primary_provider,
-        context.provider_display,
-        context.model_icon_key,
-    ) {
-        return Vec::new();
-    }
-
+fn build_client_config_input(context: ClientConfigContext<'_>) -> Option<ClientConfigInput> {
+    let primary_route = context.primary_route?;
+    context.primary_provider?;
     let thinking_policy = infer_anthropic_thinking_policy(
-        context
-            .primary_route
-            .map(|route| route.upstream_model.as_str())
+        Some(primary_route.upstream_model.as_str())
             .into_iter()
             .chain(
                 context
@@ -273,9 +332,9 @@ fn build_client_configurations(context: ClientConfigContext<'_>) -> Vec<ClientCo
     let capabilities = effective_provider_route_capabilities(
         context.route_capabilities,
         context.primary_provider,
-        context.primary_route,
+        Some(primary_route),
     );
-    let input = ClientConfigInput {
+    Some(ClientConfigInput {
         model_id: context.model.model_key.clone(),
         display_name: context
             .model
@@ -292,7 +351,7 @@ fn build_client_configurations(context: ClientConfigContext<'_>) -> Vec<ClientCo
             .map(|route| route.upstream_model.clone()),
         provider_id: DEFAULT_PROVIDER_ID.to_string(),
         provider_name: DEFAULT_PROVIDER_ID.to_string(),
-        gateway_base_url: DEFAULT_GATEWAY_BASE_URL.to_string(),
+        gateway_base_url: context.gateway_base_url.to_string(),
         api_key_env_var: DEFAULT_API_KEY_ENV_VAR.to_string(),
         input_cost_per_million_tokens_usd_10000: context.pricing_record.and_then(|record| {
             record
@@ -327,9 +386,7 @@ fn build_client_configurations(context: ClientConfigContext<'_>) -> Vec<ClientCo
             vision: capabilities.vision,
         },
         thinking_policy,
-    };
-
-    render_default_configs(&input)
+    })
 }
 
 fn effective_provider_route_capabilities(
@@ -369,34 +426,6 @@ fn provider_capabilities(
         },
         _ => ProviderCapabilities::all_enabled(),
     }
-}
-
-fn is_anthropic_labeled(
-    model: &GatewayModel,
-    execution_model: &GatewayModel,
-    primary_route: Option<&ModelRoute>,
-    primary_provider: Option<&ProviderConnection>,
-    provider_display: Option<&crate::ProviderDisplayIdentity>,
-    model_icon_key: Option<ModelIconKey>,
-) -> bool {
-    matches!(
-        model_icon_key,
-        Some(ModelIconKey::Anthropic | ModelIconKey::Claude)
-    ) || provider_display.is_some_and(|display| display.icon_key == ProviderIconKey::Anthropic)
-        || [
-            Some(model.model_key.as_str()),
-            Some(execution_model.model_key.as_str()),
-            primary_route.map(|route| route.upstream_model.as_str()),
-            primary_provider.map(|provider| provider.provider_key.as_str()),
-            primary_provider.map(|provider| provider.provider_type.as_str()),
-            provider_display.map(|display| display.label.as_str()),
-        ]
-        .into_iter()
-        .flatten()
-        .any(|value| {
-            let value = value.to_ascii_lowercase();
-            value.contains("anthropic") || value.contains("claude")
-        })
 }
 
 async fn resolve_display_pricing<R>(
@@ -807,7 +836,14 @@ mod tests {
         assert_eq!(alias.supports_tool_calling, Some(true));
         assert_eq!(alias.supports_structured_output, Some(true));
         assert_eq!(alias.supports_attachments, Some(true));
-        assert!(alias.client_configurations.is_empty());
+        assert_eq!(
+            alias
+                .client_configurations
+                .iter()
+                .map(|config| config.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["opencode", "pi", "codex"]
+        );
     }
 
     #[tokio::test]
@@ -945,7 +981,14 @@ mod tests {
         assert_eq!(items[0].supports_vision, Some(false));
         assert_eq!(items[0].supports_structured_output, Some(true));
         assert_eq!(items[0].supports_attachments, Some(false));
-        assert!(items[0].client_configurations.is_empty());
+        assert_eq!(
+            items[0]
+                .client_configurations
+                .iter()
+                .map(|config| config.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["opencode", "pi"]
+        );
     }
 
     #[tokio::test]
@@ -1031,7 +1074,14 @@ mod tests {
         assert_eq!(items[0].supports_tool_calling, Some(true));
         assert_eq!(items[0].supports_structured_output, Some(true));
         assert_eq!(items[0].supports_attachments, None);
-        assert!(items[0].client_configurations.is_empty());
+        assert_eq!(
+            items[0]
+                .client_configurations
+                .iter()
+                .map(|config| config.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["opencode", "pi"]
+        );
     }
 
     #[tokio::test]
@@ -1143,6 +1193,24 @@ mod tests {
             items[0].client_configurations[2].blocks[1]
                 .content
                 .contains("\"CLAUDE_CODE_AUTO_COMPACT_WINDOW\": \"200000\"")
+        );
+
+        let service = AdminModelsService::new(build_repo(
+            "gcp_vertex",
+            ProviderCapabilities::with_dimensions(true, false, true, true, true, true, true),
+        ))
+        .with_client_config_gateway_base_url("https://gateway.example.com/v1");
+        let items = service.list_models().await.expect("admin models");
+
+        assert!(
+            items[0].client_configurations[0].blocks[0]
+                .content
+                .contains("\"baseURL\": \"https://gateway.example.com/v1\"")
+        );
+        assert!(
+            items[0].client_configurations[2].blocks[0]
+                .content
+                .contains("\"ANTHROPIC_BASE_URL\": \"https://gateway.example.com\"")
         );
 
         let service = AdminModelsService::new(build_repo(

--- a/crates/gateway-service/src/admin_models.rs
+++ b/crates/gateway-service/src/admin_models.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use gateway_client_config::{
     ClientConfig, ClientConfigInput, ClientConfigInputSet, ClientModelCapabilities,
@@ -117,7 +120,14 @@ where
             .collect::<HashMap<_, _>>();
 
         let mut inputs = Vec::with_capacity(model_keys.len());
+        let mut seen_model_keys = HashSet::with_capacity(model_keys.len());
         for model_key in model_keys {
+            if !seen_model_keys.insert(model_key) {
+                return Err(GatewayError::InvalidRequest(format!(
+                    "model_key `{model_key}` cannot be repeated"
+                )));
+            }
+
             let input = inputs_by_key.get(model_key).ok_or_else(|| {
                 GatewayError::InvalidRequest(format!(
                     "model_key `{model_key}` is not available for client config generation"
@@ -516,7 +526,7 @@ mod tests {
 
     use async_trait::async_trait;
     use gateway_core::{
-        GatewayModel, ModelPricingRecord, ModelRepository, ModelRoute, Money4,
+        GatewayError, GatewayModel, ModelPricingRecord, ModelRepository, ModelRoute, Money4,
         PricingCatalogCacheRecord, PricingCatalogRepository, PricingLimits, PricingModalities,
         PricingProvenance, ProviderCapabilities, ProviderConnection, ProviderRepository,
         StoreError,
@@ -844,6 +854,15 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["opencode", "pi", "codex"]
         );
+
+        let duplicate_error = service
+            .render_client_configurations(&[
+                "friendly-alias".to_string(),
+                "friendly-alias".to_string(),
+            ])
+            .await
+            .expect_err("duplicate model keys should be rejected");
+        assert!(matches!(duplicate_error, GatewayError::InvalidRequest(_)));
     }
 
     #[tokio::test]

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -1731,6 +1731,41 @@
         ]
       }
     },
+    "/api/v1/admin/models/client-configs": {
+      "post": {
+        "tags": [
+          "crate::http::models"
+        ],
+        "operationId": "generate_model_client_configs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateModelClientConfigsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_GenerateModelClientConfigsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          }
+        ]
+      }
+    },
     "/api/v1/admin/observability/harness-usage": {
       "get": {
         "tags": [
@@ -3426,6 +3461,7 @@
         "required": [
           "key",
           "label",
+          "model_ids",
           "blocks",
           "notes"
         ],
@@ -3441,6 +3477,12 @@
           },
           "label": {
             "type": "string"
+          },
+          "model_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "notes": {
             "type": "array",
@@ -5342,6 +5384,32 @@
           }
         }
       },
+      "Envelope_GenerateModelClientConfigsResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "required": [
+              "client_configurations"
+            ],
+            "properties": {
+              "client_configurations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AdminModelClientConfigView"
+                }
+              }
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          }
+        }
+      },
       "Envelope_HarnessUsageView": {
         "type": "object",
         "required": [
@@ -6356,6 +6424,34 @@
           },
           "meta": {
             "$ref": "#/components/schemas/ResponseMeta"
+          }
+        }
+      },
+      "GenerateModelClientConfigsRequest": {
+        "type": "object",
+        "required": [
+          "model_keys"
+        ],
+        "properties": {
+          "model_keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GenerateModelClientConfigsResponse": {
+        "type": "object",
+        "required": [
+          "client_configurations"
+        ],
+        "properties": {
+          "client_configurations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminModelClientConfigView"
+            }
           }
         }
       },

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -287,6 +287,7 @@ pub struct AdminModelView {
 pub struct AdminModelClientConfigView {
     pub key: String,
     pub label: String,
+    pub model_ids: Vec<String>,
     pub blocks: Vec<AdminModelClientConfigBlockView>,
     pub notes: Vec<String>,
 }
@@ -296,6 +297,16 @@ pub struct AdminModelClientConfigBlockView {
     pub label: String,
     pub filename: String,
     pub content: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct GenerateModelClientConfigsRequest {
+    pub model_keys: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GenerateModelClientConfigsResponse {
+    pub client_configurations: Vec<AdminModelClientConfigView>,
 }
 
 #[derive(Debug, Deserialize, Default, IntoParams)]
@@ -1132,6 +1143,7 @@ pub struct RequestLogPayloadView {
         crate::http::identity::list_identity_users,
         crate::http::identity::list_identity_teams,
         crate::http::models::list_models,
+        crate::http::models::generate_model_client_configs,
         crate::http::identity::create_identity_team,
         crate::http::identity::update_identity_team,
         crate::http::identity::add_identity_team_members,

--- a/crates/gateway/src/http/mod.rs
+++ b/crates/gateway/src/http/mod.rs
@@ -50,6 +50,10 @@ pub fn build_router(state: AppState, admin_ui: AdminUiConfig) -> Router {
         )
         .route("/api/v1/admin/models", get(list_models))
         .route(
+            "/api/v1/admin/models/client-configs",
+            post(generate_model_client_configs),
+        )
+        .route(
             "/api/v1/admin/identity/users",
             get(list_identity_users).post(create_identity_user),
         )

--- a/crates/gateway/src/http/models.rs
+++ b/crates/gateway/src/http/models.rs
@@ -9,7 +9,8 @@ use crate::http::{
     admin_auth::require_platform_admin,
     admin_contract::{
         AdminModelClientConfigBlockView, AdminModelClientConfigView, AdminModelListQuery,
-        AdminModelPageView, AdminModelView, Envelope, envelope,
+        AdminModelPageView, AdminModelView, Envelope, GenerateModelClientConfigsRequest,
+        GenerateModelClientConfigsResponse, envelope,
     },
     error::AppError,
     state::AppState,
@@ -39,7 +40,7 @@ pub async fn list_models(
         .unwrap_or(DEFAULT_PAGE_SIZE)
         .clamp(1, MAX_PAGE_SIZE);
 
-    let service = AdminModelsService::new(state.store.clone());
+    let service = admin_models_service(&state);
     let models = service.list_models().await?;
     let total = models.len() as u64;
     let start = page.saturating_sub(1).saturating_mul(page_size) as usize;
@@ -56,6 +57,57 @@ pub async fn list_models(
         page_size,
         total,
     })))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/admin/models/client-configs",
+    request_body = GenerateModelClientConfigsRequest,
+    responses((status = 200, body = Envelope<GenerateModelClientConfigsResponse>)),
+    security(("session_cookie" = []))
+)]
+pub async fn generate_model_client_configs(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<GenerateModelClientConfigsRequest>,
+) -> Result<Json<Envelope<GenerateModelClientConfigsResponse>>, AppError> {
+    require_platform_admin(&state, &headers).await?;
+
+    let service = admin_models_service(&state);
+    let client_configurations = service
+        .render_client_configurations(&request.model_keys)
+        .await?
+        .into_iter()
+        .map(|config| AdminModelClientConfigView {
+            key: config.key,
+            label: config.label,
+            model_ids: config.model_ids,
+            blocks: config
+                .blocks
+                .into_iter()
+                .map(|block| AdminModelClientConfigBlockView {
+                    label: block.label,
+                    filename: block.filename,
+                    content: block.content,
+                })
+                .collect(),
+            notes: config.notes,
+        })
+        .collect();
+
+    Ok(Json(envelope(GenerateModelClientConfigsResponse {
+        client_configurations,
+    })))
+}
+
+fn admin_models_service(state: &AppState) -> AdminModelsService<gateway_store::AnyStore> {
+    let service = AdminModelsService::new(state.store.clone());
+    match state.client_config_gateway_base_url.as_ref().as_deref() {
+        Some(gateway_base_url) => {
+            service.with_client_config_gateway_base_url(gateway_base_url.to_string())
+        }
+        None => service,
+    }
 }
 
 fn map_model_summary(model: AdminModelSummary) -> AdminModelView {
@@ -90,6 +142,7 @@ fn map_model_summary(model: AdminModelSummary) -> AdminModelView {
             .map(|config| AdminModelClientConfigView {
                 key: config.key,
                 label: config.label,
+                model_ids: config.model_ids,
                 blocks: config
                     .blocks
                     .into_iter()

--- a/crates/gateway/src/http/state.rs
+++ b/crates/gateway/src/http/state.rs
@@ -18,4 +18,5 @@ pub struct AppState {
     pub identity_token_secret: Arc<String>,
     pub oidc_public_base_url: Arc<Option<String>>,
     pub oauth_public_base_url: Arc<Option<String>>,
+    pub client_config_gateway_base_url: Arc<Option<String>>,
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -378,8 +378,12 @@ fn load_admin_ui_config() -> AdminUiConfig {
 }
 
 fn load_client_config_gateway_base_url() -> anyhow::Result<Option<String>> {
-    let Ok(raw_url) = env::var("GATEWAY_CLIENT_CONFIG_BASE_URL") else {
-        return Ok(None);
+    let raw_url = match env::var("GATEWAY_CLIENT_CONFIG_BASE_URL") {
+        Ok(raw_url) => raw_url,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("GATEWAY_CLIENT_CONFIG_BASE_URL must be valid Unicode")
+        }
     };
     let trimmed = raw_url.trim();
     if trimmed.is_empty() {

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -204,6 +204,10 @@ async fn run_serve_with_store(
                     .resolved_public_base_url()
                     .context("failed resolving OAuth public base URL")?,
             ),
+            client_config_gateway_base_url: Arc::new(
+                load_client_config_gateway_base_url()
+                    .context("failed resolving client config gateway base URL")?,
+            ),
         },
         load_admin_ui_config(),
     );
@@ -371,6 +375,35 @@ fn load_admin_ui_config() -> AdminUiConfig {
         connect_timeout_ms: env_u64("ADMIN_UI_CONNECT_TIMEOUT_MS", 750),
         request_timeout_ms: env_u64("ADMIN_UI_REQUEST_TIMEOUT_MS", 10_000),
     }
+}
+
+fn load_client_config_gateway_base_url() -> anyhow::Result<Option<String>> {
+    let Ok(raw_url) = env::var("GATEWAY_CLIENT_CONFIG_BASE_URL") else {
+        return Ok(None);
+    };
+    let trimmed = raw_url.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("GATEWAY_CLIENT_CONFIG_BASE_URL cannot be empty");
+    }
+    if trimmed.len() != raw_url.len() {
+        anyhow::bail!(
+            "GATEWAY_CLIENT_CONFIG_BASE_URL cannot include leading or trailing whitespace"
+        );
+    }
+
+    let parsed = url::Url::parse(trimmed)
+        .context("GATEWAY_CLIENT_CONFIG_BASE_URL must be an absolute URL")?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        scheme => {
+            anyhow::bail!("GATEWAY_CLIENT_CONFIG_BASE_URL scheme `{scheme}` is not supported")
+        }
+    }
+    if parsed.host().is_none() {
+        anyhow::bail!("GATEWAY_CLIENT_CONFIG_BASE_URL must include a host");
+    }
+
+    Ok(Some(trimmed.trim_end_matches('/').to_string()))
 }
 
 fn spawn_pricing_catalog_refresh_loop(

--- a/deploy/helm/oceans-llm/README.md
+++ b/deploy/helm/oceans-llm/README.md
@@ -37,6 +37,10 @@ For production installs, provide at least:
 - `GATEWAY_IDENTITY_TOKEN_SECRET`
 - provider credentials referenced by `gateway.config.providers`
 
+Set `gateway.clientConfigGatewayBaseUrl` when users will copy generated client
+configuration snippets from `/admin/models`. Use the public gateway API base URL,
+including `/v1`, for example `https://gateway.example.com/v1`.
+
 By default, the chart rejects `literal.*` references in `gateway.config` because
 the config is rendered into a ConfigMap. Use `env.*` references backed by
 Kubernetes Secrets. Set `gateway.allowLiteralSecretsInConfig=true` only for an

--- a/deploy/helm/oceans-llm/templates/_helpers.tpl
+++ b/deploy/helm/oceans-llm/templates/_helpers.tpl
@@ -177,6 +177,10 @@ app.kubernetes.io/component: {{ .component }}
   value: "false"
 - name: GATEWAY_SEED_CONFIG
   value: "false"
+{{- with .Values.gateway.clientConfigGatewayBaseUrl }}
+- name: GATEWAY_CLIENT_CONFIG_BASE_URL
+  value: {{ . | quote }}
+{{- end }}
 {{- if eq .Values.database.mode "external" }}
 {{- with .Values.database.external.existingSecret.name }}
 - name: POSTGRES_URL

--- a/deploy/helm/oceans-llm/values.schema.json
+++ b/deploy/helm/oceans-llm/values.schema.json
@@ -12,6 +12,10 @@
         "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "configMountPath": { "type": "string", "minLength": 1 },
         "allowLiteralSecretsInConfig": { "type": "boolean" },
+        "clientConfigGatewayBaseUrl": {
+          "type": "string",
+          "description": "Public gateway API base URL used in generated client config snippets, for example https://gateway.example.com/v1."
+        },
         "config": {
           "type": "object",
           "description": "Structured gateway.yaml content rendered into the ConfigMap."

--- a/deploy/helm/oceans-llm/values.schema.json
+++ b/deploy/helm/oceans-llm/values.schema.json
@@ -13,7 +13,10 @@
         "configMountPath": { "type": "string", "minLength": 1 },
         "allowLiteralSecretsInConfig": { "type": "boolean" },
         "clientConfigGatewayBaseUrl": {
-          "type": "string",
+          "oneOf": [
+            { "type": "string", "maxLength": 0 },
+            { "type": "string", "pattern": "^https?://\\S+$" }
+          ],
           "description": "Public gateway API base URL used in generated client config snippets, for example https://gateway.example.com/v1."
         },
         "config": {

--- a/deploy/helm/oceans-llm/values.yaml
+++ b/deploy/helm/oceans-llm/values.yaml
@@ -19,6 +19,7 @@ gateway:
   containerPort: 8080
   configMountPath: /app/gateway.yaml
   allowLiteralSecretsInConfig: false
+  clientConfigGatewayBaseUrl: ""
   config:
     server:
       bind: "0.0.0.0:8080"

--- a/docs/adr/2026-05-02-server-generated-client-config-snippets.md
+++ b/docs/adr/2026-05-02-server-generated-client-config-snippets.md
@@ -18,8 +18,8 @@ Implementation points:
 - `crates/gateway-client-config` owns the config templating boundary.
 - `ClientConfigTemplate` is the shared interface for client-specific renderers.
 - OpenCode and Pi are implemented as separate templates with their own JSON shapes.
-- `AdminModelsService` builds snippets only for Anthropic-labeled rows.
-- The admin model list payload includes `client_configurations`, so the UI does not need a second endpoint.
+- `AdminModelsService` builds snippets for routed models with enough route/provider metadata.
+- The admin model list payload includes one-model `client_configurations` for row actions, and `POST /api/v1/admin/models/client-configs` renders a selected model set.
 - The crate centralizes Anthropic thinking policy for this feature: safe-effort variants are emitted only for Claude 4.6/4.7/Mythos-style families, while manual-budget Claude models remain reasoning-capable without generated variants.
 
 ## Why
@@ -32,9 +32,9 @@ A separate crate gives this feature a clear ownership boundary. Future clients c
 
 The server now ships presentation-oriented JSON snippets. That is intentional for this slice, but the templates should stay limited to end-user client configuration and should not become a second provider request-mapping layer.
 
-Anthropic thinking policy currently relies on conservative model-name inference because the catalog does not yet expose a first-class typed thinking policy flag. This is acceptable for the initial Anthropic-only slice, but it should move to explicit metadata when the provider/model policy surface is stable.
+Anthropic thinking policy currently relies on conservative model-name inference because the catalog does not yet expose a first-class typed thinking policy flag. This should move to explicit metadata when the provider/model policy surface is stable.
 
-The list payload becomes larger for supported rows because snippets are embedded. Each row includes only the clicked model's configurations, so the payload remains bounded by the visible page size and avoids another request path.
+The list payload becomes larger for supported rows because one-model snippets are embedded. Multi-model snippets use the selected-model endpoint so the browser does not merge JSON strings and the list payload remains bounded by the visible page size.
 
 ## 2026-06-11 Update: Claude Code Multi-Block Snippets
 
@@ -42,10 +42,24 @@ Claude Code is now implemented as another `ClientConfigTemplate`. Client configu
 
 Claude Code uses an Anthropic-compatible gateway base URL and appends endpoints such as `/v1/messages` and `/v1/models`. The template derives that base from the OpenAI-compatible `/v1` gateway URL used by OpenCode and Pi so copied Claude Code settings do not point at the OpenAI client base.
 
+## 2026-06-27 Update: Multi-Model Snippet Generation
+
+Client configuration rendering now accepts a selected model set. OpenCode and Pi group selected models by client API style before rendering provider entries, because both clients keep the adapter at provider scope. Mixed Anthropic Messages and OpenAI-compatible selections therefore generate separate Oceans provider ids instead of one invalid provider.
+
+Claude Code rendering filters the selected set to Anthropic Messages models and omits the Claude Code tab when none are selected. This keeps non-Anthropic gateway models available for OpenCode and Pi without producing invalid Claude Code `modelOverrides`.
+
+The admin UI calls `POST /api/v1/admin/models/client-configs` for selected-model generation. This keeps provider grouping, Claude filtering, pricing metadata, and thinking-policy rendering in Rust instead of duplicating those rules in React.
+
+## 2026-06-27 Update: Public Gateway Base URL
+
+Generated snippets use `GATEWAY_CLIENT_CONFIG_BASE_URL` when the gateway process sets it, falling back to the local development URL otherwise. Helm exposes this through `gateway.clientConfigGatewayBaseUrl` and renders it as a gateway pod environment variable.
+
+The browser origin is deliberately not used as the source of truth. Admin UI routing can differ from the public API origin local harnesses should call, especially behind ingress, path rewriting, or a split admin/API deployment.
+
 ## Follow-ups
 
 - Replace Anthropic model-name inference with typed provider/model metadata when available.
 - Consider validating OpenCode output against a pinned OpenCode config schema.
 - Consider validating Claude Code output against the SchemaStore `claude-code-settings.json` schema.
 - Add more client templates only through the `ClientConfigTemplate` boundary.
-- Revisit whether deployment-specific base URL/API key defaults should be configurable instead of fixed placeholders.
+- Revisit whether deployment-specific API key placeholders should be configurable instead of fixed placeholders.

--- a/docs/configuration/client-harness-configuration.md
+++ b/docs/configuration/client-harness-configuration.md
@@ -6,13 +6,19 @@
 
 Oceans generates client configuration snippets from the live model catalog so users can point local agent harnesses at the gateway without hand-writing model metadata.
 
-Open `/admin/models`, choose a model, then click **Client config**. Supported Anthropic-backed models show snippets for:
+Open `/admin/models`, select one or more configurable models, then click **Generate config**. You can also use the row-level client config action to generate a one-model snippet.
+
+Generated snippets are available for:
 
 - [OpenCode]
 - [Pi]
 - [Claude Code]
 
-The snippets use the gateway model id shown in the Models table. API keys are still created and governed in Oceans; the local client config only tells the harness which gateway URL, key variable, and model id to use.
+The snippets use the gateway model ids shown in the Models table. API keys are still created and governed in Oceans; the local client config only tells the harness which gateway URL, key variable, and model ids to use.
+
+By default, snippets use the local development gateway base URL `http://127.0.0.1:3000/v1`. Production deployments should set `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway process, or `gateway.clientConfigGatewayBaseUrl` in the Helm chart, to the public gateway API base URL users can reach, for example `https://gateway.example.com/v1`.
+
+OpenCode and Pi can include multiple selected models in one generated file. When the selection mixes Anthropic Messages models and OpenAI-compatible models, Oceans emits separate provider entries so each provider keeps the correct client adapter. Claude Code only includes selected models that use Anthropic Messages; non-Anthropic selections are ignored for the Claude Code tab instead of generating invalid overrides.
 
 ## Claude Code
 
@@ -22,9 +28,9 @@ The Claude Code tab emits `.claude/settings.json` content with the SchemaStore C
 - `ANTHROPIC_BASE_URL`, set to the Claude-compatible gateway base URL
 - `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`, so Claude Code can discover gateway-routed models
 - `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, and the matching default model class variable
-- `modelOverrides`, mapping Claude Code's Anthropic model id to the selected gateway model id
+- `modelOverrides`, mapping Claude Code's Anthropic model ids to the selected gateway model ids
 
-Claude Code appends Anthropic endpoints such as `/v1/messages` and `/v1/models` to `ANTHROPIC_BASE_URL`. Do not include `/v1/messages` in the value. OpenCode and Pi still use the OpenAI-compatible `/v1` base URL.
+Claude Code appends Anthropic endpoints such as `/v1/messages` and `/v1/models` to `ANTHROPIC_BASE_URL`. Do not include `/v1/messages` in the configured gateway URL. OpenCode and Pi still use the OpenAI-compatible `/v1` base URL, grouped by client API style when needed.
 
 The same dialog also shows a second `settings.json` block for a smaller local Claude Code experience. It disables telemetry, experimental betas, 1M context, and related UI/reporting behavior, and sets a lower auto-compact window.
 

--- a/docs/reference/screenshots.md
+++ b/docs/reference/screenshots.md
@@ -18,7 +18,7 @@ Shows configured models, provider identity, model metadata, and routing context.
 
 ## Model Client Config
 
-Shows generated client configuration snippets for a selected model, including multi-block clients such as Claude Code `settings.json`.
+Shows generated client configuration snippets for selected models, including grouped OpenCode/Pi providers and multi-block clients such as Claude Code `settings.json`.
 
 ![Model client config](../public/images/screenshot-model-client-config.png)
 

--- a/docs/setup/kubernetes-and-helm.md
+++ b/docs/setup/kubernetes-and-helm.md
@@ -42,7 +42,7 @@ All public HTTP traffic enters through the gateway service. The admin UI service
 
 The chart intentionally has no raw YAML fallback value. Keep deploy-specific config in values files and let the chart render the gateway config.
 
-Set `gateway.clientConfigGatewayBaseUrl` to the public gateway API base URL that users should copy into generated client snippets. This value is rendered as `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway pod. Use the externally reachable OpenAI-compatible base URL, including `/v1`, for example:
+Set `gateway.clientConfigGatewayBaseUrl` to the public gateway API base URL that admins should copy into generated client snippets. This value is rendered as `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway pod. Use the externally reachable OpenAI-compatible base URL, including `/v1`, for example:
 
 ```yaml
 gateway:

--- a/docs/setup/kubernetes-and-helm.md
+++ b/docs/setup/kubernetes-and-helm.md
@@ -42,6 +42,15 @@ All public HTTP traffic enters through the gateway service. The admin UI service
 
 The chart intentionally has no raw YAML fallback value. Keep deploy-specific config in values files and let the chart render the gateway config.
 
+Set `gateway.clientConfigGatewayBaseUrl` to the public gateway API base URL that users should copy into generated client snippets. This value is rendered as `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway pod. Use the externally reachable OpenAI-compatible base URL, including `/v1`, for example:
+
+```yaml
+gateway:
+  clientConfigGatewayBaseUrl: https://gateway.example.com/v1
+```
+
+Do not rely on the admin UI browser origin for this value. The admin UI may be served through a different ingress path or internal proxy than the API endpoint used by local harnesses.
+
 ## Secrets
 
 The gateway config supports `env.*` and `literal.*` secret references. Kubernetes installs should use env-backed references for deploy-time secrets because Helm renders `gateway.config` into a ConfigMap.


### PR DESCRIPTION
## Description

Closes #188.

- Adds server-generated multi-model client config rendering for selected Models rows.
- Adds `POST /api/v1/admin/models/client-configs` and updates the generated admin OpenAPI/TypeScript contract.
- Groups OpenCode and Pi configs by client API style so mixed Anthropic Messages and OpenAI-compatible selections produce separate valid providers.
- Filters Claude Code config generation to Anthropic Messages models and reports the applicable `model_ids` per generated config.
- Restyles the desktop Models table with bulk selection and client config actions aligned with the existing admin table patterns.
- Adds `GATEWAY_CLIENT_CONFIG_BASE_URL` and Helm `gateway.clientConfigGatewayBaseUrl` so generated snippets use the public gateway API URL instead of assuming `127.0.0.1`.
- Updates user-facing client harness docs, Helm setup docs, screenshot references, and the client-config ADR.

The public gateway URL is explicitly configured instead of inferred from the browser. The admin UI origin can differ from the API origin behind ingress, proxying, or split deployment topology, so browser inference would produce invalid snippets in common production setups.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation run:

- [x] `cargo test -p gateway-client-config`
- [x] `cargo test -p gateway-service admin_models`
- [x] `mise run admin-contract-check`
- [x] `mise run ui-test -- models-route.test.tsx`
- [x] `mise run helm-check`
- [x] In-app browser validation for mixed-model config generation and configured public snippet URL
