### PR TITLE
feat(codex): add Bedrock-safe client config

### DIFF
--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -213,7 +213,7 @@ const modelPage: ModelPageView = {
               label: 'config.toml',
               filename: 'config.toml',
               content:
-                'model = "claude-sonnet"\nmodel_reasoning_effort = "medium"\nmodel_provider = "oceans-llm"\nrequires_openai_auth = false\nopenai_base_url = "http://127.0.0.1:3000/v1"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nenv_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"\nrequires_openai_auth = false\nwire_api = "responses"\n\n[analytics]\nenabled = false\n\n[otel]\nlog_user_prompt = false\n',
+                'model = "claude-sonnet"\nmodel_reasoning_effort = "medium"\nmodel_provider = "oceans-llm"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nenv_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"\nrequires_openai_auth = false\nwire_api = "responses"\n\n[analytics]\nenabled = false\n\n[otel]\nlog_user_prompt = false\n',
             },
           ],
           notes: ['Add this provider configuration to user-level ~/.codex/config.toml.'],
@@ -443,7 +443,6 @@ describe('ModelsPage', () => {
     expect(screen.getByText('config.toml')).toBeInTheDocument()
     expect(screen.getByText(/model = "claude-sonnet"/)).toBeInTheDocument()
     expect(screen.getByText(/model_reasoning_effort = "medium"/)).toBeInTheDocument()
-    expect(screen.getByText(/openai_base_url = "http:\/\/127\.0\.0\.1:3000\/v1"/)).toBeInTheDocument()
     expect(screen.getByText(/\[model_providers.oceans-llm\]/)).toBeInTheDocument()
     expect(screen.getByText(/env_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"/)).toBeInTheDocument()
     expect(screen.getByText(/\[analytics\]/)).toBeInTheDocument()
@@ -452,7 +451,7 @@ describe('ModelsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy TOML' }))
     expect(writeText).toHaveBeenLastCalledWith(
-      'model = "claude-sonnet"\nmodel_reasoning_effort = "medium"\nmodel_provider = "oceans-llm"\nrequires_openai_auth = false\nopenai_base_url = "http://127.0.0.1:3000/v1"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nenv_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"\nrequires_openai_auth = false\nwire_api = "responses"\n\n[analytics]\nenabled = false\n\n[otel]\nlog_user_prompt = false\n',
+      'model = "claude-sonnet"\nmodel_reasoning_effort = "medium"\nmodel_provider = "oceans-llm"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nenv_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"\nrequires_openai_auth = false\nwire_api = "responses"\n\n[analytics]\nenabled = false\n\n[otel]\nlog_user_prompt = false\n',
     )
   })
 

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -213,7 +213,7 @@ const modelPage: ModelPageView = {
               label: 'config.toml',
               filename: 'config.toml',
               content:
-                'model = "claude-sonnet"\nmodel_provider = "oceans-llm"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nwire_api = "responses"\n',
+                'model = "claude-sonnet"\nmodel_reasoning_effort = "medium"\nmodel_provider = "oceans-llm"\nrequires_openai_auth = false\nopenai_base_url = "http://127.0.0.1:3000/v1"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nenv_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"\nrequires_openai_auth = false\nwire_api = "responses"\n\n[analytics]\nenabled = false\n\n[otel]\nlog_user_prompt = false\n',
             },
           ],
           notes: ['Add this provider configuration to user-level ~/.codex/config.toml.'],
@@ -347,7 +347,7 @@ describe('ModelsPage', () => {
     expect(within(table).queryByText('Gemini fallback on Vertex')).not.toBeInTheDocument()
   })
 
-  it('opens client config dialog, switches tabs, and copies active JSON', async () => {
+  it('opens client config dialog, switches tabs, and copies active config blocks', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, {
       clipboard: { writeText },
@@ -442,12 +442,17 @@ describe('ModelsPage', () => {
     ).toHaveAttribute('href', 'https://developers.openai.com/codex/config-reference')
     expect(screen.getByText('config.toml')).toBeInTheDocument()
     expect(screen.getByText(/model = "claude-sonnet"/)).toBeInTheDocument()
+    expect(screen.getByText(/model_reasoning_effort = "medium"/)).toBeInTheDocument()
+    expect(screen.getByText(/openai_base_url = "http:\/\/127\.0\.0\.1:3000\/v1"/)).toBeInTheDocument()
     expect(screen.getByText(/\[model_providers.oceans-llm\]/)).toBeInTheDocument()
+    expect(screen.getByText(/env_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"/)).toBeInTheDocument()
+    expect(screen.getByText(/\[analytics\]/)).toBeInTheDocument()
+    expect(screen.getByText(/log_user_prompt = false/)).toBeInTheDocument()
     expect(screen.getByText(/wire_api = "responses"/)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy TOML' }))
     expect(writeText).toHaveBeenLastCalledWith(
-      'model = "claude-sonnet"\nmodel_provider = "oceans-llm"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nwire_api = "responses"\n',
+      'model = "claude-sonnet"\nmodel_reasoning_effort = "medium"\nmodel_provider = "oceans-llm"\nrequires_openai_auth = false\nopenai_base_url = "http://127.0.0.1:3000/v1"\n\n[model_providers.oceans-llm]\nname = "oceans-llm"\nbase_url = "http://127.0.0.1:3000/v1"\nenv_key = "OCEANS_LLM_API_KEY"\nenv_key_instructions = "Set OCEANS_LLM_API_KEY in your environment"\nrequires_openai_auth = false\nwire_api = "responses"\n\n[analytics]\nenabled = false\n\n[otel]\nlog_user_prompt = false\n',
     )
   })
 

--- a/crates/gateway-client-config/src/templates/codex.rs
+++ b/crates/gateway-client-config/src/templates/codex.rs
@@ -37,8 +37,6 @@ impl ClientConfigTemplate for CodexConfigTemplate {
             model: input.model_id.clone(),
             model_reasoning_effort: CODEX_MODEL_REASONING_EFFORT,
             model_provider: input.provider_id.clone(),
-            requires_openai_auth: false,
-            openai_base_url: input.gateway_base_url.clone(),
             model_providers,
             analytics: CodexAnalyticsConfig { enabled: false },
             otel: CodexOtelConfig {
@@ -89,8 +87,6 @@ struct CodexConfigToml {
     model: String,
     model_reasoning_effort: &'static str,
     model_provider: String,
-    requires_openai_auth: bool,
-    openai_base_url: String,
     model_providers: BTreeMap<String, CodexModelProviderConfig>,
     analytics: CodexAnalyticsConfig,
     otel: CodexOtelConfig,

--- a/crates/gateway-client-config/src/templates/codex.rs
+++ b/crates/gateway-client-config/src/templates/codex.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 const CODEX_WIRE_API_RESPONSES: &str = "responses";
+const CODEX_MODEL_REASONING_EFFORT: &str = "medium";
 const CODEX_CONFIG_DOCS_URL: &str = "https://developers.openai.com/codex/config-reference";
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -26,14 +27,23 @@ impl ClientConfigTemplate for CodexConfigTemplate {
                 name: input.provider_name.clone(),
                 base_url: input.gateway_base_url.clone(),
                 env_key: input.api_key_env_var.clone(),
+                env_key_instructions: format!("Set {} in your environment", input.api_key_env_var),
+                requires_openai_auth: false,
                 wire_api: CODEX_WIRE_API_RESPONSES,
             },
         );
 
         let config = CodexConfigToml {
             model: input.model_id.clone(),
+            model_reasoning_effort: CODEX_MODEL_REASONING_EFFORT,
             model_provider: input.provider_id.clone(),
+            requires_openai_auth: false,
+            openai_base_url: input.gateway_base_url.clone(),
             model_providers,
+            analytics: CodexAnalyticsConfig { enabled: false },
+            otel: CodexOtelConfig {
+                log_user_prompt: false,
+            },
         };
 
         ClientConfig {
@@ -77,8 +87,13 @@ fn codex_setup(input: &ClientConfigInput) -> Vec<ClientConfigSetupItem> {
 #[derive(Debug, Serialize)]
 struct CodexConfigToml {
     model: String,
+    model_reasoning_effort: &'static str,
     model_provider: String,
+    requires_openai_auth: bool,
+    openai_base_url: String,
     model_providers: BTreeMap<String, CodexModelProviderConfig>,
+    analytics: CodexAnalyticsConfig,
+    otel: CodexOtelConfig,
 }
 
 #[derive(Debug, Serialize)]
@@ -86,5 +101,17 @@ struct CodexModelProviderConfig {
     name: String,
     base_url: String,
     env_key: String,
+    env_key_instructions: String,
+    requires_openai_auth: bool,
     wire_api: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct CodexAnalyticsConfig {
+    enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CodexOtelConfig {
+    log_user_prompt: bool,
 }

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -579,11 +579,6 @@ fn codex_shape_includes_custom_responses_provider() {
     assert_eq!(toml["model"].as_str(), Some("claude-sonnet"));
     assert_eq!(toml["model_reasoning_effort"].as_str(), Some("medium"));
     assert_eq!(toml["model_provider"].as_str(), Some("oceans"));
-    assert_eq!(toml["requires_openai_auth"].as_bool(), Some(false));
-    assert_eq!(
-        toml["openai_base_url"].as_str(),
-        Some("https://oceans.example.com/v1")
-    );
 
     let provider = &toml["model_providers"]["oceans"];
     assert_eq!(provider["name"].as_str(), Some("OpenAI using LLM proxy"));
@@ -601,7 +596,7 @@ fn codex_shape_includes_custom_responses_provider() {
     assert_eq!(toml["analytics"]["enabled"].as_bool(), Some(false));
     assert_eq!(toml["otel"]["log_user_prompt"].as_bool(), Some(false));
 
-    assert_eq!(content.matches("https://oceans.example.com/v1").count(), 2);
+    assert_eq!(content.matches("https://oceans.example.com/v1").count(), 1);
     assert!(!content.contains("]("));
     assert!(
         rendered

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use toml::Value as TomlValue;
 
 use crate::{
     AnthropicThinkingPolicy, ClaudeCodeConfigTemplate, ClientConfig, ClientConfigInput,
@@ -552,7 +553,12 @@ fn claude_code_sets_default_fable_model_env_var() {
 
 #[test]
 fn codex_shape_includes_custom_responses_provider() {
-    let rendered = CodexConfigTemplate.render(&input(Some(AnthropicThinkingPolicy::SafeEffort)));
+    let mut input = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    input.provider_id = "oceans".to_string();
+    input.provider_name = "OpenAI using LLM proxy".to_string();
+    input.gateway_base_url = "https://oceans.example.com/v1".to_string();
+    input.api_key_env_var = "OCEANS_API_KEY".to_string();
+    let rendered = CodexConfigTemplate.render(&input);
 
     assert_eq!(rendered.key, "codex");
     assert_eq!(rendered.label, "Codex");
@@ -561,42 +567,42 @@ fn codex_shape_includes_custom_responses_provider() {
         setup_value(&rendered, "Configuration"),
         "~/.codex/config.toml"
     );
-    assert!(setup_value(&rendered, "API key").contains("OCEANS_LLM_API_KEY"));
+    assert!(setup_value(&rendered, "API key").contains("OCEANS_API_KEY"));
     assert_eq!(
         setup_href(&rendered, "Docs"),
         "https://developers.openai.com/codex/config-reference"
     );
     assert_eq!(rendered.blocks[0].filename, "config.toml");
-    assert!(
-        rendered.blocks[0]
-            .content
-            .contains("model = \"claude-sonnet\"")
+
+    let content = &rendered.blocks[0].content;
+    let toml: TomlValue = content.parse().expect("codex config toml");
+    assert_eq!(toml["model"].as_str(), Some("claude-sonnet"));
+    assert_eq!(toml["model_reasoning_effort"].as_str(), Some("medium"));
+    assert_eq!(toml["model_provider"].as_str(), Some("oceans"));
+    assert_eq!(toml["requires_openai_auth"].as_bool(), Some(false));
+    assert_eq!(
+        toml["openai_base_url"].as_str(),
+        Some("https://oceans.example.com/v1")
     );
-    assert!(
-        rendered.blocks[0]
-            .content
-            .contains("model_provider = \"oceans-llm\"")
+
+    let provider = &toml["model_providers"]["oceans"];
+    assert_eq!(provider["name"].as_str(), Some("OpenAI using LLM proxy"));
+    assert_eq!(
+        provider["base_url"].as_str(),
+        Some("https://oceans.example.com/v1")
     );
-    assert!(
-        rendered.blocks[0]
-            .content
-            .contains("[model_providers.oceans-llm]")
+    assert_eq!(provider["env_key"].as_str(), Some("OCEANS_API_KEY"));
+    assert_eq!(
+        provider["env_key_instructions"].as_str(),
+        Some("Set OCEANS_API_KEY in your environment")
     );
-    assert!(
-        rendered.blocks[0]
-            .content
-            .contains("base_url = \"http://127.0.0.1:3000/v1\"")
-    );
-    assert!(
-        rendered.blocks[0]
-            .content
-            .contains("env_key = \"OCEANS_LLM_API_KEY\"")
-    );
-    assert!(
-        rendered.blocks[0]
-            .content
-            .contains("wire_api = \"responses\"")
-    );
+    assert_eq!(provider["requires_openai_auth"].as_bool(), Some(false));
+    assert_eq!(provider["wire_api"].as_str(), Some("responses"));
+    assert_eq!(toml["analytics"]["enabled"].as_bool(), Some(false));
+    assert_eq!(toml["otel"]["log_user_prompt"].as_bool(), Some(false));
+
+    assert_eq!(content.matches("https://oceans.example.com/v1").count(), 2);
+    assert!(!content.contains("]("));
     assert!(
         rendered
             .notes

--- a/crates/gateway-providers/src/bedrock/request/mod.rs
+++ b/crates/gateway-providers/src/bedrock/request/mod.rs
@@ -9,6 +9,7 @@ use content::*;
 use inference::*;
 use thinking::*;
 use tools::*;
+const OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE: &str = "image_generation";
 
 pub(super) fn map_chat_request_to_converse(
     request: &CoreChatRequest,
@@ -143,8 +144,140 @@ pub(super) fn map_openai_responses_request(
         for (key, value) in &context.extra_body {
             object.insert(key.clone(), value.clone());
         }
+        enforce_bedrock_responses_hosted_tool_compatibility(object, context)?;
     }
     Ok(body)
+}
+
+fn enforce_bedrock_responses_hosted_tool_compatibility(
+    object: &mut Map<String, Value>,
+    context: &ProviderRequestContext,
+) -> Result<(), ProviderError> {
+    let tools_contain_image_generation = object.get("tools").is_some_and(|tools| {
+        tools_contain_tool_type(tools, OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE)
+    });
+    let tool_choice_requires_image_generation =
+        object.get("tool_choice").is_some_and(|tool_choice| {
+            tool_choice_requires_tool_type(
+                tool_choice,
+                object.get("tools"),
+                OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE,
+            )
+        });
+
+    if tool_choice_requires_image_generation {
+        tracing::warn!(
+            request_id = %context.request_id,
+            provider_key = %context.provider_key,
+            model_key = %context.model_key,
+            upstream_model = %context.upstream_model,
+            reason = "unsupported_hosted_tool_required",
+            "aws_bedrock route does not support requested OpenAI hosted Responses tool"
+        );
+        return Err(ProviderError::InvalidRequest(format!(
+            "Oceans aws_bedrock provider `{}` route to upstream model `{}` does not support the OpenAI hosted image_generation Responses tool; choose an image-generation-capable route or remove the explicit image_generation tool choice",
+            context.provider_key, context.upstream_model
+        )));
+    }
+
+    if !tools_contain_image_generation {
+        return Ok(());
+    }
+
+    let removed_tool_count = object
+        .get_mut("tools")
+        .map(|tools| strip_tool_type_from_tools(tools, OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE))
+        .unwrap_or_default();
+    if object
+        .get("tools")
+        .is_some_and(|tools| matches!(tools, Value::Array(items) if items.is_empty()))
+    {
+        object.remove("tools");
+        if object
+            .get("tool_choice")
+            .is_some_and(tool_choice_is_none_or_auto)
+        {
+            object.remove("tool_choice");
+        }
+    }
+
+    if removed_tool_count > 0 {
+        tracing::info!(
+            request_id = %context.request_id,
+            provider_key = %context.provider_key,
+            model_key = %context.model_key,
+            upstream_model = %context.upstream_model,
+            removed_tool_count,
+            reason = "unsupported_hosted_tool_stripped",
+            "stripped unsupported OpenAI hosted Responses tool for aws_bedrock"
+        );
+    }
+
+    Ok(())
+}
+
+fn tools_contain_tool_type(tools: &Value, tool_type: &str) -> bool {
+    match tools {
+        Value::Array(items) => items.iter().any(|tool| tool_is_type(tool, tool_type)),
+        tool => tool_is_type(tool, tool_type),
+    }
+}
+
+fn strip_tool_type_from_tools(tools: &mut Value, tool_type: &str) -> usize {
+    let Value::Array(items) = tools else {
+        return 0;
+    };
+    let original_len = items.len();
+    items.retain(|tool| !tool_is_type(tool, tool_type));
+    original_len - items.len()
+}
+
+fn tool_choice_requires_tool_type(
+    tool_choice: &Value,
+    tools: Option<&Value>,
+    tool_type: &str,
+) -> bool {
+    if tool_choice_selects_type(tool_choice, tool_type) {
+        return true;
+    }
+
+    tool_choice_is_required(tool_choice) && tools_have_only_tool_type(tools, tool_type)
+}
+
+fn tool_choice_selects_type(tool_choice: &Value, tool_type: &str) -> bool {
+    match tool_choice {
+        Value::String(value) => value == tool_type,
+        Value::Object(object) => {
+            object.get("type").and_then(Value::as_str) == Some(tool_type)
+                || object.get("name").and_then(Value::as_str) == Some(tool_type)
+        }
+        _ => false,
+    }
+}
+
+fn tool_choice_is_required(tool_choice: &Value) -> bool {
+    match tool_choice {
+        Value::String(value) => value == "required",
+        Value::Object(object) => {
+            object.get("type").and_then(Value::as_str) == Some("required")
+                || object.get("mode").and_then(Value::as_str) == Some("required")
+        }
+        _ => false,
+    }
+}
+
+fn tools_have_only_tool_type(tools: Option<&Value>, tool_type: &str) -> bool {
+    let Some(Value::Array(items)) = tools else {
+        return false;
+    };
+    !items.is_empty() && items.iter().all(|tool| tool_is_type(tool, tool_type))
+}
+
+fn tool_is_type(tool: &Value, tool_type: &str) -> bool {
+    tool.as_object()
+        .and_then(|object| object.get("type"))
+        .and_then(Value::as_str)
+        == Some(tool_type)
 }
 
 pub(super) fn is_anthropic_claude_model(upstream_model: &str) -> bool {

--- a/crates/gateway-providers/src/bedrock/request/mod.rs
+++ b/crates/gateway-providers/src/bedrock/request/mod.rs
@@ -164,8 +164,11 @@ fn enforce_bedrock_responses_hosted_tool_compatibility(
                 OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE,
             )
         });
+    let tools_require_image_generation = object.get("tools").is_some_and(|tools| {
+        tools_require_tool_type(tools, OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE)
+    });
 
-    if tool_choice_requires_image_generation {
+    if tool_choice_requires_image_generation || tools_require_image_generation {
         tracing::warn!(
             request_id = %context.request_id,
             provider_key = %context.provider_key,
@@ -223,6 +226,13 @@ fn tools_contain_tool_type(tools: &Value, tool_type: &str) -> bool {
     }
 }
 
+fn tools_require_tool_type(tools: &Value, tool_type: &str) -> bool {
+    match tools {
+        Value::Array(items) => items.iter().any(|tool| tool_requires_type(tool, tool_type)),
+        tool => tool_requires_type(tool, tool_type),
+    }
+}
+
 fn strip_tool_type_from_tools(tools: &mut Value, tool_type: &str) -> usize {
     let Value::Array(items) = tools else {
         return 0;
@@ -242,6 +252,15 @@ fn tool_choice_requires_tool_type(
     }
 
     tool_choice_is_required(tool_choice) && tools_have_only_tool_type(tools, tool_type)
+}
+
+fn tool_requires_type(tool: &Value, tool_type: &str) -> bool {
+    tool_is_type(tool, tool_type)
+        && tool
+            .as_object()
+            .and_then(|object| object.get("action"))
+            .and_then(Value::as_str)
+            .is_some_and(|action| action != "auto")
 }
 
 fn tool_choice_selects_type(tool_choice: &Value, tool_type: &str) -> bool {

--- a/crates/gateway-providers/src/bedrock/request/mod.rs
+++ b/crates/gateway-providers/src/bedrock/request/mod.rs
@@ -153,9 +153,6 @@ fn enforce_bedrock_responses_hosted_tool_compatibility(
     object: &mut Map<String, Value>,
     context: &ProviderRequestContext,
 ) -> Result<(), ProviderError> {
-    let tools_contain_image_generation = object.get("tools").is_some_and(|tools| {
-        tools_contain_tool_type(tools, OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE)
-    });
     let tool_choice_requires_image_generation =
         object.get("tool_choice").is_some_and(|tool_choice| {
             tool_choice_requires_tool_type(
@@ -183,47 +180,46 @@ fn enforce_bedrock_responses_hosted_tool_compatibility(
         )));
     }
 
-    if !tools_contain_image_generation {
-        return Ok(());
-    }
-
     let removed_tool_count = object
         .get_mut("tools")
         .map(|tools| strip_tool_type_from_tools(tools, OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE))
         .unwrap_or_default();
-    if object
-        .get("tools")
-        .is_some_and(|tools| matches!(tools, Value::Array(items) if items.is_empty()))
-    {
-        object.remove("tools");
-        if object
-            .get("tool_choice")
-            .is_some_and(tool_choice_is_none_or_auto)
-        {
-            object.remove("tool_choice");
-        }
+    let removed_tool_choice_count = object
+        .get_mut("tool_choice")
+        .map(|tool_choice| {
+            strip_tool_type_from_allowed_tool_choice(
+                tool_choice,
+                OPENAI_HOSTED_IMAGE_GENERATION_TOOL_TYPE,
+            )
+        })
+        .unwrap_or_default();
+    let removed_total_count = removed_tool_count + removed_tool_choice_count;
+
+    if removed_total_count == 0 {
+        return Ok(());
     }
 
-    if removed_tool_count > 0 {
-        tracing::info!(
-            request_id = %context.request_id,
-            provider_key = %context.provider_key,
-            model_key = %context.model_key,
-            upstream_model = %context.upstream_model,
-            removed_tool_count,
-            reason = "unsupported_hosted_tool_stripped",
-            "stripped unsupported OpenAI hosted Responses tool for aws_bedrock"
-        );
+    if object.get("tools").is_some_and(tools_are_empty) {
+        object.remove("tools");
+        object.remove("tool_choice");
+    } else if object
+        .get("tool_choice")
+        .is_some_and(tool_choice_allowed_tools_empty)
+    {
+        object.remove("tool_choice");
     }
+
+    tracing::info!(
+        request_id = %context.request_id,
+        provider_key = %context.provider_key,
+        model_key = %context.model_key,
+        upstream_model = %context.upstream_model,
+        removed_tool_count = removed_total_count,
+        reason = "unsupported_hosted_tool_stripped",
+        "stripped unsupported OpenAI hosted Responses tool for aws_bedrock"
+    );
 
     Ok(())
-}
-
-fn tools_contain_tool_type(tools: &Value, tool_type: &str) -> bool {
-    match tools {
-        Value::Array(items) => items.iter().any(|tool| tool_is_type(tool, tool_type)),
-        tool => tool_is_type(tool, tool_type),
-    }
 }
 
 fn tools_require_tool_type(tools: &Value, tool_type: &str) -> bool {
@@ -234,12 +230,32 @@ fn tools_require_tool_type(tools: &Value, tool_type: &str) -> bool {
 }
 
 fn strip_tool_type_from_tools(tools: &mut Value, tool_type: &str) -> usize {
-    let Value::Array(items) = tools else {
+    match tools {
+        Value::Array(items) => {
+            let original_len = items.len();
+            items.retain(|tool| !tool_is_type(tool, tool_type));
+            original_len - items.len()
+        }
+        tool if tool_is_type(tool, tool_type) => {
+            *tool = Value::Array(Vec::new());
+            1
+        }
+        _ => 0,
+    }
+}
+
+fn strip_tool_type_from_allowed_tool_choice(tool_choice: &mut Value, tool_type: &str) -> usize {
+    let Some(object) = tool_choice.as_object_mut() else {
         return 0;
     };
-    let original_len = items.len();
-    items.retain(|tool| !tool_is_type(tool, tool_type));
-    original_len - items.len()
+    if object.get("type").and_then(Value::as_str) != Some("allowed_tools") {
+        return 0;
+    }
+
+    object
+        .get_mut("tools")
+        .map(|tools| strip_tool_type_from_tools(tools, tool_type))
+        .unwrap_or_default()
 }
 
 fn tool_choice_requires_tool_type(
@@ -251,7 +267,8 @@ fn tool_choice_requires_tool_type(
         return true;
     }
 
-    tool_choice_is_required(tool_choice) && tools_have_only_tool_type(tools, tool_type)
+    tool_choice_allowed_tools_require_only_tool_type(tool_choice, tool_type)
+        || (tool_choice_is_required(tool_choice) && tools_have_only_tool_type(tools, tool_type))
 }
 
 fn tool_requires_type(tool: &Value, tool_type: &str) -> bool {
@@ -266,12 +283,18 @@ fn tool_requires_type(tool: &Value, tool_type: &str) -> bool {
 fn tool_choice_selects_type(tool_choice: &Value, tool_type: &str) -> bool {
     match tool_choice {
         Value::String(value) => value == tool_type,
-        Value::Object(object) => {
-            object.get("type").and_then(Value::as_str) == Some(tool_type)
-                || object.get("name").and_then(Value::as_str) == Some(tool_type)
-        }
+        Value::Object(object) => object.get("type").and_then(Value::as_str) == Some(tool_type),
         _ => false,
     }
+}
+
+fn tool_choice_allowed_tools_require_only_tool_type(tool_choice: &Value, tool_type: &str) -> bool {
+    let Some(object) = tool_choice.as_object() else {
+        return false;
+    };
+    object.get("type").and_then(Value::as_str) == Some("allowed_tools")
+        && object.get("mode").and_then(Value::as_str) == Some("required")
+        && tools_have_only_tool_type(object.get("tools"), tool_type)
 }
 
 fn tool_choice_is_required(tool_choice: &Value) -> bool {
@@ -285,11 +308,26 @@ fn tool_choice_is_required(tool_choice: &Value) -> bool {
     }
 }
 
-fn tools_have_only_tool_type(tools: Option<&Value>, tool_type: &str) -> bool {
-    let Some(Value::Array(items)) = tools else {
+fn tool_choice_allowed_tools_empty(tool_choice: &Value) -> bool {
+    let Some(object) = tool_choice.as_object() else {
         return false;
     };
-    !items.is_empty() && items.iter().all(|tool| tool_is_type(tool, tool_type))
+    object.get("type").and_then(Value::as_str) == Some("allowed_tools")
+        && object.get("tools").is_none_or(tools_are_empty)
+}
+
+fn tools_have_only_tool_type(tools: Option<&Value>, tool_type: &str) -> bool {
+    match tools {
+        Some(Value::Array(items)) => {
+            !items.is_empty() && items.iter().all(|tool| tool_is_type(tool, tool_type))
+        }
+        Some(tool) => tool_is_type(tool, tool_type),
+        None => false,
+    }
+}
+
+fn tools_are_empty(tools: &Value) -> bool {
+    matches!(tools, Value::Array(items) if items.is_empty())
 }
 
 fn tool_is_type(tool: &Value, tool_type: &str) -> bool {

--- a/crates/gateway-providers/src/bedrock/tests/provider_requests.rs
+++ b/crates/gateway-providers/src/bedrock/tests/provider_requests.rs
@@ -534,6 +534,101 @@ async fn rejects_mantle_openai_responses_when_image_generation_tool_forces_actio
 }
 
 #[tokio::test]
+async fn rejects_mantle_openai_responses_when_allowed_tools_requires_image_generation() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([
+        {"type": "image_generation"},
+        {"type": "function", "name": "lookup", "parameters": {"type": "object"}}
+    ]));
+    request.tool_choice = Some(json!({
+        "type": "allowed_tools",
+        "mode": "required",
+        "tools": [{"type": "image_generation"}]
+    }));
+    let context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+
+    let error = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect_err("required allowed_tools image generation is rejected")
+        .to_string();
+
+    assert!(error.contains("image_generation"));
+    assert!(error.contains("openai.gpt-5.5"));
+}
+
+#[tokio::test]
+async fn builds_mantle_openai_responses_request_prunes_allowed_image_generation_tools() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([
+        {"type": "image_generation"},
+        {"type": "function", "name": "lookup", "parameters": {"type": "object"}}
+    ]));
+    request.tool_choice = Some(json!({
+        "type": "allowed_tools",
+        "mode": "auto",
+        "tools": [
+            {"type": "image_generation"},
+            {"type": "function", "name": "lookup"}
+        ]
+    }));
+    let context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+
+    let built = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect("request");
+    let body: Value =
+        serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+    let tools = body["tools"].as_array().expect("tools");
+    let allowed_tools = body["tool_choice"]["tools"]
+        .as_array()
+        .expect("allowed tools");
+
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["type"], "function");
+    assert_eq!(allowed_tools.len(), 1);
+    assert_eq!(allowed_tools[0]["type"], "function");
+}
+
+#[tokio::test]
+async fn builds_mantle_openai_responses_request_with_function_named_image_generation() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([
+        {"type": "function", "name": "image_generation", "parameters": {"type": "object"}}
+    ]));
+    request.tool_choice = Some(json!({"type": "function", "name": "image_generation"}));
+    let context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+
+    let built = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect("request");
+    let body: Value =
+        serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert_eq!(body["tools"][0]["name"], "image_generation");
+    assert_eq!(body["tool_choice"]["type"], "function");
+    assert_eq!(body["tool_choice"]["name"], "image_generation");
+}
+
+#[tokio::test]
 async fn strips_image_generation_added_by_route_extra_body() {
     let provider = mantle_bearer_provider();
     let request = responses_request(false);
@@ -560,6 +655,30 @@ async fn strips_image_generation_added_by_route_extra_body() {
 
     assert_eq!(tools.len(), 1);
     assert_eq!(tools[0]["type"], "function");
+}
+
+#[tokio::test]
+async fn strips_single_object_image_generation_added_by_route_extra_body() {
+    let provider = mantle_bearer_provider();
+    let request = responses_request(false);
+    let mut context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+    context
+        .extra_body
+        .insert("tools".to_string(), json!({"type": "image_generation"}));
+
+    let built = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect("request");
+    let body: Value =
+        serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+
+    assert!(body.get("tools").is_none());
+    assert!(body.get("tool_choice").is_none());
 }
 
 #[tokio::test]

--- a/crates/gateway-providers/src/bedrock/tests/provider_requests.rs
+++ b/crates/gateway-providers/src/bedrock/tests/provider_requests.rs
@@ -513,6 +513,27 @@ async fn rejects_mantle_openai_responses_when_tool_choice_requires_image_generat
 }
 
 #[tokio::test]
+async fn rejects_mantle_openai_responses_when_image_generation_tool_forces_action() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([{"type": "image_generation", "action": "generate"}]));
+    let context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+
+    let error = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect_err("forced image generation is rejected")
+        .to_string();
+
+    assert!(error.contains("image_generation"));
+    assert!(error.contains("openai.gpt-5.5"));
+}
+
+#[tokio::test]
 async fn strips_image_generation_added_by_route_extra_body() {
     let provider = mantle_bearer_provider();
     let request = responses_request(false);

--- a/crates/gateway-providers/src/bedrock/tests/provider_requests.rs
+++ b/crates/gateway-providers/src/bedrock/tests/provider_requests.rs
@@ -426,6 +426,122 @@ async fn builds_mantle_openai_responses_stream_request() {
 }
 
 #[tokio::test]
+async fn builds_mantle_openai_responses_request_strips_opportunistic_image_generation_tool() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([
+        {"type": "image_generation"},
+        {"type": "function", "name": "lookup", "parameters": {"type": "object"}},
+        {"type": "custom", "name": "custom_tool"},
+        {"type": "namespace", "namespace": "browser"},
+        {"type": "tool_search"},
+        {"type": "mcp", "server_label": "tools"}
+    ]));
+    request.tool_choice = Some(json!("auto"));
+    let context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+
+    let built = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect("request");
+    let body: Value =
+        serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+    let tools = body["tools"].as_array().expect("tools");
+    let tool_types = tools
+        .iter()
+        .filter_map(|tool| tool.get("type").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+
+    assert_eq!(body["model"], "openai.gpt-5.5");
+    assert!(!tool_types.contains(&"image_generation"));
+    assert!(tool_types.contains(&"function"));
+    assert!(tool_types.contains(&"custom"));
+    assert!(tool_types.contains(&"namespace"));
+    assert!(tool_types.contains(&"tool_search"));
+    assert!(tool_types.contains(&"mcp"));
+}
+
+#[tokio::test]
+async fn builds_mantle_openai_responses_request_omits_only_opportunistic_image_generation_tool() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([{"type": "image_generation"}]));
+    request.tool_choice = Some(json!("auto"));
+    let context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+
+    let built = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect("request");
+    let body: Value =
+        serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+
+    assert!(body.get("tools").is_none());
+    assert!(body.get("tool_choice").is_none());
+}
+
+#[tokio::test]
+async fn rejects_mantle_openai_responses_when_tool_choice_requires_image_generation() {
+    let provider = mantle_bearer_provider();
+    let mut request = responses_request(false);
+    request.tools = Some(json!([{"type": "image_generation"}]));
+    request.tool_choice = Some(json!({"type": "image_generation"}));
+    let mut context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+    context.provider_key = "bedrock-mantle".to_string();
+
+    let error = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect_err("explicit image generation is rejected")
+        .to_string();
+
+    assert!(error.contains("image_generation"));
+    assert!(error.contains("bedrock-mantle"));
+    assert!(error.contains("openai.gpt-5.5"));
+}
+
+#[tokio::test]
+async fn strips_image_generation_added_by_route_extra_body() {
+    let provider = mantle_bearer_provider();
+    let request = responses_request(false);
+    let mut context = context_with_api_style(
+        "openai.gpt-5.5",
+        AwsBedrockApiStyle::MantleOpenaiResponses,
+        Some("/openai/v1"),
+    );
+    context.extra_body.insert(
+        "tools".to_string(),
+        json!([
+            {"type": "image_generation"},
+            {"type": "function", "name": "lookup", "parameters": {"type": "object"}}
+        ]),
+    );
+
+    let built = provider
+        .build_responses_request(&request, &context, false)
+        .await
+        .expect("request");
+    let body: Value =
+        serde_json::from_slice(built.body().unwrap().as_bytes().unwrap()).expect("json body");
+    let tools = body["tools"].as_array().expect("tools");
+
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["type"], "function");
+}
+
+#[tokio::test]
 #[serial]
 async fn mantle_openai_responses_default_chain_uses_mantle_sigv4_service() {
     let _env = AwsCredentialEnvGuard::set();

--- a/crates/gateway-providers/src/openai_compat.rs
+++ b/crates/gateway-providers/src/openai_compat.rs
@@ -1320,6 +1320,29 @@ mod tests {
     }
 
     #[test]
+    fn builds_responses_request_preserves_image_generation_for_openai_compat() {
+        let provider = provider();
+        let mut request = responses_request(false);
+        request.tools = Some(json!([
+            {"type": "image_generation"},
+            {"type": "function", "name": "lookup"}
+        ]));
+        request.tool_choice = Some(json!({"type": "image_generation"}));
+        let context = default_context();
+
+        let built = provider
+            .build_responses_request(&request, &context)
+            .expect("build request");
+        let body_json = request_body_json(&built);
+
+        assert_eq!(body_json["tools"], request.tools.expect("tools"));
+        assert_eq!(
+            body_json["tool_choice"],
+            json!({"type": "image_generation"})
+        );
+    }
+
+    #[test]
     fn build_responses_stream_request_enforces_stream_without_chat_stream_options() {
         let provider = provider();
         let request = responses_request(false);

--- a/docs/configuration/client-harness-configuration.md
+++ b/docs/configuration/client-harness-configuration.md
@@ -13,12 +13,13 @@ Generated snippets are available for:
 - [OpenCode]
 - [Pi]
 - [Claude Code]
+- [Codex]
 
 The snippets use the gateway model ids shown in the Models table. API keys are still created and governed in Oceans; the local client config only tells the harness which gateway URL, key variable, and model ids to use.
 
 By default, snippets use the local development gateway base URL `http://127.0.0.1:3000/v1`. Production deployments should set `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway process, or `gateway.clientConfigGatewayBaseUrl` in the Helm chart, to the public gateway API base URL users can reach, for example `https://gateway.example.com/v1`.
 
-OpenCode and Pi can include multiple selected models in one generated file. When the selection mixes Anthropic Messages models and OpenAI-compatible models, Oceans emits separate provider entries so each provider keeps the correct client adapter. Claude Code only includes selected models that use Anthropic Messages; non-Anthropic selections are ignored for the Claude Code tab instead of generating invalid overrides.
+OpenCode and Pi can include multiple selected models in one generated file. When the selection mixes Anthropic Messages models and OpenAI-compatible models, Oceans emits separate provider entries so each provider keeps the correct client adapter. Claude Code only includes selected models that use Anthropic Messages; non-Anthropic selections are ignored for the Claude Code tab instead of generating invalid overrides. Codex snippets require a single Responses-capable model selection.
 
 ## OpenCode
 
@@ -42,6 +43,14 @@ Claude Code appends Anthropic endpoints such as `/v1/messages` and `/v1/models` 
 
 The same dialog also shows a second `settings.json` block for a smaller local Claude Code experience. It disables telemetry, experimental betas, 1M context, and related UI/reporting behavior, and sets a lower auto-compact window.
 
+## Codex
+
+The Codex tab emits `config.toml` content for the user-level Codex configuration at `~/.codex/config.toml`. Codex ignores provider, auth, and telemetry keys from project-local `.codex/config.toml` files, so copy this block into the user-level config unless the Codex docs say otherwise.
+
+Oceans includes Codex only when the selection contains one Responses-capable model. The generated TOML uses the selected gateway model id, configured gateway base URL, Oceans provider id/name, and gateway API-key environment variable. It also sets `wire_api = "responses"`, disables OpenAI auth for the proxy provider, disables analytics, disables OTEL prompt logging, and sets `model_reasoning_effort = "medium"` for a predictable default.
+
+Responses-compatible Bedrock routes can still support only a subset of OpenAI-hosted tools. For example, Bedrock Mantle GPT-5.5 is usable through Codex over the Responses API but does not support the OpenAI-hosted `image_generation` tool; see [Provider API Compatibility](../reference/provider-api-compatibility.md#hosted-responses-tools).
+
 ## Budgets And Access
 
 Client snippets do not grant access by themselves. A request is accepted only when the gateway API key is active, the caller has model access, and any applicable hard budget still has room.
@@ -59,3 +68,4 @@ Use `/admin/spend-controls` to configure those budgets. For the full taxonomy an
 [opencode configuration docs]: https://opencode.ai/docs/config/
 [pi settings docs]: https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/settings.md
 [claude code]: https://code.claude.com/docs/en/settings
+[codex]: https://developers.openai.com/codex/config-reference

--- a/docs/overview-features.md
+++ b/docs/overview-features.md
@@ -1,3 +1,5 @@
 # Overview and Features
 
+`See also`: [Documentation Home](index.md)
+
 Why?

--- a/docs/providers/aws-bedrock-openai-gpt-55.md
+++ b/docs/providers/aws-bedrock-openai-gpt-55.md
@@ -114,6 +114,18 @@ models:
 
 Projects apply to OpenAI-compatible Mantle routes. Do not rely on caller-supplied inbound headers for project routing; configure `OpenAI-Project` in the selected route.
 
+## Hosted Tool Compatibility
+
+GPT-5.5 on Bedrock Mantle is configured as a Responses-first route through `api_style: mantle_openai_responses`. The `tools: true` capability in the examples means the route can attempt supported tool-bearing Responses workflows; it does not mean Bedrock supports every OpenAI-hosted tool.
+
+Bedrock Mantle currently does not support the OpenAI-hosted `image_generation` Responses tool. Direct OpenAI GPT-5.5 can support hosted image generation, but the Bedrock OpenAI-compatible path has a narrower feature set.
+
+Oceans strips opportunistic `image_generation` tool declarations before forwarding ordinary Bedrock-backed coding workflows. If a request explicitly requires image generation, for example through `tool_choice: { "type": "image_generation" }`, Oceans fails locally with a deterministic 400 instead of forwarding the request and exposing an opaque Bedrock validation error.
+
+Revisit this shim when Bedrock Mantle supports hosted `image_generation`, or when Oceans grows explicit hosted-tool capabilities that can route image-generation-required requests to a provider that actually supports them.
+
+For the broader rule, see [Provider API Compatibility](../reference/provider-api-compatibility.md#hosted-responses-tools).
+
 ## Caller Usage
 
 Call the gateway's `/v1/responses` endpoint with the configured gateway model id:

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -38,7 +38,7 @@ This matrix is about current execution support, not provider marketing claims.
 | `gcp_cloud_run_openai_compat` | Supported through the OpenAI-compatible adapter with Cloud Run ID-token auth. | Supported when the deployed service exposes an OpenAI-compatible Responses endpoint. Chat Completions profile transforms do not apply. | Supported when the deployed service exposes an OpenAI-compatible embeddings endpoint. |
 | `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Not implemented in this slice; keep route `embeddings: false`. |
 | `gcp_vertex` with `anthropic/*` upstream models | Supported for Chat Completions and Anthropic Messages when route capabilities allow it. Tool use is supported for text/tool workflows. | Not implemented; keep route `responses: false`. | Not applicable. |
-| `aws_bedrock` | Supported through explicit `compatibility.aws_bedrock.api_style`: Runtime Converse, Runtime Anthropic InvokeModel, Runtime OpenAI Chat, Mantle OpenAI Chat, or Mantle Anthropic Messages. Streaming uses the configured style's stream contract. | Supported for `api_style: mantle_openai_responses` with an OpenAI base path such as `/openai/v1`. | Not implemented; keep route `embeddings: false`. |
+| `aws_bedrock` | Supported through explicit `compatibility.aws_bedrock.api_style`: Runtime Converse, Runtime Anthropic InvokeModel, Runtime OpenAI Chat, Mantle OpenAI Chat, or Mantle Anthropic Messages. Streaming uses the configured style's stream contract. | Supported for `api_style: mantle_openai_responses` with an OpenAI base path such as `/openai/v1`. This is the Bedrock-supported Responses subset, not full direct-OpenAI hosted-tool parity. | Not implemented; keep route `embeddings: false`. |
 
 Route capability flags are still useful when a provider implementation does not support a public API family. They make failures happen at the gateway edge instead of later inside the provider adapter.
 
@@ -104,6 +104,16 @@ Effective capability is the intersection of configured route metadata and provid
 For example, a Vertex Google chat route should normally set `responses: false` and `embeddings: false` until those provider paths are implemented. Otherwise the route may look viable from config alone and still fail when the provider adapter rejects the unsupported API family.
 
 For Cloud Run OpenAI-compatible routes, set capabilities to the endpoints exposed by the deployed service. The gateway adapter can construct Chat Completions, Responses, embeddings, and streams through the OpenAI-compatible path, but a vLLM deployment might only enable some of those endpoints.
+
+### Hosted Responses Tools
+
+Route `capabilities.tools` is a coarse gateway gate. It means a route can attempt tool-bearing requests at all; it does not claim support for every OpenAI Responses hosted tool type.
+
+Hosted tools such as `image_generation` are provider- and deployment-specific. Function, custom, namespace, tool-search, and MCP workflows can be available on a route even when an OpenAI-hosted tool is not.
+
+For `aws_bedrock` routes using `api_style: mantle_openai_responses`, Bedrock exposes an OpenAI-compatible Responses subset. Bedrock Mantle GPT-5.5 does not support the OpenAI-hosted `image_generation` tool even though direct OpenAI GPT-5.5 can. Oceans strips opportunistic `image_generation` tool declarations for ordinary Bedrock-backed coding workflows and fails locally when a request explicitly requires image generation, so callers receive a deterministic gateway 400 instead of an upstream Bedrock validation error.
+
+If Oceans later routes between providers based on hosted-tool support, that should become an explicit capability dimension instead of overloading `tools`.
 
 ## Cloud Run OpenAI-Compatible Auth
 


### PR DESCRIPTION
## Description

Generate complete Codex `config.toml` snippets from the server-owned client-config template and add a Bedrock Mantle Responses compatibility guard for unsupported OpenAI-hosted `image_generation` tools.

- Summary of changes
  - Add Codex defaults for `model_reasoning_effort`, proxy auth, `openai_base_url`, provider env-key instructions, Responses wire API, disabled analytics, and disabled OTEL prompt logging.
  - Preserve the existing generic admin UI client-config dialog while updating route tests for richer Codex TOML copy behavior.
  - Strip opportunistic Bedrock `image_generation` hosted-tool declarations, preserve supported tool types, and fail locally when image generation is explicitly required.
  - Document Codex config behavior and Bedrock hosted-tool limitations.
- Why this approach was chosen
  - Keeps Codex semantics server-owned in `gateway-client-config` instead of duplicating TOML logic in React.
  - Uses a narrow Bedrock final-body guard so route `extra_body` cannot reintroduce unsupported tools and direct OpenAI-compatible providers remain unchanged.
- How it works
  - `CodexConfigTemplate` serializes richer private TOML structs from existing `ClientConfigInput` fields.
  - Bedrock Responses mapping sanitizes the final outbound JSON body before request construction/signing.
  - Structured logs record stripped or explicitly rejected hosted-tool requests.
- Risks, tradeoffs, and alternatives considered
  - `capabilities.tools` remains coarse; a future hosted-tool capability matrix is the right long-term route-selection solution.
  - The compatibility shim is not image-generation support. It should be revisited when Bedrock supports hosted `image_generation` or Oceans can route explicit image-generation requests to a capable provider.
- Additional context for reviewers
  - Addresses #216 and #217.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres` (not run; task is not defined in root or gateway-store mise configs)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres` (not run; task is not defined in root or gateway-store mise configs)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke` (not run; task is not defined in root or gateway-store mise configs)
