### PR TITLE
fix(test): repair api key all-model ci coverage

### DIFF
--- a/crates/admin-ui/web/e2e/gateway-contract.e2e.ts
+++ b/crates/admin-ui/web/e2e/gateway-contract.e2e.ts
@@ -1,9 +1,88 @@
-import { expect, test } from 'playwright/test'
+import { type APIRequestContext, expect, test } from 'playwright/test'
 
 import { ensureAdminSession } from './admin-session'
 import { requireEnv, stubAdminUrl } from './env'
 
 const gatewayApiKey = process.env.E2E_GATEWAY_API_KEY ?? 'gwk_e2e.secret-value'
+
+type ApiKeysCatalog = {
+  users: Array<{ id: string }>
+  models: Array<{ key: string }>
+}
+
+function invitationToken(inviteUrl: string, root: string): string {
+  const token = new URL(inviteUrl, root).pathname.split('/').filter(Boolean).pop()
+  if (!token) {
+    throw new Error(`expected password invite URL to include a token: ${inviteUrl}`)
+  }
+  return token
+}
+
+async function createActiveApiKeyOwner(
+  request: APIRequestContext,
+  root: string,
+  adminCookie: string,
+): Promise<{ owner: { id: string }; catalog: ApiKeysCatalog }> {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const createUserResponse = await request.post(`${root}/api/v1/admin/identity/users`, {
+    headers: {
+      cookie: adminCookie,
+      'content-type': 'application/json',
+    },
+    data: {
+      name: 'E2E All Models Owner',
+      email: `all-model-owner-${unique}@example.com`,
+      auth_mode: 'password',
+      global_role: 'user',
+    },
+  })
+  expect(createUserResponse.status()).toBe(200)
+  const createUserBody = (await createUserResponse.json()) as {
+    data:
+      | {
+          kind: 'password_invite'
+          user: { id: string }
+          invite_url: string
+        }
+      | {
+          kind: string
+        }
+  }
+  expect(createUserBody.data.kind).toBe('password_invite')
+  if (createUserBody.data.kind !== 'password_invite') {
+    throw new Error(`expected password invite onboarding, received ${createUserBody.data.kind}`)
+  }
+
+  const completeInviteResponse = await request.post(
+    `${root}/api/v1/auth/invitations/${invitationToken(createUserBody.data.invite_url, root)}/password`,
+    {
+      headers: {
+        'content-type': 'application/json',
+      },
+      data: {
+        password: 'all-model-owner-pass',
+      },
+    },
+  )
+  expect(completeInviteResponse.status()).toBe(200)
+
+  const apiKeysResponse = await request.get(`${root}/api/v1/admin/api-keys`, {
+    headers: {
+      cookie: adminCookie,
+    },
+  })
+  expect(apiKeysResponse.status()).toBe(200)
+  const apiKeysBody = (await apiKeysResponse.json()) as {
+    data: ApiKeysCatalog
+  }
+  const owner = apiKeysBody.data.users.find((user) => user.id === createUserBody.data.user.id)
+  expect(owner).toBeTruthy()
+  if (!owner) {
+    throw new Error('expected the activated user to be available as an API key owner')
+  }
+
+  return { owner, catalog: apiKeysBody.data }
+}
 
 test('gateway exposes the seeded model and forwards chat completions to the stub upstream', async ({
   request,
@@ -427,25 +506,8 @@ test('user-owned all-model api keys track the live model catalog', async ({
   const root = baseURL ?? requireEnv('E2E_BASE_URL')
   const adminCookie = await ensureAdminSession(page, request, root)
 
-  const apiKeysResponse = await request.get(`${root}/api/v1/admin/api-keys`, {
-    headers: {
-      cookie: adminCookie,
-    },
-  })
-  expect(apiKeysResponse.status()).toBe(200)
-  const apiKeysBody = (await apiKeysResponse.json()) as {
-    data: {
-      users: Array<{ id: string }>
-      models: Array<{ key: string }>
-    }
-  }
-  const [owner] = apiKeysBody.data.users
-  expect(owner).toBeTruthy()
-  if (!owner) {
-    throw new Error('expected an active user owner for all-model API key coverage')
-  }
-
-  const expectedModelKeys = apiKeysBody.data.models.map((model) => model.key).sort()
+  const { owner, catalog } = await createActiveApiKeyOwner(request, root, adminCookie)
+  const expectedModelKeys = catalog.models.map((model) => model.key).sort()
   expect(expectedModelKeys.length).toBeGreaterThan(0)
 
   const createResponse = await request.post(`${root}/api/v1/admin/api-keys`, {

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -4314,9 +4314,9 @@ mod tests {
         conn.execute(
             r#"
             INSERT INTO api_keys (
-              id, public_id, secret_hash, name, status, model_grant_mode,
+              id, public_id, secret_hash, name, status,
               owner_kind, owner_user_id, owner_team_id, created_at
-            ) VALUES (?1, 'pub_user', 'hash', 'User key', 'active', 'explicit', 'user', ?2, NULL, ?3)
+            ) VALUES (?1, 'pub_user', 'hash', 'User key', 'active', 'user', ?2, NULL, ?3)
             "#,
             libsql::params![api_key_id.to_string(), user_id.to_string(), now],
         )


### PR DESCRIPTION
## Description

Fixes the CI regressions found while validating PR #210.

- Restores the legacy libsql migration fixture so it inserts only columns that exist before the v35 `model_grant_mode` migration.
- Updates the all-model API-key E2E contract test to create a password user, complete the invite flow, and use that active user as the API-key owner.
- Keeps the contract coverage meaningful without depending on the system bootstrap admin, which is intentionally excluded from API-key owner options.

This is a stacked PR targeting `codex/api-key-all-model-grant-mode` so reviewers can inspect only the CI fixes for PR #210.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation run:
- [x] `cargo test -p gateway-store libsql_service_account_migration_preserves_user_key_history`
- [x] `mise run e2e-test`
- [x] `git diff --check`
