### PR TITLE
feat(client-config): add Fable 5 adaptive config

### DIFF
--- a/crates/gateway-client-config/src/templates/claude_code.rs
+++ b/crates/gateway-client-config/src/templates/claude_code.rs
@@ -184,7 +184,9 @@ fn claude_code_default_model_env_var(input: &ClientConfigInput) -> Option<&'stat
     .join(" ")
     .to_ascii_lowercase();
 
-    if joined.contains("opus") {
+    if joined.contains("fable") {
+        Some("ANTHROPIC_DEFAULT_FABLE_MODEL")
+    } else if joined.contains("opus") {
         Some("ANTHROPIC_DEFAULT_OPUS_MODEL")
     } else if joined.contains("sonnet") {
         Some("ANTHROPIC_DEFAULT_SONNET_MODEL")

--- a/crates/gateway-client-config/src/templates/claude_code.rs
+++ b/crates/gateway-client-config/src/templates/claude_code.rs
@@ -15,10 +15,11 @@ use crate::{
 pub(crate) const CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER: &str = "<gateway api token>";
 
 const CLAUDE_CODE_SETTINGS_SCHEMA: &str = "https://json.schemastore.org/claude-code-settings.json";
-const CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV: [(&str, &str); 10] = [
+const CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV: [(&str, &str); 11] = [
     ("CLAUDE_CODE_ENABLE_TELEMETRY", "0"),
     ("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "1"),
     ("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1"),
+    ("CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT", "1"),
     ("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "200000"),
     ("ENABLE_TOOL_SEARCH", "auto"),
     ("CLAUDE_CODE_NO_FLICKER", "1"),

--- a/crates/gateway-client-config/src/templates/claude_code.rs
+++ b/crates/gateway-client-config/src/templates/claude_code.rs
@@ -15,7 +15,7 @@ use crate::{
 pub(crate) const CLAUDE_CODE_AUTH_TOKEN_PLACEHOLDER: &str = "<gateway api token>";
 
 const CLAUDE_CODE_SETTINGS_SCHEMA: &str = "https://json.schemastore.org/claude-code-settings.json";
-const CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV: [(&str, &str); 11] = [
+const CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV: &[(&str, &str)] = &[
     ("CLAUDE_CODE_ENABLE_TELEMETRY", "0"),
     ("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS", "1"),
     ("CLAUDE_CODE_DISABLE_1M_CONTEXT", "1"),
@@ -198,7 +198,7 @@ fn claude_code_default_model_env_var(input: &ClientConfigInput) -> Option<&'stat
 fn claude_code_minimal_experience_config() -> Value {
     json!({
         "$schema": CLAUDE_CODE_SETTINGS_SCHEMA,
-        "env": env_from_pairs(&CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV),
+        "env": env_from_pairs(CLAUDE_CODE_LOWER_TOKEN_USAGE_ENV),
     })
 }
 

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -98,18 +98,22 @@ fn cache_read_is_omitted_when_missing() {
 }
 
 #[test]
-fn safe_thinking_variants_are_emitted_for_newer_claude_models() {
+fn infers_safe_effort_for_newer_claude_models() {
     for model in [
+        "anthropic/claude-fable-5",
+        "anthropic/claude-opus-4-8",
         "anthropic/claude-sonnet-4-6",
         "anthropic/claude-sonnet-5",
-        "anthropic/claude-fable-5",
     ] {
         assert_eq!(
             infer_anthropic_thinking_policy([model]),
             Some(AnthropicThinkingPolicy::SafeEffort)
         );
     }
+}
 
+#[test]
+fn safe_thinking_variants_are_emitted_for_newer_claude_models() {
     let input = input(infer_anthropic_thinking_policy([
         "anthropic/claude-sonnet-4-6",
         "Claude Sonnet 4.6",

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -99,9 +99,21 @@ fn cache_read_is_omitted_when_missing() {
 
 #[test]
 fn safe_thinking_variants_are_emitted_for_newer_claude_models() {
-    let policy =
-        infer_anthropic_thinking_policy(["anthropic/claude-sonnet-4-6", "Claude Sonnet 4.6"]);
-    let input = input(policy);
+    for model in [
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-sonnet-5",
+        "anthropic/claude-fable-5",
+    ] {
+        assert_eq!(
+            infer_anthropic_thinking_policy([model]),
+            Some(AnthropicThinkingPolicy::SafeEffort)
+        );
+    }
+
+    let input = input(infer_anthropic_thinking_policy([
+        "anthropic/claude-sonnet-4-6",
+        "Claude Sonnet 4.6",
+    ]));
     let opencode: Value =
         serde_json::from_str(&OpenCodeConfigTemplate.render(&input).blocks[0].content)
             .expect("json");
@@ -444,6 +456,10 @@ fn claude_code_shape_includes_gateway_env_and_model_override() {
     assert_eq!(
         lower_usage_settings["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"],
         "200000"
+    );
+    assert_eq!(
+        lower_usage_settings["env"]["CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT"],
+        "1"
     );
     assert_eq!(lower_usage_settings["env"]["ENABLE_TOOL_SEARCH"], "auto");
     assert!(

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -110,6 +110,14 @@ fn infers_safe_effort_for_newer_claude_models() {
             Some(AnthropicThinkingPolicy::SafeEffort)
         );
     }
+    assert_eq!(
+        infer_anthropic_thinking_policy(["anthropic/claude-sonnet-50"]),
+        Some(AnthropicThinkingPolicy::ManualBudget)
+    );
+    assert_eq!(
+        infer_anthropic_thinking_policy(["anthropic/claude-fable-50"]),
+        Some(AnthropicThinkingPolicy::ManualBudget)
+    );
 }
 
 #[test]
@@ -471,6 +479,26 @@ fn claude_code_shape_includes_gateway_env_and_model_override() {
             .notes
             .iter()
             .any(|note| note.contains("/v1/messages"))
+    );
+}
+
+#[test]
+fn claude_code_sets_default_fable_model_env_var() {
+    let mut input = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    input.model_id = "claude-fable".to_string();
+    input.display_name = "Claude Fable".to_string();
+    input.upstream_model = Some("anthropic/claude-fable-5".to_string());
+
+    let rendered = ClaudeCodeConfigTemplate.render(&input);
+    let gateway_settings: Value = serde_json::from_str(&rendered.blocks[0].content).expect("json");
+
+    assert_eq!(
+        gateway_settings["env"]["ANTHROPIC_DEFAULT_FABLE_MODEL"],
+        "claude-fable"
+    );
+    assert_eq!(
+        gateway_settings["modelOverrides"]["claude-fable-5"],
+        "claude-fable"
     );
 }
 

--- a/crates/gateway-client-config/src/thinking.rs
+++ b/crates/gateway-client-config/src/thinking.rs
@@ -1,5 +1,18 @@
 use crate::types::AnthropicThinkingPolicy;
 
+const SAFE_EFFORT_MODEL_MARKERS: &[&str] = &[
+    "claude-fable-5",
+    "claude-mythos-preview",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-4-9",
+    "claude-opus-5",
+    "claude-opus-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-5",
+];
+
 #[must_use]
 pub fn infer_anthropic_thinking_policy(
     values: impl IntoIterator<Item = impl AsRef<str>>,
@@ -10,16 +23,9 @@ pub fn infer_anthropic_thinking_policy(
         .collect::<Vec<_>>()
         .join(" ");
 
-    if joined.contains("claude-mythos-preview")
-        || joined.contains("claude-opus-4-7")
-        || joined.contains("claude-opus-4-8")
-        || joined.contains("claude-opus-4-9")
-        || joined.contains("claude-opus-5")
-        || joined.contains("claude-opus-6")
-        || joined.contains("claude-sonnet-5")
-        || joined.contains("claude-sonnet-4-6")
-        || joined.contains("claude-fable-5")
-        || joined.contains("claude-opus-4-6")
+    if SAFE_EFFORT_MODEL_MARKERS
+        .iter()
+        .any(|marker| joined.contains(marker))
     {
         return Some(AnthropicThinkingPolicy::SafeEffort);
     }

--- a/crates/gateway-client-config/src/thinking.rs
+++ b/crates/gateway-client-config/src/thinking.rs
@@ -16,7 +16,9 @@ pub fn infer_anthropic_thinking_policy(
         || joined.contains("claude-opus-4-9")
         || joined.contains("claude-opus-5")
         || joined.contains("claude-opus-6")
+        || joined.contains("claude-sonnet-5")
         || joined.contains("claude-sonnet-4-6")
+        || joined.contains("claude-fable-5")
         || joined.contains("claude-opus-4-6")
     {
         return Some(AnthropicThinkingPolicy::SafeEffort);

--- a/crates/gateway-client-config/src/thinking.rs
+++ b/crates/gateway-client-config/src/thinking.rs
@@ -1,7 +1,6 @@
 use crate::types::AnthropicThinkingPolicy;
 
 const SAFE_EFFORT_MODEL_MARKERS: &[&str] = &[
-    "claude-fable-5",
     "claude-mythos-preview",
     "claude-opus-4-6",
     "claude-opus-4-7",
@@ -10,8 +9,9 @@ const SAFE_EFFORT_MODEL_MARKERS: &[&str] = &[
     "claude-opus-5",
     "claude-opus-6",
     "claude-sonnet-4-6",
-    "claude-sonnet-5",
 ];
+
+const SAFE_EFFORT_EXACT_MODEL_MARKERS: &[&str] = &["claude-fable-5", "claude-sonnet-5"];
 
 #[must_use]
 pub fn infer_anthropic_thinking_policy(
@@ -26,6 +26,9 @@ pub fn infer_anthropic_thinking_policy(
     if SAFE_EFFORT_MODEL_MARKERS
         .iter()
         .any(|marker| joined.contains(marker))
+        || SAFE_EFFORT_EXACT_MODEL_MARKERS
+            .iter()
+            .any(|marker| contains_exact_model_marker(&joined, marker))
     {
         return Some(AnthropicThinkingPolicy::SafeEffort);
     }
@@ -35,4 +38,12 @@ pub fn infer_anthropic_thinking_policy(
     }
 
     None
+}
+
+fn contains_exact_model_marker(value: &str, marker: &str) -> bool {
+    value.split(marker).skip(1).any(|rest| {
+        rest.chars().next().is_none_or(|ch| {
+            ch.is_ascii_whitespace() || matches!(ch, '/' | ':' | '@' | ',' | ')' | ']')
+        })
+    })
 }

--- a/crates/gateway-providers/src/bedrock/request/mod.rs
+++ b/crates/gateway-providers/src/bedrock/request/mod.rs
@@ -86,6 +86,7 @@ pub(super) fn map_chat_request_to_converse(
     if let Some(additional) = passthrough.remove("additional_model_request_fields") {
         body.insert("additionalModelRequestFields".to_string(), additional);
     }
+    merge_object_overrides(&mut body, &context.extra_body);
     apply_converse_anthropic_thinking_compatibility(
         &mut body,
         &mut passthrough,
@@ -99,7 +100,6 @@ pub(super) fn map_chat_request_to_converse(
 
     reject_openai_only_fields(&passthrough)?;
     reject_unknown_converse_fields(&passthrough)?;
-    merge_object_overrides(&mut body, &context.extra_body);
     Ok(Value::Object(body))
 }
 
@@ -251,12 +251,12 @@ pub(super) fn map_chat_request_to_anthropic_messages(
         body.extend(tools);
     }
     extract_anthropic_passthrough_fields(&mut body, &mut passthrough);
+    merge_object_overrides(&mut body, &context.extra_body);
     apply_anthropic_thinking_compatibility(&mut body, &mut passthrough, &context.upstream_model)?;
     reject_openai_only_fields(&passthrough)?;
     reject_unknown_anthropic_messages_fields(&passthrough)?;
     validate_anthropic_sampling_fields(&mut body, &context.upstream_model)?;
 
-    merge_object_overrides(&mut body, &context.extra_body);
     if !body.contains_key("max_tokens") {
         return Err(ProviderError::InvalidRequest(
             "aws_bedrock Anthropic Claude Messages requires `max_tokens` or `max_completion_tokens`"

--- a/crates/gateway-providers/src/bedrock/request/thinking.rs
+++ b/crates/gateway-providers/src/bedrock/request/thinking.rs
@@ -26,8 +26,16 @@ pub(super) fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPoli
 
 pub(super) fn is_adaptive_only_claude(model: &str) -> bool {
     is_opus_4_7_or_later(model)
-        || model.contains("claude-fable-5")
-        || model.contains("claude-sonnet-5")
+        || contains_exact_claude_model_marker(model, "claude-fable-5")
+        || contains_exact_claude_model_marker(model, "claude-sonnet-5")
+}
+
+pub(super) fn contains_exact_claude_model_marker(model: &str, marker: &str) -> bool {
+    model.split(marker).skip(1).any(|rest| {
+        rest.chars().next().is_none_or(|ch| {
+            ch.is_ascii_whitespace() || matches!(ch, '/' | ':' | '@' | ',' | ')' | ']')
+        })
+    })
 }
 
 pub(super) fn is_opus_4_7_or_later(model: &str) -> bool {
@@ -637,6 +645,19 @@ pub(super) fn validate_converse_anthropic_sampling_fields(
     {
         return Err(ProviderError::InvalidRequest(format!(
             "`top_k` is not supported for `{upstream_model}`; omit the field for adaptive-only Claude models"
+        )));
+    }
+
+    for field in ["temperature", "top_p", "top_k"] {
+        let Some(value) = body.get(field) else {
+            continue;
+        };
+        if value.is_null() || is_default_anthropic_sampling_value(field, value) {
+            body.remove(field);
+            continue;
+        }
+        return Err(ProviderError::InvalidRequest(format!(
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for adaptive-only Claude models"
         )));
     }
 

--- a/crates/gateway-providers/src/bedrock/request/thinking.rs
+++ b/crates/gateway-providers/src/bedrock/request/thinking.rs
@@ -13,7 +13,7 @@ pub(super) fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPoli
     let model = upstream_model.to_ascii_lowercase();
     if model.contains("claude-mythos-preview") {
         ClaudeThinkingPolicy::MythosPreview
-    } else if is_opus_4_7_or_later(&model) {
+    } else if is_adaptive_only_claude(&model) {
         ClaudeThinkingPolicy::AdaptiveOnly
     } else if model.contains("claude-opus-4-6") || model.contains("claude-sonnet-4-6") {
         ClaudeThinkingPolicy::AdaptivePreferred
@@ -22,6 +22,12 @@ pub(super) fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPoli
     } else {
         ClaudeThinkingPolicy::ManualOnly
     }
+}
+
+pub(super) fn is_adaptive_only_claude(model: &str) -> bool {
+    is_opus_4_7_or_later(model)
+        || model.contains("claude-fable-5")
+        || model.contains("claude-sonnet-5")
 }
 
 pub(super) fn is_opus_4_7_or_later(model: &str) -> bool {
@@ -362,7 +368,7 @@ pub(super) fn validate_anthropic_sampling_fields(
             continue;
         }
         return Err(ProviderError::InvalidRequest(format!(
-            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for adaptive-only Claude models"
         )));
     }
 
@@ -630,7 +636,7 @@ pub(super) fn validate_converse_anthropic_sampling_fields(
         && !value.is_null()
     {
         return Err(ProviderError::InvalidRequest(format!(
-            "`top_k` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+            "`top_k` is not supported for `{upstream_model}`; omit the field for adaptive-only Claude models"
         )));
     }
 
@@ -650,7 +656,7 @@ pub(super) fn validate_converse_anthropic_sampling_fields(
             continue;
         }
         return Err(ProviderError::InvalidRequest(format!(
-            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for adaptive-only Claude models"
         )));
     }
     if inference_config.is_empty() {
@@ -676,7 +682,7 @@ pub(super) fn validate_converse_additional_top_k(
                 continue;
             }
             return Err(ProviderError::InvalidRequest(format!(
-                "`{field}` is not supported for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+                "`{field}` is not supported for `{upstream_model}`; omit the field for adaptive-only Claude models"
             )));
         }
         additional.is_empty()

--- a/crates/gateway-providers/src/bedrock/tests/request_thinking.rs
+++ b/crates/gateway-providers/src/bedrock/tests/request_thinking.rs
@@ -1,28 +1,32 @@
 use super::*;
 
 #[test]
-fn maps_opus_4_7_reasoning_effort_to_adaptive_thinking() {
-    let request = CoreChatRequest {
-        model: "claude".to_string(),
-        messages: vec![message("user", "Think carefully")],
-        stream: false,
-        extra: BTreeMap::from([
-            ("max_tokens".to_string(), json!(4096)),
-            ("reasoning_effort".to_string(), json!("xhigh")),
-            ("temperature".to_string(), json!(1.0)),
-        ]),
-    };
+fn maps_adaptive_only_claude_reasoning_effort_to_adaptive_thinking() {
+    for upstream_model in [
+        "global.anthropic.claude-fable-5",
+        "global.anthropic.claude-opus-4-7",
+        "global.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-sonnet-5",
+    ] {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("xhigh")),
+                ("temperature".to_string(), json!(1.0)),
+            ]),
+        };
 
-    let body = map_chat_request_to_anthropic_messages(
-        &request,
-        &context("global.anthropic.claude-opus-4-7"),
-    )
-    .expect("mapped");
+        let body = map_chat_request_to_anthropic_messages(&request, &context(upstream_model))
+            .expect("mapped");
 
-    assert_eq!(body["thinking"], json!({ "type": "adaptive" }));
-    assert_eq!(body["output_config"], json!({ "effort": "xhigh" }));
-    assert!(body.get("reasoning_effort").is_none());
-    assert!(body.get("temperature").is_none());
+        assert_eq!(body["thinking"], json!({ "type": "adaptive" }));
+        assert_eq!(body["output_config"], json!({ "effort": "xhigh" }));
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("temperature").is_none());
+    }
 }
 
 #[test]
@@ -208,6 +212,39 @@ fn maps_claude_converse_reasoning_effort_to_additional_model_request_fields() {
 }
 
 #[test]
+fn maps_adaptive_only_claude_converse_reasoning_effort() {
+    for upstream_model in [
+        "global.anthropic.claude-fable-5",
+        "global.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-sonnet-5",
+    ] {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: true,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                ("reasoning_effort".to_string(), json!("xhigh")),
+            ]),
+        };
+
+        let body =
+            map_chat_request_to_converse(&request, &context(upstream_model)).expect("mapped");
+
+        assert_eq!(
+            body["additionalModelRequestFields"],
+            json!({
+                "thinking": {
+                    "type": "adaptive",
+                    "effort": "xhigh"
+                }
+            })
+        );
+        assert!(body.get("reasoning_effort").is_none());
+    }
+}
+
+#[test]
 fn maps_older_claude_converse_reasoning_budget_to_manual_thinking() {
     let request = CoreChatRequest {
         model: "claude".to_string(),
@@ -357,7 +394,7 @@ fn rejects_opus_4_7_converse_additional_model_top_k() {
             .to_string();
 
     assert!(error.contains("top_k"));
-    assert!(error.contains("Claude Opus 4.7+"));
+    assert!(error.contains("adaptive-only Claude models"));
 }
 
 #[test]
@@ -381,33 +418,36 @@ fn rejects_opus_4_7_converse_additional_model_top_k_without_inference_config() {
             .to_string();
 
     assert!(error.contains("top_k"));
-    assert!(error.contains("Claude Opus 4.7+"));
+    assert!(error.contains("adaptive-only Claude models"));
 }
 
 #[test]
-fn rejects_opus_4_7_manual_thinking_budget() {
-    let request = CoreChatRequest {
-        model: "claude".to_string(),
-        messages: vec![message("user", "Think carefully")],
-        stream: false,
-        extra: BTreeMap::from([
-            ("max_tokens".to_string(), json!(4096)),
-            (
-                "thinking".to_string(),
-                json!({ "type": "enabled", "budget_tokens": 1024 }),
-            ),
-        ]),
-    };
+fn rejects_adaptive_only_manual_thinking_budget() {
+    for upstream_model in [
+        "global.anthropic.claude-fable-5",
+        "global.anthropic.claude-opus-4-8",
+        "global.anthropic.claude-sonnet-5",
+    ] {
+        let request = CoreChatRequest {
+            model: "claude".to_string(),
+            messages: vec![message("user", "Think carefully")],
+            stream: false,
+            extra: BTreeMap::from([
+                ("max_tokens".to_string(), json!(4096)),
+                (
+                    "thinking".to_string(),
+                    json!({ "type": "enabled", "budget_tokens": 1024 }),
+                ),
+            ]),
+        };
 
-    let error = map_chat_request_to_anthropic_messages(
-        &request,
-        &context("global.anthropic.claude-opus-4-7"),
-    )
-    .expect_err("manual thinking rejected")
-    .to_string();
+        let error = map_chat_request_to_anthropic_messages(&request, &context(upstream_model))
+            .expect_err("manual thinking rejected")
+            .to_string();
 
-    assert!(error.contains("thinking.type: enabled"));
-    assert!(error.contains("claude-opus-4-7"));
+        assert!(error.contains("thinking.type: enabled"));
+        assert!(error.contains(upstream_model));
+    }
 }
 
 #[test]

--- a/crates/gateway-providers/src/bedrock/tests/request_thinking.rs
+++ b/crates/gateway-providers/src/bedrock/tests/request_thinking.rs
@@ -215,6 +215,7 @@ fn maps_claude_converse_reasoning_effort_to_additional_model_request_fields() {
 fn maps_adaptive_only_claude_converse_reasoning_effort() {
     for upstream_model in [
         "global.anthropic.claude-fable-5",
+        "global.anthropic.claude-opus-4-7",
         "global.anthropic.claude-opus-4-8",
         "global.anthropic.claude-sonnet-5",
     ] {
@@ -425,6 +426,7 @@ fn rejects_opus_4_7_converse_additional_model_top_k_without_inference_config() {
 fn rejects_adaptive_only_manual_thinking_budget() {
     for upstream_model in [
         "global.anthropic.claude-fable-5",
+        "global.anthropic.claude-opus-4-7",
         "global.anthropic.claude-opus-4-8",
         "global.anthropic.claude-sonnet-5",
     ] {
@@ -448,6 +450,112 @@ fn rejects_adaptive_only_manual_thinking_budget() {
         assert!(error.contains("thinking.type: enabled"));
         assert!(error.contains(upstream_model));
     }
+}
+
+#[test]
+fn rejects_near_match_adaptive_only_claude_ids() {
+    let request = CoreChatRequest {
+        model: "claude".to_string(),
+        messages: vec![message("user", "Think carefully")],
+        stream: false,
+        extra: BTreeMap::from([
+            ("max_tokens".to_string(), json!(4096)),
+            ("reasoning_effort".to_string(), json!("high")),
+        ]),
+    };
+
+    let error = map_chat_request_to_anthropic_messages(
+        &request,
+        &context("global.anthropic.claude-sonnet-50"),
+    )
+    .expect_err("near-match model should not be adaptive-only")
+    .to_string();
+
+    assert!(error.contains("manual thinking budget"));
+}
+
+#[test]
+fn rejects_anthropic_messages_extra_body_incompatible_with_adaptive_only_policy() {
+    let request = CoreChatRequest {
+        model: "claude".to_string(),
+        messages: vec![message("user", "Think carefully")],
+        stream: false,
+        extra: BTreeMap::from([("max_tokens".to_string(), json!(4096))]),
+    };
+    let mut context = context("global.anthropic.claude-sonnet-5");
+    context.extra_body.insert(
+        "thinking".to_string(),
+        json!({ "type": "enabled", "budget_tokens": 1024 }),
+    );
+
+    let error = map_chat_request_to_anthropic_messages(&request, &context)
+        .expect_err("extra_body manual thinking rejected")
+        .to_string();
+
+    assert!(error.contains("thinking.type: enabled"));
+}
+
+#[test]
+fn rejects_anthropic_messages_extra_body_non_default_sampling() {
+    let request = CoreChatRequest {
+        model: "claude".to_string(),
+        messages: vec![message("user", "Hello")],
+        stream: false,
+        extra: BTreeMap::from([("max_tokens".to_string(), json!(64))]),
+    };
+    let mut context = context("global.anthropic.claude-sonnet-5");
+    context
+        .extra_body
+        .insert("temperature".to_string(), json!(0.2));
+
+    let error = map_chat_request_to_anthropic_messages(&request, &context)
+        .expect_err("extra_body sampling rejected")
+        .to_string();
+
+    assert!(error.contains("temperature"));
+    assert!(error.contains("adaptive-only Claude models"));
+}
+
+#[test]
+fn rejects_converse_extra_body_incompatible_with_adaptive_only_policy() {
+    let request = CoreChatRequest {
+        model: "claude".to_string(),
+        messages: vec![message("user", "Think carefully")],
+        stream: true,
+        extra: BTreeMap::from([("max_tokens".to_string(), json!(4096))]),
+    };
+    let mut context = context("global.anthropic.claude-sonnet-5");
+    context.extra_body.insert(
+        "additionalModelRequestFields".to_string(),
+        json!({ "thinking": { "type": "enabled", "budget_tokens": 1024 } }),
+    );
+
+    let error = map_chat_request_to_converse(&request, &context)
+        .expect_err("extra_body manual thinking rejected")
+        .to_string();
+
+    assert!(error.contains("additionalModelRequestFields.thinking.type: enabled"));
+}
+
+#[test]
+fn rejects_converse_extra_body_non_default_sampling() {
+    let request = CoreChatRequest {
+        model: "claude".to_string(),
+        messages: vec![message("user", "Hello")],
+        stream: true,
+        extra: BTreeMap::from([("max_tokens".to_string(), json!(64))]),
+    };
+    let mut context = context("global.anthropic.claude-sonnet-5");
+    context
+        .extra_body
+        .insert("inferenceConfig".to_string(), json!({ "temperature": 0.2 }));
+
+    let error = map_chat_request_to_converse(&request, &context)
+        .expect_err("extra_body sampling rejected")
+        .to_string();
+
+    assert!(error.contains("temperature"));
+    assert!(error.contains("adaptive-only Claude models"));
 }
 
 #[test]

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -469,8 +469,16 @@ fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPolicy {
 
 fn is_adaptive_only_claude(model: &str) -> bool {
     is_opus_4_7_or_later(model)
-        || model.contains("claude-fable-5")
-        || model.contains("claude-sonnet-5")
+        || contains_exact_claude_model_marker(model, "claude-fable-5")
+        || contains_exact_claude_model_marker(model, "claude-sonnet-5")
+}
+
+fn contains_exact_claude_model_marker(model: &str, marker: &str) -> bool {
+    model.split(marker).skip(1).any(|rest| {
+        rest.chars().next().is_none_or(|ch| {
+            ch.is_ascii_whitespace() || matches!(ch, '/' | ':' | '@' | ',' | ')' | ']')
+        })
+    })
 }
 
 fn is_opus_4_7_or_later(model: &str) -> bool {
@@ -2920,6 +2928,7 @@ mod tests {
     fn rejects_vertex_adaptive_only_manual_thinking_budget() {
         for upstream_model in [
             "anthropic/claude-fable-5",
+            "anthropic/claude-opus-4-7",
             "anthropic/claude-opus-4-8",
             "anthropic/claude-sonnet-5",
         ] {
@@ -2944,6 +2953,25 @@ mod tests {
                 other => panic!("unexpected error: {other}"),
             }
         }
+    }
+
+    #[test]
+    fn rejects_vertex_near_match_adaptive_only_claude_ids() {
+        let mut request = chat_request(vec![CoreChatMessage {
+            role: "user".to_string(),
+            content: Value::String("think carefully".to_string()),
+            name: None,
+            extra: BTreeMap::new(),
+        }]);
+        request
+            .extra
+            .insert("reasoning_effort".to_string(), json!("high"));
+
+        let error = map_anthropic_request(&request, &context("anthropic/claude-sonnet-50"), false)
+            .expect_err("near-match model should not be adaptive-only")
+            .to_string();
+
+        assert!(error.contains("manual thinking budget"));
     }
 
     #[test]

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -456,7 +456,7 @@ fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPolicy {
     let model = upstream_model.to_ascii_lowercase();
     if model.contains("claude-mythos-preview") {
         ClaudeThinkingPolicy::MythosPreview
-    } else if is_opus_4_7_or_later(&model) {
+    } else if is_adaptive_only_claude(&model) {
         ClaudeThinkingPolicy::AdaptiveOnly
     } else if model.contains("claude-opus-4-6") || model.contains("claude-sonnet-4-6") {
         ClaudeThinkingPolicy::AdaptivePreferred
@@ -465,6 +465,12 @@ fn claude_thinking_policy(upstream_model: &str) -> ClaudeThinkingPolicy {
     } else {
         ClaudeThinkingPolicy::ManualOnly
     }
+}
+
+fn is_adaptive_only_claude(model: &str) -> bool {
+    is_opus_4_7_or_later(model)
+        || model.contains("claude-fable-5")
+        || model.contains("claude-sonnet-5")
 }
 
 fn is_opus_4_7_or_later(model: &str) -> bool {
@@ -807,7 +813,7 @@ fn validate_vertex_anthropic_sampling_fields(
             continue;
         }
         return Err(ProviderError::InvalidRequest(format!(
-            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for Claude Opus 4.7+"
+            "`{field}` is not supported with non-default values for `{upstream_model}`; omit the field for adaptive-only Claude models"
         )));
     }
 
@@ -2671,30 +2677,37 @@ mod tests {
     }
 
     #[test]
-    fn maps_vertex_opus_4_7_reasoning_effort_to_adaptive_thinking() {
-        let mut request = chat_request(vec![CoreChatMessage {
-            role: "user".to_string(),
-            content: Value::String("think carefully".to_string()),
-            name: None,
-            extra: BTreeMap::new(),
-        }]);
-        request.extra.insert("model".to_string(), json!("fast"));
-        request
-            .extra
-            .insert("reasoning_effort".to_string(), json!("xhigh"));
-        request.extra.insert("temperature".to_string(), json!(1.0));
-        request.extra.insert("top_p".to_string(), json!(1.0));
+    fn maps_vertex_adaptive_only_claude_reasoning_effort_to_adaptive_thinking() {
+        for upstream_model in [
+            "anthropic/claude-fable-5",
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-sonnet-5",
+        ] {
+            let mut request = chat_request(vec![CoreChatMessage {
+                role: "user".to_string(),
+                content: Value::String("think carefully".to_string()),
+                name: None,
+                extra: BTreeMap::new(),
+            }]);
+            request.extra.insert("model".to_string(), json!("fast"));
+            request
+                .extra
+                .insert("reasoning_effort".to_string(), json!("xhigh"));
+            request.extra.insert("temperature".to_string(), json!(1.0));
+            request.extra.insert("top_p".to_string(), json!(1.0));
 
-        let mapped = map_anthropic_request(&request, &context("anthropic/claude-opus-4-7"), false)
-            .expect("mapped");
+            let mapped =
+                map_anthropic_request(&request, &context(upstream_model), false).expect("mapped");
 
-        assert_eq!(mapped["anthropic_version"], "vertex-2023-10-16");
-        assert_eq!(mapped["thinking"], json!({ "type": "adaptive" }));
-        assert_eq!(mapped["output_config"], json!({ "effort": "xhigh" }));
-        assert!(mapped.get("reasoning_effort").is_none());
-        assert!(mapped.get("model").is_none());
-        assert!(mapped.get("temperature").is_none());
-        assert!(mapped.get("top_p").is_none());
+            assert_eq!(mapped["anthropic_version"], "vertex-2023-10-16");
+            assert_eq!(mapped["thinking"], json!({ "type": "adaptive" }));
+            assert_eq!(mapped["output_config"], json!({ "effort": "xhigh" }));
+            assert!(mapped.get("reasoning_effort").is_none());
+            assert!(mapped.get("model").is_none());
+            assert!(mapped.get("temperature").is_none());
+            assert!(mapped.get("top_p").is_none());
+        }
     }
 
     #[test]
@@ -2904,26 +2917,32 @@ mod tests {
     }
 
     #[test]
-    fn rejects_vertex_opus_4_7_manual_thinking_budget() {
-        let mut request = chat_request(vec![CoreChatMessage {
-            role: "user".to_string(),
-            content: Value::String("think carefully".to_string()),
-            name: None,
-            extra: BTreeMap::new(),
-        }]);
-        request.extra.insert(
-            "thinking".to_string(),
-            json!({ "type": "enabled", "budget_tokens": 4096 }),
-        );
+    fn rejects_vertex_adaptive_only_manual_thinking_budget() {
+        for upstream_model in [
+            "anthropic/claude-fable-5",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-sonnet-5",
+        ] {
+            let mut request = chat_request(vec![CoreChatMessage {
+                role: "user".to_string(),
+                content: Value::String("think carefully".to_string()),
+                name: None,
+                extra: BTreeMap::new(),
+            }]);
+            request.extra.insert(
+                "thinking".to_string(),
+                json!({ "type": "enabled", "budget_tokens": 4096 }),
+            );
 
-        let error = map_anthropic_request(&request, &context("anthropic/claude-opus-4-7"), false)
-            .expect_err("manual thinking should be rejected");
+            let error = map_anthropic_request(&request, &context(upstream_model), false)
+                .expect_err("manual thinking should be rejected");
 
-        match error {
-            ProviderError::InvalidRequest(message) => {
-                assert!(message.contains("thinking.type: enabled"));
+            match error {
+                ProviderError::InvalidRequest(message) => {
+                    assert!(message.contains("thinking.type: enabled"));
+                }
+                other => panic!("unexpected error: {other}"),
             }
-            other => panic!("unexpected error: {other}"),
         }
     }
 
@@ -2946,7 +2965,7 @@ mod tests {
         match error {
             ProviderError::InvalidRequest(message) => {
                 assert!(message.contains("temperature"));
-                assert!(message.contains("Claude Opus 4.7+"));
+                assert!(message.contains("adaptive-only Claude models"));
             }
             other => panic!("unexpected error: {other}"),
         }


### PR DESCRIPTION
## Description

Adds adaptive-thinking support for newer Claude model IDs across generated client config and provider request mapping.

- Summary of changes
  - Classify `claude-sonnet-5` and `claude-fable-5` as safe-effort adaptive-thinking models for generated client configs.
  - Add `CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT=1` to the Claude Code lower-token settings block.
  - Classify Claude Sonnet 5 and Claude Fable 5 as adaptive-only in Vertex and Bedrock Anthropic thinking policy.
  - Expand client-config and provider tests for Opus 4.8, Sonnet 5, and Fable 5 adaptive effort handling.
- Why this approach was chosen
  - Existing runtime and client-config code already infer Anthropic thinking behavior from model identifiers, so this keeps the new IDs in the established policy paths.
- How it works
  - Safe-effort models emit adaptive-thinking variants for generated clients.
  - Vertex and Bedrock now map `reasoning_effort` to adaptive Anthropic thinking for the new adaptive-only IDs and reject manual budgets for those models.
  - Adaptive-only sampling validation now uses generic wording instead of Opus-only wording.
- Risks, tradeoffs, and alternatives considered
  - Claude thinking policy remains duplicated across provider and client-config code. A future metadata centralization pass would reduce drift as model IDs change.
- Additional context for reviewers
  - Exa/docs checks confirmed Fable 5, Sonnet 5, and Opus 4.8 use adaptive reasoning behavior in Claude Code/Anthropic docs.

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Validation run for this PR:

- `cargo fmt --check`
- `cargo test -p gateway-client-config`
- `cargo test -p gateway-providers adaptive_only`
- `cargo test -p gateway-providers request_thinking`
- `cargo clippy --workspace --all-targets -- -D warnings`
