### PR TITLE
fix(admin): refresh pricing before releases

### DIFF
--- a/crates/admin-ui/web/src/routes/observability/request-logs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/request-logs.tsx
@@ -62,6 +62,10 @@ const initialFilters: RequestLogFiltersInput = {
   tag_value: '',
 }
 
+const requestLogRowEstimatePx = 56
+const requestLogDesktopPreviewRows = 12
+const requestLogDesktopTableHeightPx = requestLogRowEstimatePx * requestLogDesktopPreviewRows
+
 export function RequestLogsPage() {
   const { data: logPage } = Route.useLoaderData()
   const search = Route.useSearch()
@@ -120,7 +124,7 @@ export function RequestLogsPage() {
   const rowVirtualizer = useVirtualizer({
     count: logPage.items.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 56,
+    estimateSize: () => requestLogRowEstimatePx,
     overscan: 12,
   })
 
@@ -343,7 +347,12 @@ export function RequestLogsPage() {
                 <span className="px-3 py-2 font-semibold">Tools</span>
                 <span className="px-3 py-2 font-semibold">Inspect</span>
               </div>
-              <div ref={parentRef} className="h-[430px] overflow-y-auto">
+              <div
+                ref={parentRef}
+                className="overflow-y-auto"
+                data-testid="request-log-desktop-table-viewport"
+                style={{ height: `${requestLogDesktopTableHeightPx}px` }}
+              >
                 <div
                   className="relative"
                   style={{

--- a/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
@@ -103,6 +103,7 @@ describe('RequestLogsPage', () => {
 
     expect(screen.getByTestId('request-log-mobile-list')).toBeInTheDocument()
     expect(screen.getByTestId('request-log-desktop-table')).toBeInTheDocument()
+    // 12 rows × 56 px (requestLogDesktopPreviewRows × requestLogRowEstimatePx)
     expect(screen.getByTestId('request-log-desktop-table-viewport')).toHaveStyle({
       height: '672px',
     })

--- a/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
@@ -103,6 +103,9 @@ describe('RequestLogsPage', () => {
 
     expect(screen.getByTestId('request-log-mobile-list')).toBeInTheDocument()
     expect(screen.getByTestId('request-log-desktop-table')).toBeInTheDocument()
+    expect(screen.getByTestId('request-log-desktop-table-viewport')).toHaveStyle({
+      height: '672px',
+    })
     expect(
       screen.getByText(
         'Inspect single-route request execution, latency, and sanitized payloads without dropping into raw traces.',

--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -40,10 +40,11 @@ The tag workflow is distribution, not the quality gate.
 
 Current task steps:
 
-1. `cog bump --auto --skip-untracked`
-2. `git-cliff -o CHANGELOG.md`
-3. `gh release create v$(cog get-version) ...`
-4. `cargo release version $(cog get-version) --execute`
+1. `mise run sync-pricing-catalog`
+2. `cog bump --auto --skip-untracked`
+3. `git-cliff -o CHANGELOG.md`
+4. `gh release create v$(cog get-version) ...`
+5. `cargo release version $(cog get-version) --execute`
 
 That means release metadata and version updates are authored locally before any push happens. The GitHub release is not created as a draft by this task.
 

--- a/mise.toml
+++ b/mise.toml
@@ -297,6 +297,7 @@ run = "bun run --cwd crates/admin-ui/web test:e2e"
 
 [tasks.release]
 description = "Analyze commits and dispatch the release workflow when a release is pending"
+depends = ["sync-pricing-catalog"]
 env = { GITHUB_TOKEN = { required = true } }
 # Cocogitto is used purely for version bumping and publishing tags.
 # git-cliff, might be able to replace it entirely, but failed when an initial tag didn't exist.


### PR DESCRIPTION
## Description

Refresh model pricing during the local release flow and increase the request logs desktop table viewport.

- Summary of changes
  - Adds `sync-pricing-catalog` as a dependency of `mise run release`.
  - Updates the release runbook's `mise run release` step list to include the pricing catalog refresh.
  - Increases the request logs desktop table viewport to 12 estimated rows.
  - Adds a route test assertion for the 12-row viewport height.
- Why this approach was chosen
  - The repo already had a suitably described `sync-pricing-catalog` mise task, so release can reuse it directly instead of adding new tooling.
  - The request logs table already uses a virtualizer with a 56px row estimate, so the viewport height is derived from that estimate and the requested 12-row preview.
- How it works
  - `mise run release` now runs `sync-pricing-catalog` before the existing release commands.
  - The desktop request-log scroll container uses a 672px height, calculated as 12 rows times the 56px virtualizer row estimate.
- Risks, tradeoffs, and alternatives considered
  - The release task will now perform network-backed pricing refresh work before local release commands.
  - The request logs card is taller on desktop, trading a bit more vertical space for better log visibility.
- Additional context for reviewers
  - The Postgres-specific release-readiness tasks named below are not present in `mise tasks ls` in this checkout.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres` (task not defined in this checkout)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres` (task not defined in this checkout)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke` (task not defined in this checkout)
