### PR TITLE
fix(auth): improve github oauth email verification handling

### DIFF
--- a/crates/admin-ui/web/src/routes/account-ready.tsx
+++ b/crates/admin-ui/web/src/routes/account-ready.tsx
@@ -2,12 +2,13 @@ import { createFileRoute } from '@tanstack/react-router'
 
 import { AuthLayout } from '@/components/layout/auth-layout'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 
 export const Route = createFileRoute('/account-ready')({
   component: AccountReadyPage,
 })
 
-function AccountReadyPage() {
+export function AccountReadyPage() {
   const search = Route.useSearch() as { mode?: string; email?: string }
 
   return (
@@ -26,6 +27,11 @@ function AccountReadyPage() {
           You can close this page and return to the gateway control-plane workflow.
         </AlertDescription>
       </Alert>
+      <div className="flex justify-end">
+        <Button asChild>
+          <a href="/admin">Open control plane</a>
+        </Button>
+      </div>
     </AuthLayout>
   )
 }

--- a/crates/admin-ui/web/src/routes/login.tsx
+++ b/crates/admin-ui/web/src/routes/login.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute('/login')({
   component: LoginPage,
 })
 
-function LoginPage() {
+export function LoginPage() {
   const search = Route.useSearch()
   const oidcLoginOptions = Route.useLoaderData()
   const oidcProviders = oidcLoginOptions.oidcProviders
@@ -161,13 +161,15 @@ function ssoRedirectTarget(redirect: string | undefined) {
   return '/admin'
 }
 
-function ssoErrorMessage(code: string | undefined) {
+export function ssoErrorMessage(code: string | undefined) {
   switch (code) {
     case 'access_denied':
     case 'denied':
       return 'Access was denied for this SSO account.'
     case 'unmatched_identity':
       return 'This SSO account is not allowed to sign in.'
+    case 'github_unverified_email':
+      return 'GitHub did not return a primary verified email for this account. Verify your primary email at https://github.com/settings/emails, then try signing in again.'
     case 'state_expired':
       return 'The SSO sign-in request expired. Start sign-in again.'
     case 'state_invalid':

--- a/crates/admin-ui/web/src/test/routes/account-ready-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/account-ready-route.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routeMock = {
+  useSearch: vi.fn(),
+}
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => routeMock,
+}))
+
+describe('AccountReadyPage', () => {
+  beforeEach(() => {
+    routeMock.useSearch.mockReturnValue({ mode: 'oauth' })
+  })
+
+  it('links back to the control plane after onboarding', async () => {
+    const { AccountReadyPage } = await import('@/routes/account-ready')
+
+    render(<AccountReadyPage />)
+
+    expect(screen.getByRole('link', { name: 'Open control plane' })).toHaveAttribute(
+      'href',
+      '/admin',
+    )
+  })
+})

--- a/crates/admin-ui/web/src/test/routes/login-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/login-route.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => ({}),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/server/admin-data.functions', () => ({
+  getOidcLoginOptions: vi.fn(),
+  loginAdminWithPassword: vi.fn(),
+}))
+
+describe('login SSO errors', () => {
+  it('explains GitHub unverified primary email failures', async () => {
+    const { ssoErrorMessage } = await import('@/routes/login')
+
+    expect(ssoErrorMessage('github_unverified_email')).toContain(
+      'https://github.com/settings/emails',
+    )
+  })
+})

--- a/crates/gateway-core/src/domain.rs
+++ b/crates/gateway-core/src/domain.rs
@@ -569,6 +569,7 @@ pub struct OauthProviderRecord {
     pub client_secret_ref: String,
     pub scopes: Vec<String>,
     pub allowed_email_domains: Vec<String>,
+    pub sso_email_verification_enabled: bool,
     pub enabled: bool,
     pub jit: OauthJitPolicy,
     pub created_at: OffsetDateTime,
@@ -2441,6 +2442,7 @@ pub struct SeedOauthProvider {
     pub client_secret_ref: String,
     pub scopes: Vec<String>,
     pub allowed_email_domains: Vec<String>,
+    pub sso_email_verification_enabled: bool,
     pub enabled: bool,
     pub jit: OauthJitPolicy,
 }

--- a/crates/gateway-store/migrations/V33__oauth_provider_sso_email_verification.sql
+++ b/crates/gateway-store/migrations/V33__oauth_provider_sso_email_verification.sql
@@ -1,2 +1,2 @@
 ALTER TABLE oauth_providers
-    ADD COLUMN sso_email_verification_enabled INTEGER NOT NULL DEFAULT 1;
+    ADD COLUMN sso_email_verification_enabled INTEGER NOT NULL DEFAULT 1 CHECK (sso_email_verification_enabled IN (0, 1));

--- a/crates/gateway-store/migrations/V33__oauth_provider_sso_email_verification.sql
+++ b/crates/gateway-store/migrations/V33__oauth_provider_sso_email_verification.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_providers
+    ADD COLUMN sso_email_verification_enabled INTEGER NOT NULL DEFAULT 1;

--- a/crates/gateway-store/migrations/postgres/V33__oauth_provider_sso_email_verification.sql
+++ b/crates/gateway-store/migrations/postgres/V33__oauth_provider_sso_email_verification.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_providers
+    ADD COLUMN sso_email_verification_enabled BIGINT NOT NULL DEFAULT 1 CHECK (sso_email_verification_enabled IN (0, 1));

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -99,6 +99,7 @@ mod tests {
             client_secret_ref: "literal.secret".to_string(),
             scopes: vec!["read:user".to_string(), "user:email".to_string()],
             allowed_email_domains: domains.into_iter().map(str::to_string).collect(),
+            sso_email_verification_enabled: true,
             enabled: true,
             jit: OauthJitPolicy::default(),
         }
@@ -4337,20 +4338,13 @@ mod tests {
             providers[0].allowed_email_domains,
             vec!["test.com".to_string()]
         );
+        assert!(providers[0].sso_email_verification_enabled);
 
+        let mut updated_provider =
+            seed_github_oauth_provider_with_domains(vec!["example.com", "team.example.com"]);
+        updated_provider.sso_email_verification_enabled = false;
         store
-            .seed_from_inputs(
-                &[],
-                &[],
-                &[],
-                &[],
-                &[seed_github_oauth_provider_with_domains(vec![
-                    "example.com",
-                    "team.example.com",
-                ])],
-                &[],
-                &[],
-            )
+            .seed_from_inputs(&[], &[], &[], &[], &[updated_provider], &[], &[])
             .await
             .expect("update provider");
         let provider = store
@@ -4362,6 +4356,7 @@ mod tests {
             provider.allowed_email_domains,
             vec!["example.com".to_string(), "team.example.com".to_string()]
         );
+        assert!(!provider.sso_email_verification_enabled);
     }
 
     #[tokio::test]
@@ -4407,20 +4402,13 @@ mod tests {
             providers[0].allowed_email_domains,
             vec!["test.com".to_string()]
         );
+        assert!(providers[0].sso_email_verification_enabled);
 
+        let mut updated_provider =
+            seed_github_oauth_provider_with_domains(vec!["example.com", "team.example.com"]);
+        updated_provider.sso_email_verification_enabled = false;
         store
-            .seed_from_inputs(
-                &[],
-                &[],
-                &[],
-                &[],
-                &[seed_github_oauth_provider_with_domains(vec![
-                    "example.com",
-                    "team.example.com",
-                ])],
-                &[],
-                &[],
-            )
+            .seed_from_inputs(&[], &[], &[], &[], &[updated_provider], &[], &[])
             .await
             .expect("update provider");
         let provider = store
@@ -4432,6 +4420,7 @@ mod tests {
             provider.allowed_email_domains,
             vec!["example.com".to_string(), "team.example.com".to_string()]
         );
+        assert!(!provider.sso_email_verification_enabled);
 
         store.pool().close().await;
         drop_postgres_test_database(&test_db).await;

--- a/crates/gateway-store/src/libsql_store/identity.rs
+++ b/crates/gateway-store/src/libsql_store/identity.rs
@@ -504,7 +504,7 @@ impl LibsqlStore {
                        scopes_json, enabled, label, client_secret_ref, jit_enabled,
                        jit_global_role, jit_team_key, jit_team_role,
                        jit_request_logging_enabled, allowed_email_domains_json,
-                       created_at, updated_at
+                       sso_email_verification_enabled, created_at, updated_at
                 FROM oauth_providers
                 WHERE enabled = 1
                 ORDER BY provider_key ASC
@@ -534,7 +534,7 @@ impl LibsqlStore {
                        scopes_json, enabled, label, client_secret_ref, jit_enabled,
                        jit_global_role, jit_team_key, jit_team_role,
                        jit_request_logging_enabled, allowed_email_domains_json,
-                       created_at, updated_at
+                       sso_email_verification_enabled, created_at, updated_at
                 FROM oauth_providers
                 WHERE provider_key = ?1 AND enabled = 1
                 LIMIT 1

--- a/crates/gateway-store/src/libsql_store/seed.rs
+++ b/crates/gateway-store/src/libsql_store/seed.rs
@@ -159,8 +159,8 @@ impl LibsqlStore {
                         scopes_json, enabled, label, client_secret_ref, jit_enabled,
                         jit_global_role, jit_team_key, jit_team_role,
                         jit_request_logging_enabled, allowed_email_domains_json,
-                        created_at, updated_at
-                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
+                        sso_email_verification_enabled, created_at, updated_at
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?16)
                     ON CONFLICT(provider_key) DO UPDATE SET
                         provider_type = excluded.provider_type,
                         client_id = excluded.client_id,
@@ -174,6 +174,7 @@ impl LibsqlStore {
                         jit_team_role = excluded.jit_team_role,
                         jit_request_logging_enabled = excluded.jit_request_logging_enabled,
                         allowed_email_domains_json = excluded.allowed_email_domains_json,
+                        sso_email_verification_enabled = excluded.sso_email_verification_enabled,
                         updated_at = excluded.updated_at
                     "#,
                     libsql::params![
@@ -203,6 +204,11 @@ impl LibsqlStore {
                             0_i64
                         },
                         allowed_email_domains_json,
+                        if provider.sso_email_verification_enabled {
+                            1_i64
+                        } else {
+                            0_i64
+                        },
                         now_unix,
                     ],
                 )

--- a/crates/gateway-store/src/libsql_store/support.rs
+++ b/crates/gateway-store/src/libsql_store/support.rs
@@ -336,8 +336,9 @@ pub(super) fn decode_oauth_provider_record(
     let jit_team_role: Option<String> = row.get(11).map_err(to_query_error)?;
     let jit_request_logging_enabled: i64 = row.get(12).map_err(to_query_error)?;
     let allowed_email_domains_json: String = row.get(13).map_err(to_query_error)?;
-    let created_at: i64 = row.get(14).map_err(to_query_error)?;
-    let updated_at: i64 = row.get(15).map_err(to_query_error)?;
+    let sso_email_verification_enabled: i64 = row.get(14).map_err(to_query_error)?;
+    let created_at: i64 = row.get(15).map_err(to_query_error)?;
+    let updated_at: i64 = row.get(16).map_err(to_query_error)?;
     let provider_key: String = row.get(1).map_err(to_query_error)?;
     let label: Option<String> = row.get(6).map_err(to_query_error)?;
 
@@ -355,6 +356,7 @@ pub(super) fn decode_oauth_provider_record(
             .map_err(|error| StoreError::Serialization(error.to_string()))?,
         allowed_email_domains: serde_json::from_str(&allowed_email_domains_json)
             .map_err(|error| StoreError::Serialization(error.to_string()))?,
+        sso_email_verification_enabled: sso_email_verification_enabled == 1,
         enabled: enabled == 1,
         jit: OauthJitPolicy {
             enabled: jit_enabled == 1,

--- a/crates/gateway-store/src/migration_registry.rs
+++ b/crates/gateway-store/src/migration_registry.rs
@@ -143,6 +143,15 @@ pub(crate) const MIGRATION_REGISTRY: &[MigrationManifest] = &[
             "../migrations/postgres/V32__oauth_provider_allowed_email_domains.sql"
         ),
     },
+    MigrationManifest {
+        version: 33,
+        name: "oauth_provider_sso_email_verification",
+        checksum: "V33__oauth_provider_sso_email_verification.sql",
+        libsql_sql: include_str!("../migrations/V33__oauth_provider_sso_email_verification.sql"),
+        postgres_sql: include_str!(
+            "../migrations/postgres/V33__oauth_provider_sso_email_verification.sql"
+        ),
+    },
 ];
 
 #[cfg(test)]

--- a/crates/gateway-store/src/postgres_store/identity.rs
+++ b/crates/gateway-store/src/postgres_store/identity.rs
@@ -436,7 +436,7 @@ impl PostgresStore {
                    scopes_json, enabled, label, client_secret_ref, jit_enabled,
                    jit_global_role, jit_team_key, jit_team_role,
                    jit_request_logging_enabled, allowed_email_domains_json,
-                   created_at, updated_at
+                   sso_email_verification_enabled, created_at, updated_at
             FROM oauth_providers
             WHERE enabled = 1
             ORDER BY provider_key ASC
@@ -459,7 +459,7 @@ impl PostgresStore {
                    scopes_json, enabled, label, client_secret_ref, jit_enabled,
                    jit_global_role, jit_team_key, jit_team_role,
                    jit_request_logging_enabled, allowed_email_domains_json,
-                   created_at, updated_at
+                   sso_email_verification_enabled, created_at, updated_at
             FROM oauth_providers
             WHERE provider_key = $1 AND enabled = 1
             LIMIT 1

--- a/crates/gateway-store/src/postgres_store/seed.rs
+++ b/crates/gateway-store/src/postgres_store/seed.rs
@@ -156,8 +156,8 @@ impl PostgresStore {
                     scopes_json, enabled, label, client_secret_ref, jit_enabled,
                     jit_global_role, jit_team_key, jit_team_role,
                     jit_request_logging_enabled, allowed_email_domains_json,
-                    created_at, updated_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $15)
+                    sso_email_verification_enabled, created_at, updated_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $16)
                 ON CONFLICT(provider_key) DO UPDATE SET
                     provider_type = excluded.provider_type,
                     client_id = excluded.client_id,
@@ -171,6 +171,7 @@ impl PostgresStore {
                     jit_team_role = excluded.jit_team_role,
                     jit_request_logging_enabled = excluded.jit_request_logging_enabled,
                     allowed_email_domains_json = excluded.allowed_email_domains_json,
+                    sso_email_verification_enabled = excluded.sso_email_verification_enabled,
                     updated_at = excluded.updated_at
                 "#,
             )
@@ -204,6 +205,11 @@ impl PostgresStore {
                 0_i64
             })
             .bind(allowed_email_domains_json)
+            .bind(if provider.sso_email_verification_enabled {
+                1_i64
+            } else {
+                0_i64
+            })
             .bind(now_unix)
             .execute(&self.pool)
             .await

--- a/crates/gateway-store/src/postgres_store/support.rs
+++ b/crates/gateway-store/src/postgres_store/support.rs
@@ -310,8 +310,9 @@ pub(super) fn decode_oauth_provider_record(row: &PgRow) -> Result<OauthProviderR
     let jit_team_role: Option<String> = row.try_get(11).map_err(to_query_error)?;
     let jit_request_logging_enabled: i64 = row.try_get(12).map_err(to_query_error)?;
     let allowed_email_domains_json: String = row.try_get(13).map_err(to_query_error)?;
-    let created_at: i64 = row.try_get(14).map_err(to_query_error)?;
-    let updated_at: i64 = row.try_get(15).map_err(to_query_error)?;
+    let sso_email_verification_enabled: i64 = row.try_get(14).map_err(to_query_error)?;
+    let created_at: i64 = row.try_get(15).map_err(to_query_error)?;
+    let updated_at: i64 = row.try_get(16).map_err(to_query_error)?;
     let provider_key: String = row.try_get(1).map_err(to_query_error)?;
     let label: Option<String> = row.try_get(6).map_err(to_query_error)?;
 
@@ -329,6 +330,7 @@ pub(super) fn decode_oauth_provider_record(row: &PgRow) -> Result<OauthProviderR
             .map_err(|error| StoreError::Serialization(error.to_string()))?,
         allowed_email_domains: serde_json::from_str(&allowed_email_domains_json)
             .map_err(|error| StoreError::Serialization(error.to_string()))?,
+        sso_email_verification_enabled: sso_email_verification_enabled == 1,
         enabled: enabled == 1,
         jit: OauthJitPolicy {
             enabled: jit_enabled == 1,

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1403,6 +1403,8 @@ pub struct OauthProviderConfig {
     pub scopes: Vec<String>,
     #[serde(default)]
     pub allowed_email_domains: Vec<String>,
+    #[serde(default = "default_sso_email_verification_enabled")]
+    pub sso_email_verification_enabled: bool,
     #[serde(default = "default_enabled")]
     pub enabled: bool,
     #[serde(default)]
@@ -1431,6 +1433,7 @@ impl OauthProviderConfig {
                 &self.allowed_email_domains,
                 "auth.oauth.providers[].allowed_email_domains",
             )?,
+            sso_email_verification_enabled: self.sso_email_verification_enabled,
             enabled: self.enabled,
             jit: self.jit.seed_policy()?,
         })
@@ -2601,6 +2604,10 @@ fn default_oidc_scopes() -> Vec<String> {
 
 fn default_oauth_provider_type() -> String {
     "github".to_string()
+}
+
+fn default_sso_email_verification_enabled() -> bool {
+    true
 }
 
 fn default_github_oauth_scopes() -> Vec<String> {
@@ -4477,6 +4484,7 @@ auth:
         let config = GatewayConfig::from_path(&config_path).expect("config should parse");
         let oauth_providers = config.seed_oauth_providers().expect("seed oauth providers");
         assert_eq!(oauth_providers[0].client_id, "github-client-id");
+        assert!(oauth_providers[0].sso_email_verification_enabled);
     }
 
     #[test]
@@ -4594,6 +4602,33 @@ auth:
             oauth_providers[0].allowed_email_domains,
             vec!["test.com", "engineering.example.com"]
         );
+    }
+
+    #[test]
+    fn parses_github_oauth_sso_email_verification_escape_hatch() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+auth:
+  oauth:
+    public_base_url: literal.https://gateway.example.com
+    providers:
+      - key: github
+        label: GitHub
+        provider_type: github
+        client_id: github-client-id
+        client_secret: literal.secret
+        scopes: [read:user, user:email]
+        sso_email_verification_enabled: false
+"#,
+        );
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let oauth_providers = config.seed_oauth_providers().expect("seed oauth providers");
+        assert!(!oauth_providers[0].sso_email_verification_enabled);
     }
 
     #[test]

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -1854,18 +1854,16 @@ async fn github_primary_email(
 
 fn select_github_primary_email(
     emails: &[GithubEmailResponse],
-    sso_email_verification_enabled: bool,
+    require_verified_primary_email: bool,
 ) -> Result<String, GithubEmailLookupError> {
     let selected = emails
         .iter()
-        .find(|email| email.primary && (!sso_email_verification_enabled || email.verified))
-        .ok_or({
-            if sso_email_verification_enabled {
-                GithubEmailLookupError::NoPrimaryVerifiedEmail
-            } else {
-                GithubEmailLookupError::NoPrimaryEmail
-            }
-        })?;
+        .find(|email| email.primary)
+        .ok_or(GithubEmailLookupError::NoPrimaryEmail)?;
+
+    if require_verified_primary_email && !selected.verified {
+        return Err(GithubEmailLookupError::NoPrimaryVerifiedEmail);
+    }
 
     normalize_email(&selected.email).map_err(GithubEmailLookupError::Provider)
 }
@@ -3151,6 +3149,19 @@ mod tests {
             error,
             GithubEmailLookupError::NoPrimaryVerifiedEmail
         ));
+    }
+
+    #[test]
+    fn github_email_selection_reports_missing_primary_email_before_verification() {
+        let emails = vec![GithubEmailResponse {
+            email: "Alice@Example.com".to_string(),
+            primary: false,
+            verified: true,
+        }];
+
+        let error = select_github_primary_email(&emails, true).expect_err("email should fail");
+
+        assert!(matches!(error, GithubEmailLookupError::NoPrimaryEmail));
     }
 
     #[test]

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -1560,13 +1560,21 @@ pub async fn oauth_callback_github(
             return Ok(oidc_error_redirect("provider_failure"));
         }
     };
-    let email = match github_primary_verified_email(&access_token).await {
-        Ok(email) => email,
-        Err(error) => {
-            tracing::warn!(error = %error.0, "github oauth email lookup failed");
-            return Ok(oidc_error_redirect("unmatched_identity"));
-        }
-    };
+    let email =
+        match github_primary_email(&access_token, provider.sso_email_verification_enabled).await {
+            Ok(email) => email,
+            Err(GithubEmailLookupError::NoPrimaryVerifiedEmail) => {
+                tracing::warn!(
+                    error = "github account has no primary verified email",
+                    "github oauth email lookup failed"
+                );
+                return Ok(oidc_error_redirect("github_unverified_email"));
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "github oauth email lookup failed");
+                return Ok(oidc_error_redirect("unmatched_identity"));
+            }
+        };
     let email_domain = github_email_domain(&email);
     if !github_email_domain_allowed_domain(email_domain, &provider.allowed_email_domains) {
         tracing::warn!(
@@ -1702,6 +1710,36 @@ struct GithubEmailResponse {
     verified: bool,
 }
 
+enum GithubEmailLookupError {
+    Provider(AppError),
+    NoPrimaryEmail,
+    NoPrimaryVerifiedEmail,
+}
+
+impl std::fmt::Display for GithubEmailLookupError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Provider(error) => write!(formatter, "{}", error.0),
+            Self::NoPrimaryEmail => formatter.write_str("github account has no primary email"),
+            Self::NoPrimaryVerifiedEmail => {
+                formatter.write_str("github account has no primary verified email")
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for GithubEmailLookupError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl From<AppError> for GithubEmailLookupError {
+    fn from(error: AppError) -> Self {
+        Self::Provider(error)
+    }
+}
+
 async fn github_exchange_oauth_code(
     provider: &OauthProviderRecord,
     code: &str,
@@ -1779,7 +1817,10 @@ async fn github_user_subject(access_token: &str) -> Result<String, AppError> {
     Ok(payload.id.to_string())
 }
 
-async fn github_primary_verified_email(access_token: &str) -> Result<String, AppError> {
+async fn github_primary_email(
+    access_token: &str,
+    sso_email_verification_enabled: bool,
+) -> Result<String, GithubEmailLookupError> {
     let client = oidc_http_client()?;
     let response = client
         .get("https://api.github.com/user/emails")
@@ -1789,30 +1830,44 @@ async fn github_primary_verified_email(access_token: &str) -> Result<String, App
         .bearer_auth(access_token)
         .send()
         .await
-        .map_err(|error| AppError(GatewayError::InvalidRequest(error.to_string())))?;
-
-    if !response.status().is_success() {
-        return Err(AppError(GatewayError::InvalidRequest(format!(
-            "github emails endpoint returned status {}",
-            response.status()
-        ))));
-    }
-
-    let emails: Vec<GithubEmailResponse> = response
-        .json()
-        .await
-        .map_err(|error| AppError(GatewayError::InvalidRequest(error.to_string())))?;
-
-    let selected = emails
-        .iter()
-        .find(|email| email.primary && email.verified)
-        .ok_or_else(|| {
-            AppError(GatewayError::InvalidRequest(
-                "github account has no primary verified email".to_string(),
-            ))
+        .map_err(|error| {
+            GithubEmailLookupError::Provider(AppError(GatewayError::InvalidRequest(
+                error.to_string(),
+            )))
         })?;
 
-    normalize_email(&selected.email)
+    if !response.status().is_success() {
+        return Err(GithubEmailLookupError::Provider(AppError(
+            GatewayError::InvalidRequest(format!(
+                "github emails endpoint returned status {}",
+                response.status()
+            )),
+        )));
+    }
+
+    let emails: Vec<GithubEmailResponse> = response.json().await.map_err(|error| {
+        GithubEmailLookupError::Provider(AppError(GatewayError::InvalidRequest(error.to_string())))
+    })?;
+
+    select_github_primary_email(&emails, sso_email_verification_enabled)
+}
+
+fn select_github_primary_email(
+    emails: &[GithubEmailResponse],
+    sso_email_verification_enabled: bool,
+) -> Result<String, GithubEmailLookupError> {
+    let selected = emails
+        .iter()
+        .find(|email| email.primary && (!sso_email_verification_enabled || email.verified))
+        .ok_or({
+            if sso_email_verification_enabled {
+                GithubEmailLookupError::NoPrimaryVerifiedEmail
+            } else {
+                GithubEmailLookupError::NoPrimaryEmail
+            }
+        })?;
+
+    normalize_email(&selected.email).map_err(GithubEmailLookupError::Provider)
 }
 
 #[cfg(test)]
@@ -3060,7 +3115,10 @@ pub async fn list_public_oauth_providers(
 
 #[cfg(test)]
 mod tests {
-    use super::github_email_domain_allowed;
+    use super::{
+        GithubEmailLookupError, GithubEmailResponse, github_email_domain_allowed,
+        select_github_primary_email,
+    };
 
     #[test]
     fn github_email_domain_policy_allows_empty_policy() {
@@ -3077,5 +3135,34 @@ mod tests {
         assert!(!github_email_domain_allowed("alice@sub.test.com", &allowed));
         assert!(!github_email_domain_allowed("alice@", &allowed));
         assert!(!github_email_domain_allowed("invalid-email", &allowed));
+    }
+
+    #[test]
+    fn github_email_selection_requires_verified_primary_email_by_default() {
+        let emails = vec![GithubEmailResponse {
+            email: "Alice@Example.com".to_string(),
+            primary: true,
+            verified: false,
+        }];
+
+        let error = select_github_primary_email(&emails, true).expect_err("email should fail");
+
+        assert!(matches!(
+            error,
+            GithubEmailLookupError::NoPrimaryVerifiedEmail
+        ));
+    }
+
+    #[test]
+    fn github_email_selection_accepts_primary_email_when_verification_disabled() {
+        let emails = vec![GithubEmailResponse {
+            email: "Alice@Example.com".to_string(),
+            primary: true,
+            verified: false,
+        }];
+
+        let email = select_github_primary_email(&emails, false).expect("email should be selected");
+
+        assert_eq!(email, "alice@example.com");
     }
 }

--- a/deploy/config/gateway.local.yaml
+++ b/deploy/config/gateway.local.yaml
@@ -46,8 +46,11 @@ auth:
         scopes:
           - read:user
           - user:email
+        # Keep true unless you intentionally accept GitHub primary emails that
+        # GitHub has not verified.
+        sso_email_verification_enabled: true
         # Optional: restrict GitHub OAuth sign-in, invite activation, and JIT
-        # provisioning to verified primary email domains owned by your organization.
+        # provisioning to primary email domains owned by your organization.
         # allowed_email_domains:
         #   - example.com
         enabled: false

--- a/deploy/config/gateway.yaml
+++ b/deploy/config/gateway.yaml
@@ -46,8 +46,11 @@ auth:
         scopes:
           - read:user
           - user:email
+        # Keep true unless you intentionally accept GitHub primary emails that
+        # GitHub has not verified.
+        sso_email_verification_enabled: true
         # Optional: restrict GitHub OAuth sign-in, invite activation, and JIT
-        # provisioning to verified primary email domains owned by your organization.
+        # provisioning to primary email domains owned by your organization.
         # allowed_email_domains:
         #   - example.com
         enabled: false

--- a/docs/access/github-oauth-admin-setup.md
+++ b/docs/access/github-oauth-admin-setup.md
@@ -10,11 +10,11 @@ Create a GitHub **OAuth App** for the specific self-hosted Oceans LLM install.
 
 Required GitHub OAuth App fields:
 
-- **Application name**: your operator-visible name (for example, `Oceans LLM`)
+- **Application name**: your admin-visible name (for example, `Oceans LLM`)
 - **Homepage URL**: `https://<your-oceans-host>`
 - **Authorization callback URL**: `https://<your-oceans-host>/api/v1/auth/oauth/callback/github`
 
-> For self-hosted installs, this callback URL should match each operator's public Oceans LLM URL.
+> For self-hosted installs, this callback URL should match the deployment's public Oceans LLM URL.
 
 ## GitHub Keys to Store
 
@@ -60,9 +60,9 @@ auth:
 
 `allowed_email_domains` is optional. Leave it empty or omit it to allow the existing invite/JIT rules to decide access without an email-domain guardrail. When it is set, GitHub OAuth can only complete for accounts whose selected primary email domain exactly matches one of the configured domains.
 
-`sso_email_verification_enabled` defaults to `true`. With the default, Oceans only accepts the GitHub account's primary email when GitHub marks that email as verified. If GitHub returns no primary verified email, sign-in fails with `github account has no primary verified email`; ask the user to verify their primary email in [GitHub email settings](https://github.com/settings/emails), then retry sign-in.
+`sso_email_verification_enabled` defaults to `true`. With the default, Oceans only accepts the GitHub account's primary email when GitHub marks that email as verified. If GitHub returns no primary verified email, sign-in redirects with `github_unverified_email` and the gateway logs `github account has no primary verified email`; ask the user to verify their primary email in [GitHub email settings](https://github.com/settings/emails), then retry sign-in.
 
-Set `sso_email_verification_enabled: false` only as an operator escape hatch when you intentionally want Oceans to accept GitHub's primary email even if GitHub has not verified it. Domain restrictions still run against the selected primary email domain.
+Set `sso_email_verification_enabled: false` only as an admin escape hatch when you intentionally want Oceans to accept GitHub's primary email even if GitHub has not verified it. Domain restrictions still run against the selected primary email domain.
 
 ## Identity Mapping Behavior
 

--- a/docs/access/github-oauth-admin-setup.md
+++ b/docs/access/github-oauth-admin-setup.md
@@ -48,6 +48,7 @@ auth:
         scopes:
           - read:user
           - user:email
+        sso_email_verification_enabled: true
         allowed_email_domains:
           - example.com
         enabled: true
@@ -57,23 +58,28 @@ auth:
           request_logging_enabled: true
 ```
 
-`allowed_email_domains` is optional. Leave it empty or omit it to allow the existing invite/JIT rules to decide access without an email-domain guardrail. When it is set, GitHub OAuth can only complete for accounts whose verified primary email domain exactly matches one of the configured domains.
+`allowed_email_domains` is optional. Leave it empty or omit it to allow the existing invite/JIT rules to decide access without an email-domain guardrail. When it is set, GitHub OAuth can only complete for accounts whose selected primary email domain exactly matches one of the configured domains.
+
+`sso_email_verification_enabled` defaults to `true`. With the default, Oceans only accepts the GitHub account's primary email when GitHub marks that email as verified. If GitHub returns no primary verified email, sign-in fails with `github account has no primary verified email`; ask the user to verify their primary email in [GitHub email settings](https://github.com/settings/emails), then retry sign-in.
+
+Set `sso_email_verification_enabled: false` only as an operator escape hatch when you intentionally want Oceans to accept GitHub's primary email even if GitHub has not verified it. Domain restrictions still run against the selected primary email domain.
 
 ## Identity Mapping Behavior
 
 Direct GitHub OAuth uses:
 
 - provider subject: GitHub numeric user id (`/user`)
-- email for invite/JIT matching: verified primary email (`/user/emails`)
-- optional domain restriction: exact domain part of the verified primary email
+- email for invite/JIT matching: primary email from `/user/emails`; by default it must also be GitHub-verified
+- optional domain restriction: exact domain part of the selected primary email
 
 Oceans does **not** auto-link existing password users by email.
 
 ## Security Notes
 
 - Keep `jit.enabled: false` unless you explicitly want auto-provisioning.
-- When `jit.enabled: true`, set `allowed_email_domains` unless every verified GitHub email address should be eligible for JIT provisioning.
-- Domain checks run after GitHub returns the verified primary email and before OAuth link creation, invited-user activation, JIT user creation, or session cookie issuance.
+- Keep `sso_email_verification_enabled: true` unless your deployment has an explicit reason to trust unverified GitHub primary emails.
+- When `jit.enabled: true`, set `allowed_email_domains` unless every eligible GitHub primary email should be allowed for JIT provisioning.
+- Domain checks run after GitHub returns the selected primary email and before OAuth link creation, invited-user activation, JIT user creation, or session cookie issuance.
 - Domain matching is case-insensitive and exact on the email domain. `alice@example.com` matches `example.com`; `alice@evil-example.com` does not.
 - Do not grant broad admin roles through JIT unless constrained by your org policy.
 - Rotate GitHub client secrets if leaked.

--- a/docs/access/oidc-and-sso-status.md
+++ b/docs/access/oidc-and-sso-status.md
@@ -14,10 +14,10 @@ The OIDC/OAuth flow includes:
 - `/api/v1/auth/oidc/start` performs provider discovery and redirects with state, nonce, and PKCE
 - `/api/v1/auth/oidc/callback` consumes one-time state, exchanges the authorization code, verifies the ID token and nonce, and issues the existing `ogw_session` cookie
 - `/api/v1/auth/oauth/start` redirects to the OAuth provider with one-time state and PKCE
-- `/api/v1/auth/oauth/callback/github` consumes one-time state, exchanges the code with GitHub, resolves verified email + numeric subject, and issues `ogw_session`
+- `/api/v1/auth/oauth/callback/github` consumes one-time state, exchanges the code with GitHub, resolves numeric subject plus the selected primary email, and issues `ogw_session`
 - invited/config-declared OIDC users activate on first successful provider login
 - provider-specific JIT user creation can assign explicit global role, team membership, and request logging defaults
-- direct GitHub OAuth can restrict sign-in and JIT provisioning to configured verified email domains
+- direct GitHub OAuth requires a GitHub-verified primary email by default, can use `sso_email_verification_enabled: false` as an operator escape hatch, and can restrict sign-in and JIT provisioning to configured email domains
 - local Authentik compose profiles provide a repeatable manual IdP fixture
 
 ## Security Boundary
@@ -29,7 +29,7 @@ Account linking is intentionally conservative:
 - existing `(provider, sub)` links win
 - invited/config-declared OIDC users with matching normalized email and provider link are activated and linked
 - unmatched identities use the provider's explicit JIT policy
-- GitHub OAuth `allowed_email_domains` is enforced before account linking, invite activation, JIT creation, or session issuance
+- GitHub OAuth `sso_email_verification_enabled` and `allowed_email_domains` are enforced before account linking, invite activation, JIT creation, or session issuance
 - existing password/local users with the same email are rejected instead of auto-linked
 
 ## Practical Admin Impact

--- a/docs/access/oidc-and-sso-status.md
+++ b/docs/access/oidc-and-sso-status.md
@@ -17,7 +17,7 @@ The OIDC/OAuth flow includes:
 - `/api/v1/auth/oauth/callback/github` consumes one-time state, exchanges the code with GitHub, resolves numeric subject plus the selected primary email, and issues `ogw_session`
 - invited/config-declared OIDC users activate on first successful provider login
 - provider-specific JIT user creation can assign explicit global role, team membership, and request logging defaults
-- direct GitHub OAuth requires a GitHub-verified primary email by default, can use `sso_email_verification_enabled: false` as an operator escape hatch, and can restrict sign-in and JIT provisioning to configured email domains
+- direct GitHub OAuth requires a GitHub-verified primary email by default, can use `sso_email_verification_enabled: false` as an admin escape hatch, and can restrict sign-in and JIT provisioning to configured email domains
 - local Authentik compose profiles provide a repeatable manual IdP fixture
 
 ## Security Boundary

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -312,6 +312,7 @@ auth:
         client_id: env.GITHUB_OAUTH_CLIENT_ID
         client_secret: env.GITHUB_OAUTH_CLIENT_SECRET
         scopes: [read:user, user:email]
+        sso_email_verification_enabled: true
         allowed_email_domains:
           - example.com
         enabled: true
@@ -327,12 +328,17 @@ Important GitHub OAuth provider fields:
 - `client_id`
 - `client_secret`
 - `scopes`: must include `user:email`
+- `sso_email_verification_enabled`
+  - optional
+  - defaults to `true`
+  - when `true`, GitHub OAuth requires the account's primary email to be verified by GitHub
+  - when `false`, Oceans accepts GitHub's primary email even when GitHub has not verified it
 - `allowed_email_domains`
   - optional
   - defaults to an empty list, which keeps the existing invite/JIT behavior without a domain restriction
   - entries are normalized by trimming whitespace, converting to lowercase, and removing trailing dots
   - empty entries, email addresses, URLs, wildcards, single-label values, names with invalid DNS characters, and duplicates after normalization are rejected at startup
-  - matching is case-insensitive and exact on the verified primary email's domain part
+  - matching is case-insensitive and exact on the selected primary email's domain part
 - `enabled`
 - `jit`
 

--- a/docs/reference/data-relationships.md
+++ b/docs/reference/data-relationships.md
@@ -85,8 +85,8 @@ Compatibility metadata is not a provider config fallback and is not an `extra_bo
   - Key columns: `user_id`, `oidc_provider_id`, `subject`, `email_claim`
   - Notes: unique `(oidc_provider_id, subject)`
 - `oauth_providers`
-  - Key columns: `oauth_provider_id`, `provider_key`, `provider_type`, `client_id`, `scopes_json`, `allowed_email_domains_json`, `enabled`
-  - Notes: direct OAuth currently supports GitHub; `allowed_email_domains_json` stores the normalized verified-email-domain allowlist enforced before OAuth link creation, invite activation, JIT creation, or session issuance
+  - Key columns: `oauth_provider_id`, `provider_key`, `provider_type`, `client_id`, `scopes_json`, `allowed_email_domains_json`, `sso_email_verification_enabled`, `enabled`
+  - Notes: direct OAuth currently supports GitHub; `sso_email_verification_enabled` controls whether GitHub primary emails must be verified, and `allowed_email_domains_json` stores the normalized email-domain allowlist enforced before OAuth link creation, invite activation, JIT creation, or session issuance
 - `user_oauth_links`
   - Purpose: pre-provisioned relationship between a user and the OAuth provider they are allowed to activate against
 - `user_oauth_auth`


### PR DESCRIPTION
## Description

Fixes direct GitHub OAuth handling for accounts that do not have a GitHub-verified primary email, and improves the admin UI recovery path.

- Summary of changes
  - Added `sso_email_verification_enabled` to GitHub OAuth provider config, defaulting to `true`.
  - Added libsql and Postgres V33 migrations plus seed/read support for the new provider flag.
  - Updated GitHub OAuth email selection so the default requires `primary && verified`, while the escape hatch accepts GitHub's primary email without the verified requirement.
  - Redirects the unverified-primary-email failure as `github_unverified_email` instead of generic `unmatched_identity`.
  - Shows an actionable login error that points users to https://github.com/settings/emails.
  - Adds an account-ready button back to the control plane.
  - Updates GitHub OAuth docs, config reference, deployment examples, and data relationship docs.

- Why this approach was chosen
  - The secure default remains unchanged: GitHub SSO requires a primary verified email unless an operator explicitly disables that policy.
  - The escape hatch is persisted with the OAuth provider record so config seeding, runtime lookup, and both database backends stay consistent.

- How it works
  - `sso_email_verification_enabled: true` selects a GitHub email where `primary && verified`.
  - `sso_email_verification_enabled: false` selects the primary GitHub email without requiring GitHub's verified flag.
  - Domain restrictions still apply after email selection.

- Risks, tradeoffs, and alternatives considered
  - Disabling email verification weakens the trust boundary for GitHub email claims, so docs and examples keep the setting enabled by default and describe it as an operator escape hatch.
  - Existing deployments migrate to the secure default via V33.

- Additional context for reviewers
  - Closes #190.
  - The PR template lists Postgres-specific task names that are not currently defined in the checked mise configs; the full workspace test suite still exercised libsql and available Postgres-gated tests according to local environment configuration.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres` (task not defined in checked mise configs)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres` (task not defined in checked mise configs)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke` (task not defined in checked mise configs)
