### PR TITLE
fix(admin-ui): serve static assets before auth fallback

### DIFF
--- a/crates/admin-ui/web/e2e/admin-static-assets.e2e.ts
+++ b/crates/admin-ui/web/e2e/admin-static-assets.e2e.ts
@@ -50,8 +50,6 @@ test('admin shell serves linked CSS and JavaScript assets through the gateway', 
   if (!stylesheetUrl || !scriptUrl) {
     throw new Error('expected the admin shell to link built CSS and JavaScript assets')
   }
-  expect(stylesheetUrl.pathname).toMatch(/^\/admin\/assets\/.*\.css$/)
-  expect(scriptUrl.pathname).toMatch(/^\/admin\/assets\/.*\.js$/)
 
   const stylesheetResponse = await request.get(stylesheetUrl.href)
   expect(stylesheetResponse.status()).toBe(200)

--- a/crates/admin-ui/web/e2e/admin-static-assets.e2e.ts
+++ b/crates/admin-ui/web/e2e/admin-static-assets.e2e.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'playwright/test'
+
+import { requireEnv } from './env'
+
+function extractAttribute(tag: string, name: string): string | null {
+  const match = tag.match(new RegExp(`\\s${name}=(['"])(.*?)\\1`, 'i'))
+  return match?.[2] ?? null
+}
+
+function assetUrlsFromHtml(
+  html: string,
+  root: string,
+  selector: 'stylesheet' | 'script',
+): Array<URL> {
+  const tags =
+    selector === 'stylesheet'
+      ? Array.from(html.matchAll(/<link\b[^>]*>/gi), (match) => match[0]).filter((tag) =>
+          extractAttribute(tag, 'rel')
+            ?.toLowerCase()
+            .split(/\s+/)
+            .includes('stylesheet'),
+        )
+      : Array.from(html.matchAll(/<script\b[^>]*>/gi), (match) => match[0])
+
+  return tags
+    .map((tag) => extractAttribute(tag, selector === 'stylesheet' ? 'href' : 'src'))
+    .filter((asset): asset is string => Boolean(asset))
+    .map((asset) => new URL(asset, root))
+}
+
+test('admin shell serves linked CSS and JavaScript assets through the gateway', async ({
+  request,
+  baseURL,
+}) => {
+  const root = baseURL ?? requireEnv('E2E_BASE_URL')
+  const shellResponse = await request.get(`${root}/admin`)
+
+  expect(shellResponse.status()).toBe(200)
+  expect(shellResponse.headers()['content-type']).toMatch(/^text\/html\b/i)
+
+  const shellHtml = await shellResponse.text()
+  const stylesheetUrls = assetUrlsFromHtml(shellHtml, root, 'stylesheet')
+  const scriptUrls = assetUrlsFromHtml(shellHtml, root, 'script')
+
+  const stylesheetUrl = stylesheetUrls.find((url) =>
+    /^\/admin\/assets\/.*\.css$/.test(url.pathname),
+  )
+  const scriptUrl = scriptUrls.find((url) => /^\/admin\/assets\/.*\.js$/.test(url.pathname))
+
+  if (!stylesheetUrl || !scriptUrl) {
+    throw new Error('expected the admin shell to link built CSS and JavaScript assets')
+  }
+  expect(stylesheetUrl.pathname).toMatch(/^\/admin\/assets\/.*\.css$/)
+  expect(scriptUrl.pathname).toMatch(/^\/admin\/assets\/.*\.js$/)
+
+  const stylesheetResponse = await request.get(stylesheetUrl.href)
+  expect(stylesheetResponse.status()).toBe(200)
+  expect(stylesheetResponse.headers()['content-type']).toMatch(/^text\/css\b/i)
+
+  const stylesheetBody = await stylesheetResponse.text()
+  expect(stylesheetBody).toMatch(/\{[^}]+\}/)
+  expect(stylesheetBody).not.toMatch(/<!doctype html|<html\b|Admin sign in/i)
+
+  const scriptResponse = await request.get(scriptUrl.href)
+  expect(scriptResponse.status()).toBe(200)
+  expect(scriptResponse.headers()['content-type']).toMatch(
+    /^(?:application|text)\/javascript\b/i,
+  )
+
+  const scriptBody = await scriptResponse.text()
+  expect(scriptBody.trimStart()).not.toMatch(/^(?:<!doctype html|<html\b)/i)
+})
+
+test('unauthenticated protected admin routes still require login', async ({ page }) => {
+  await page.goto('/admin/api-keys')
+
+  await expect(page).toHaveURL(/\/admin\/login\?redirect=%2Fapi-keys$/)
+  await expect(page.getByText('Admin sign in')).toBeVisible()
+})

--- a/crates/admin-ui/web/server.ts
+++ b/crates/admin-ui/web/server.ts
@@ -51,7 +51,12 @@ function resolveStaticAssetRequest(pathname: string): StaticAssetRequest | null 
   }
 
   const normalizedPath = path.posix.normalize(relativePath)
-  if (normalizedPath.startsWith('../') || normalizedPath.includes('/../')) {
+  if (
+    normalizedPath === '.' ||
+    normalizedPath === '..' ||
+    normalizedPath.startsWith('../') ||
+    normalizedPath.includes('/../')
+  ) {
     return null
   }
 

--- a/crates/admin-ui/web/server.ts
+++ b/crates/admin-ui/web/server.ts
@@ -7,6 +7,31 @@ const rootDirectory = path.dirname(fileURLToPath(import.meta.url))
 const clientDirectory = path.join(rootDirectory, 'dist', 'client')
 const serverEntryPoint = path.join(rootDirectory, 'dist', 'server', 'server.js')
 
+const staticAssetExtensions: Record<string, true> = {
+  '.avif': true,
+  '.css': true,
+  '.gif': true,
+  '.ico': true,
+  '.jpeg': true,
+  '.jpg': true,
+  '.js': true,
+  '.json': true,
+  '.map': true,
+  '.mjs': true,
+  '.png': true,
+  '.svg': true,
+  '.txt': true,
+  '.webmanifest': true,
+  '.webp': true,
+  '.woff': true,
+  '.woff2': true,
+}
+
+interface StaticAssetRequest {
+  path: string
+  terminal: boolean
+}
+
 const serverEntryModule = (await import(pathToFileURL(serverEntryPoint).href)) as {
   default: {
     fetch: (request: Request) => Response | Promise<Response>
@@ -15,7 +40,7 @@ const serverEntryModule = (await import(pathToFileURL(serverEntryPoint).href)) a
 
 const appHandler = serverEntryModule.default
 
-function resolveStaticAssetPath(pathname: string): string | null {
+function resolveStaticAssetRequest(pathname: string): StaticAssetRequest | null {
   if (!pathname.startsWith('/admin/')) {
     return null
   }
@@ -30,23 +55,40 @@ function resolveStaticAssetPath(pathname: string): string | null {
     return null
   }
 
-  return path.join(clientDirectory, normalizedPath)
+  const terminal =
+    normalizedPath.startsWith('assets/') ||
+    staticAssetExtensions[path.extname(normalizedPath)] === true
+
+  return {
+    path: path.join(clientDirectory, normalizedPath),
+    terminal,
+  }
 }
 
 const server = Bun.serve({
   port: PORT,
   async fetch(request) {
     const url = new URL(request.url)
-    const candidatePath = resolveStaticAssetPath(url.pathname)
+    const candidate = resolveStaticAssetRequest(url.pathname)
 
-    if (candidatePath) {
-      const file = Bun.file(candidatePath)
+    if (candidate) {
+      const file = Bun.file(candidate.path)
       if (await file.exists()) {
         return new Response(file, {
           headers: {
             'Cache-Control': url.pathname.includes('/assets/')
               ? 'public, max-age=31536000, immutable'
               : 'public, max-age=300',
+          },
+        })
+      }
+
+      if (candidate.terminal) {
+        return new Response('Static asset not found', {
+          status: 404,
+          headers: {
+            'Cache-Control': 'no-store',
+            'Content-Type': 'text/plain; charset=utf-8',
           },
         })
       }

--- a/docs/access/service-accounts.md
+++ b/docs/access/service-accounts.md
@@ -1,34 +1,133 @@
 # Service Accounts
 
-`See also`: [Identity and Access](identity-and-access.md), [Admin Control Plane](admin-control-plane.md), [Budgets and Spending](../contributing/operations/budgets-and-spending.md), [Data Relationships](../contributing/reference/data-relationships.md), [ADR: Team Service Accounts for Non-Human Gateway Access](../adr/2026-05-10-team-service-accounts.md)
+`See also`: [Identity and Access](identity-and-access.md), [Admin Control Plane](admin-control-plane.md), [Budgets](budgets.md), [Configuration Reference](../configuration/configuration-reference.md), [Runtime Bootstrap and Access](../setup/runtime-bootstrap-and-access.md), [ADR: Team Service Accounts for Non-Human Gateway Access](../adr/2026-05-10-team-service-accounts.md), [Service Account Config and Managed API Key Secrets](../adr/2026-07-02-service-account-config-and-managed-api-key-secrets.md)
 
-This page describes the intended service-account model for non-human gateway callers.
+Service accounts are the gateway identity for automation, applications, CI jobs and agents.
+
+Use them when you need a shared identity, with least privilege, that can be scoped to a team and a workload.
+
+## When to Use a Service Account
+
+Use a service account when:
+
+- a shared workload calls `/v1/*`
+- the caller should keep working when a team member leaves
+- spend should be visible as team-owned automation spend
+- model grants should be scoped to the workload instead of a person
+
+Use a user-owned API key only when the traffic should be attributable to that user. Do not use provider service-account credentials, such as Google Cloud service-account JSON, as gateway caller credentials.
 
 ## Model
 
-Service accounts are first-class gateway principals for automation, applications, and other non-human callers.
+Service accounts are first-class gateway principals for machine callers.
 
 - every service account belongs to exactly one team
 - service accounts are not users and cannot sign in to `/admin`
-- service-account credentials can call `/v1/*`
+- service-account API keys can call `/v1/*`
 - service-account spend is attributable to the service account and its owning team
 - service-account lifecycle is independent from team user membership
-- active service-account credentials require an active service-account budget
+- active service-account API keys require an active service-account budget
 
-API keys remain credentials. They are not the principal for team automation. A non-human team caller authenticates with a credential attached to a service account.
+API keys are credentials. They are not the principal for team automation. A non-human team caller authenticates with a credential attached to a service account.
 
-## No Legacy Team-Owned Runtime Keys
+## Add a Service Account in the Admin UI
 
-Direct team-owned runtime API keys are removed from the product contract.
+Allowed admins can create service accounts and credentials from `/admin`.
 
-Removed compatibility paths:
+1. Open **Identity** and create the service account under the owning team.
+2. Open **Spend Controls** and create an active **Service Account Budget** for that service account.
+3. Open **API Keys** and create a key whose owner is the service account.
+4. Grant only the gateway models that workload needs.
+5. Copy the raw key when it is shown and store it in the caller's secret manager.
+6. Configure the caller to send the key as a bearer token:
 
-- no reserved `system-legacy` team
-- no system-owned seeded runtime key compatibility
-- no direct team owner kind on runtime API keys
-- no fallback that treats a team as a non-human principal
+```http
+Authorization: Bearer gwk_<public-id>.<secret>
+```
 
-Teams own service accounts. Service accounts own their runtime credentials.
+For rotation, create a replacement key, update the caller secret, verify traffic with the replacement key, then revoke the old key.
+
+## Configure Service Accounts Declaratively
+
+Deployments can seed service accounts from top-level `service_accounts` config. This is the recommended path for bootstrap or deployment-managed automation credentials.
+
+The owning team must exist in `teams`. Each declared service account must have an active budget before its active keys can authenticate.
+
+```yaml
+teams:
+  - id: platform
+    name: Platform
+
+service_accounts:
+  - id: ci-indexer
+    name: CI Indexer
+    team: platform
+    budget:
+      cadence: daily
+      amount_usd: "25.0000"
+      hard_limit: true
+      timezone: UTC
+    keys:
+      - id: primary
+        name: CI Indexer Primary
+        auto_create: true
+        allowed_models:
+          - gpt-4o-mini
+          - gemini-fast
+```
+
+This example creates the `ci-indexer` service account, reconciles its budget, and creates one managed gateway API key if that managed key does not already exist. Generated managed keys are create-only: rerunning config does not rotate an existing generated key.
+
+Managed service-account key material is encrypted before storage so allowed admins can reveal it later. Set `OCEANS_API_KEY_SECRET_ENCRYPTION_KEY` to a base64-encoded 32-byte key before using config-managed service-account keys or creating service-account-owned keys in the admin UI. Do not rotate this encryption key by changing only the environment variable; existing stored key material would become undecryptable.
+
+## Use a Static Predefined Key
+
+If a caller already has a deployment-managed key value, reference it with `value`. Use `env.*` so the raw key comes from the deployment secret manager instead of the YAML file.
+
+```yaml
+teams:
+  - id: platform
+    name: Platform
+
+service_accounts:
+  - id: release-bot
+    name: Release Bot
+    team: platform
+    budget:
+      cadence: monthly
+      amount_usd: "100.0000"
+      hard_limit: true
+      timezone: UTC
+    keys:
+      - id: primary
+        name: Release Bot Primary
+        value: env.RELEASE_BOT_GATEWAY_API_KEY
+        allowed_models:
+          - openai-fast
+```
+
+The referenced environment variable must contain a gateway API key in the gateway format:
+
+```dotenv
+RELEASE_BOT_GATEWAY_API_KEY=gwk_releasebotprod.primary-secret-value
+```
+
+Static, predefined keys must be prefixed with `gwk_` and include both a non-empty public ID and a non-empty secret separated by a dot:
+
+```text
+gwk_<public-id>.<secret>
+```
+
+Examples that are rejected:
+
+```text
+releasebotprod.primary-secret-value
+gwk_releasebotprod
+gwk_.primary-secret-value
+gwk_releasebotprod.
+```
+
+Configured key values are authoritative. Changing `keys[*].value` rotates that managed key to the new predefined value on the next seed run.
 
 ## Access Control
 
@@ -78,6 +177,21 @@ Recipients are:
 - active team admins
 
 Recipients are resolved when alert delivery rows are created. Disabled users, removed team members, ordinary members, and non-members do not receive service-account budget alerts.
+
+## No Legacy Team-Owned Runtime Keys
+
+Direct team-owned runtime API keys are removed from the product contract.
+
+Removed compatibility paths:
+
+- no reserved `system-legacy` team
+- no system-owned seeded runtime key compatibility
+- no direct team owner kind on runtime API keys
+- no fallback that treats a team as a non-human principal
+
+Teams own service accounts. Service accounts own their runtime credentials.
+
+The old YAML-facing `auth.seed_api_keys` path is removed. Declare non-human gateway callers in top-level `service_accounts` instead.
 
 ## Provider Credential Boundary
 

--- a/docs/access/service-accounts.md
+++ b/docs/access/service-accounts.md
@@ -1,133 +1,34 @@
 # Service Accounts
 
-`See also`: [Identity and Access](identity-and-access.md), [Admin Control Plane](admin-control-plane.md), [Budgets](budgets.md), [Configuration Reference](../configuration/configuration-reference.md), [Runtime Bootstrap and Access](../setup/runtime-bootstrap-and-access.md), [ADR: Team Service Accounts for Non-Human Gateway Access](../adr/2026-05-10-team-service-accounts.md), [Service Account Config and Managed API Key Secrets](../adr/2026-07-02-service-account-config-and-managed-api-key-secrets.md)
+`See also`: [Identity and Access](identity-and-access.md), [Admin Control Plane](admin-control-plane.md), [Budgets and Spending](../contributing/operations/budgets-and-spending.md), [Data Relationships](../contributing/reference/data-relationships.md), [ADR: Team Service Accounts for Non-Human Gateway Access](../adr/2026-05-10-team-service-accounts.md)
 
-Service accounts are the gateway identity for automation, applications, CI jobs and agents.
-
-Use them when you need a shared identity, with least privilege, that can be scoped to a team and a workload.
-
-## When to Use a Service Account
-
-Use a service account when:
-
-- a shared workload calls `/v1/*`
-- the caller should keep working when a team member leaves
-- spend should be visible as team-owned automation spend
-- model grants should be scoped to the workload instead of a person
-
-Use a user-owned API key only when the traffic should be attributable to that user. Do not use provider service-account credentials, such as Google Cloud service-account JSON, as gateway caller credentials.
+This page describes the intended service-account model for non-human gateway callers.
 
 ## Model
 
-Service accounts are first-class gateway principals for machine callers.
+Service accounts are first-class gateway principals for automation, applications, and other non-human callers.
 
 - every service account belongs to exactly one team
 - service accounts are not users and cannot sign in to `/admin`
-- service-account API keys can call `/v1/*`
+- service-account credentials can call `/v1/*`
 - service-account spend is attributable to the service account and its owning team
 - service-account lifecycle is independent from team user membership
-- active service-account API keys require an active service-account budget
+- active service-account credentials require an active service-account budget
 
-API keys are credentials. They are not the principal for team automation. A non-human team caller authenticates with a credential attached to a service account.
+API keys remain credentials. They are not the principal for team automation. A non-human team caller authenticates with a credential attached to a service account.
 
-## Add a Service Account in the Admin UI
+## No Legacy Team-Owned Runtime Keys
 
-Allowed admins can create service accounts and credentials from `/admin`.
+Direct team-owned runtime API keys are removed from the product contract.
 
-1. Open **Identity** and create the service account under the owning team.
-2. Open **Spend Controls** and create an active **Service Account Budget** for that service account.
-3. Open **API Keys** and create a key whose owner is the service account.
-4. Grant only the gateway models that workload needs.
-5. Copy the raw key when it is shown and store it in the caller's secret manager.
-6. Configure the caller to send the key as a bearer token:
+Removed compatibility paths:
 
-```http
-Authorization: Bearer gwk_<public-id>.<secret>
-```
+- no reserved `system-legacy` team
+- no system-owned seeded runtime key compatibility
+- no direct team owner kind on runtime API keys
+- no fallback that treats a team as a non-human principal
 
-For rotation, create a replacement key, update the caller secret, verify traffic with the replacement key, then revoke the old key.
-
-## Configure Service Accounts Declaratively
-
-Deployments can seed service accounts from top-level `service_accounts` config. This is the recommended path for bootstrap or deployment-managed automation credentials.
-
-The owning team must exist in `teams`. Each declared service account must have an active budget before its active keys can authenticate.
-
-```yaml
-teams:
-  - id: platform
-    name: Platform
-
-service_accounts:
-  - id: ci-indexer
-    name: CI Indexer
-    team: platform
-    budget:
-      cadence: daily
-      amount_usd: "25.0000"
-      hard_limit: true
-      timezone: UTC
-    keys:
-      - id: primary
-        name: CI Indexer Primary
-        auto_create: true
-        allowed_models:
-          - gpt-4o-mini
-          - gemini-fast
-```
-
-This example creates the `ci-indexer` service account, reconciles its budget, and creates one managed gateway API key if that managed key does not already exist. Generated managed keys are create-only: rerunning config does not rotate an existing generated key.
-
-Managed service-account key material is encrypted before storage so allowed admins can reveal it later. Set `OCEANS_API_KEY_SECRET_ENCRYPTION_KEY` to a base64-encoded 32-byte key before using config-managed service-account keys or creating service-account-owned keys in the admin UI. Do not rotate this encryption key by changing only the environment variable; existing stored key material would become undecryptable.
-
-## Use a Static Predefined Key
-
-If a caller already has a deployment-managed key value, reference it with `value`. Use `env.*` so the raw key comes from the deployment secret manager instead of the YAML file.
-
-```yaml
-teams:
-  - id: platform
-    name: Platform
-
-service_accounts:
-  - id: release-bot
-    name: Release Bot
-    team: platform
-    budget:
-      cadence: monthly
-      amount_usd: "100.0000"
-      hard_limit: true
-      timezone: UTC
-    keys:
-      - id: primary
-        name: Release Bot Primary
-        value: env.RELEASE_BOT_GATEWAY_API_KEY
-        allowed_models:
-          - openai-fast
-```
-
-The referenced environment variable must contain a gateway API key in the gateway format:
-
-```dotenv
-RELEASE_BOT_GATEWAY_API_KEY=gwk_releasebotprod.primary-secret-value
-```
-
-Static, predefined keys must be prefixed with `gwk_` and include both a non-empty public ID and a non-empty secret separated by a dot:
-
-```text
-gwk_<public-id>.<secret>
-```
-
-Examples that are rejected:
-
-```text
-releasebotprod.primary-secret-value
-gwk_releasebotprod
-gwk_.primary-secret-value
-gwk_releasebotprod.
-```
-
-Configured key values are authoritative. Changing `keys[*].value` rotates that managed key to the new predefined value on the next seed run.
+Teams own service accounts. Service accounts own their runtime credentials.
 
 ## Access Control
 
@@ -177,21 +78,6 @@ Recipients are:
 - active team admins
 
 Recipients are resolved when alert delivery rows are created. Disabled users, removed team members, ordinary members, and non-members do not receive service-account budget alerts.
-
-## No Legacy Team-Owned Runtime Keys
-
-Direct team-owned runtime API keys are removed from the product contract.
-
-Removed compatibility paths:
-
-- no reserved `system-legacy` team
-- no system-owned seeded runtime key compatibility
-- no direct team owner kind on runtime API keys
-- no fallback that treats a team as a non-human principal
-
-Teams own service accounts. Service accounts own their runtime credentials.
-
-The old YAML-facing `auth.seed_api_keys` path is removed. Declare non-human gateway callers in top-level `service_accounts` instead.
 
 ## Provider Credential Boundary
 

--- a/docs/setup/runtime-bootstrap-and-access.md
+++ b/docs/setup/runtime-bootstrap-and-access.md
@@ -184,6 +184,10 @@ The right first-access path depends on the runtime shape.
 - call `/healthz` and `/readyz` through the gateway service or ingress
 - sign in to `/admin` only after bootstrap-admin is intentionally enabled or a pre-existing admin exists
 
+## Admin UI Static Assets
+
+The gateway proxies `/admin/*` to the admin UI runtime. The admin UI runtime must serve built static assets such as `/admin/assets/*.css`, JavaScript bundles, images, and fonts before TanStack route auth runs. Static asset misses should fail as static misses instead of falling through to the protected app router; otherwise an unauthenticated asset URL can render the login HTML with `content-type: text/html`, leaving `/admin` unstyled even though the HTML and JavaScript routes are reachable.
+
 ## Startup Paths That Are Easy To Confuse
 
 These behaviors are easy to blur together:

--- a/docs/setup/runtime-bootstrap-and-access.md
+++ b/docs/setup/runtime-bootstrap-and-access.md
@@ -186,7 +186,7 @@ The right first-access path depends on the runtime shape.
 
 ## Admin UI Static Assets
 
-The gateway proxies `/admin/*` to the admin UI runtime. The admin UI runtime must serve built static assets such as `/admin/assets/*.css`, JavaScript bundles, images, and fonts before TanStack route auth runs. Static asset misses should fail as static misses instead of falling through to the protected app router; otherwise an unauthenticated asset URL can render the login HTML with `content-type: text/html`, leaving `/admin` unstyled even though the HTML and JavaScript routes are reachable.
+The gateway proxies `/admin/*` to the admin UI runtime. The admin UI runtime must serve built static assets such as `/admin/assets/*.css`, JavaScript bundles, images, and fonts before TanStack route auth runs. Static asset misses should fail as static misses instead of falling through to the protected app router; otherwise an unauthenticated asset URL can render the login HTML with `content-type: text/html`, leaving `/admin` unstyled even though the HTML and JavaScript routes are reachable. See [`server.ts`](../../crates/admin-ui/web/server.ts) for the implementation and [issue #222](https://github.com/ahstn/oceans-llm/issues/222) for the original report.
 
 ## Startup Paths That Are Easy To Confuse
 


### PR DESCRIPTION
## Description

Fixes #222.

- Summary of changes
  - Serve terminal admin UI static asset paths before TanStack route auth fallback.
  - Return a deterministic `404 text/plain` for missing `/admin/assets/*` and known static asset extension paths instead of rendering login HTML.
  - Add Playwright E2E coverage that loads `/admin` through the gateway, extracts linked CSS/JS assets, and verifies CSS is `text/css` and not login HTML.
  - Document the admin UI static asset boundary in runtime bootstrap docs.
  - Remove an unrelated service-account documentation rewrite from this PR so review scope stays aligned with issue #222.
- Why this approach was chosen
  - Investigation showed the Rust gateway proxy forwards `/admin/*` verbatim; the bug source was the admin UI Bun server falling through to the protected app router on static asset misses.
  - Terminal static asset handling keeps protected app routes login-gated while preventing asset URLs from becoming application routes.
- How it works
  - `server.ts` maps `/admin/*` to `dist/client/*` as before, but classifies `/admin/assets/*` and known static extensions as terminal static requests.
  - Existing files are served normally with existing cache behavior; missing terminal static requests return `404` without invoking `appHandler.fetch`.
  - Normalized `.` and `..` path results are rejected before filesystem lookup.
- Risks, tradeoffs, and alternatives considered
  - Static-looking `/admin/*.css` style routes now behave as missing static assets rather than app routes. That matches built admin asset expectations and avoids auth fallback HTML for asset URLs.
  - No Rust proxy change was made because the proxy does not branch on asset type.
- Additional context for reviewers
  - Targeted E2E command run: `mise exec -- node ./node_modules/playwright/cli.js test e2e/admin-static-assets.e2e.ts`.
  - Direct production-server smoke confirmed CSS `200 text/css`, JS `200 text/javascript`, and missing CSS `404 text/plain`.
  - Review follow-up ran `mise run docs:check` after updating docs links and removing the out-of-scope service-account doc rewrite.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run docs:check`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Not run: full `mise run test`; Postgres gates are not applicable to this admin UI static-asset routing fix.