### PR TITLE
feat(gateway): add native Vertex embeddings

### DIFF
--- a/crates/gateway-core/src/domain.rs
+++ b/crates/gateway-core/src/domain.rs
@@ -2232,6 +2232,38 @@ impl Default for ProviderCapabilities {
     }
 }
 
+pub const VERTEX_TEXT_EMBEDDING_MODEL_IDS: &[&str] = &[
+    "gemini-embedding-001",
+    "text-embedding-005",
+    "text-multilingual-embedding-002",
+];
+
+#[must_use]
+pub fn is_supported_vertex_text_embedding_model_id(model_id: &str) -> bool {
+    VERTEX_TEXT_EMBEDDING_MODEL_IDS.contains(&model_id)
+}
+
+#[must_use]
+pub fn is_supported_vertex_text_embedding_upstream_model(upstream_model: &str) -> bool {
+    upstream_model
+        .strip_prefix("google/")
+        .is_some_and(is_supported_vertex_text_embedding_model_id)
+}
+
+#[must_use]
+pub const fn vertex_text_embedding_capabilities() -> ProviderCapabilities {
+    ProviderCapabilities {
+        chat_completions: false,
+        responses: false,
+        stream: false,
+        embeddings: true,
+        tools: false,
+        vision: false,
+        json_schema: false,
+        developer_role: false,
+    }
+}
+
 const fn default_true() -> bool {
     true
 }

--- a/crates/gateway-core/src/domain.rs
+++ b/crates/gateway-core/src/domain.rs
@@ -2234,6 +2234,7 @@ impl Default for ProviderCapabilities {
 
 pub const VERTEX_TEXT_EMBEDDING_MODEL_IDS: &[&str] = &[
     "gemini-embedding-001",
+    "gemini-embedding-2",
     "text-embedding-005",
     "text-multilingual-embedding-002",
 ];
@@ -2262,6 +2263,25 @@ pub const fn vertex_text_embedding_capabilities() -> ProviderCapabilities {
         json_schema: false,
         developer_role: false,
     }
+}
+
+#[must_use]
+pub fn vertex_route_capabilities_for_upstream_model(
+    upstream_model: Option<&str>,
+) -> ProviderCapabilities {
+    let Some(upstream_model) = upstream_model else {
+        return ProviderCapabilities::chat_only_streaming();
+    };
+
+    if is_supported_vertex_text_embedding_upstream_model(upstream_model) {
+        return vertex_text_embedding_capabilities();
+    }
+
+    if upstream_model.starts_with("anthropic/") {
+        return ProviderCapabilities::with_dimensions(true, true, false, true, true, false, true);
+    }
+
+    ProviderCapabilities::chat_only_streaming()
 }
 
 const fn default_true() -> bool {

--- a/crates/gateway-core/src/error.rs
+++ b/crates/gateway-core/src/error.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use thiserror::Error;
 
 use crate::domain::Money4;
@@ -72,6 +73,11 @@ pub enum ProviderError {
     Transport(String),
     #[error("upstream provider returned {status}: {body}")]
     UpstreamHttp { status: u16, body: String },
+    #[error("provider call failed after billable upstream usage: {source}")]
+    PartialUsage {
+        source: Box<ProviderError>,
+        provider_usage: Option<Value>,
+    },
     #[error("provider is not implemented: {0}")]
     NotImplemented(String),
 }
@@ -79,15 +85,18 @@ pub enum ProviderError {
 impl ProviderError {
     #[must_use]
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            Self::Timeout
-                | Self::Transport(_)
-                | Self::UpstreamHttp {
-                    status: 408 | 429 | 500..=599,
-                    ..
-                }
-        )
+        match self {
+            Self::PartialUsage { source, .. } => source.is_retryable(),
+            _ => matches!(
+                self,
+                Self::Timeout
+                    | Self::Transport(_)
+                    | Self::UpstreamHttp {
+                        status: 408 | 429 | 500..=599,
+                        ..
+                    }
+            ),
+        }
     }
 }
 
@@ -159,6 +168,13 @@ impl GatewayError {
             Self::McpUpstreamAuthRequired { .. }
             | Self::McpCredentialRequired { .. }
             | Self::McpCredentialExpired { .. } => 403,
+            Self::Provider(ProviderError::PartialUsage { source, .. }) => match source.as_ref() {
+                ProviderError::InvalidRequest(_) => 400,
+                ProviderError::UpstreamHttp { status, .. } => *status,
+                ProviderError::Timeout => 504,
+                ProviderError::Transport(_) | ProviderError::PartialUsage { .. } => 502,
+                ProviderError::NotImplemented(_) => 501,
+            },
             Self::Provider(ProviderError::InvalidRequest(_)) => 400,
             Self::Provider(ProviderError::UpstreamHttp { status, .. }) => *status,
             Self::Provider(ProviderError::Timeout) => 504,
@@ -223,6 +239,15 @@ impl GatewayError {
             Self::Route(RouteError::ModelNotFound(_)) => "model_not_found",
             Self::Route(RouteError::NoRoutesAvailable(_)) => "no_routes_available",
             Self::Route(RouteError::Policy(_)) => "routing_policy_error",
+            Self::Provider(ProviderError::PartialUsage { source, .. }) => match source.as_ref() {
+                ProviderError::Timeout => "upstream_timeout",
+                ProviderError::Transport(_) | ProviderError::PartialUsage { .. } => {
+                    "upstream_transport"
+                }
+                ProviderError::UpstreamHttp { .. } => "upstream_http_error",
+                ProviderError::NotImplemented(_) => "provider_not_implemented",
+                ProviderError::InvalidRequest(_) => "invalid_request",
+            },
             Self::Provider(ProviderError::Timeout) => "upstream_timeout",
             Self::Provider(ProviderError::Transport(_)) => "upstream_transport",
             Self::Provider(ProviderError::UpstreamHttp { .. }) => "upstream_http_error",

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -61,7 +61,7 @@ pub use domain::{
     UsagePricingStatus, UserOauthAuthRecord, UserOidcAuthRecord, UserPasswordAuthRecord,
     UserRecord, UserSessionRecord, UserStatus, VERTEX_TEXT_EMBEDDING_MODEL_IDS, budget_window_utc,
     is_supported_vertex_text_embedding_model_id, is_supported_vertex_text_embedding_upstream_model,
-    vertex_text_embedding_capabilities,
+    vertex_route_capabilities_for_upstream_model, vertex_text_embedding_capabilities,
 };
 pub use error::{AuthError, GatewayError, ProviderError, RouteError, StoreError};
 pub use gateway_keys::{

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -59,7 +59,9 @@ pub use domain::{
     UpsertMcpUpstreamCredentialBindingRecord, UpsertReviewAgentPullRequestRecord,
     UsageLeaderboardBucketRecord, UsageLeaderboardUserRecord, UsageLedgerRecord,
     UsagePricingStatus, UserOauthAuthRecord, UserOidcAuthRecord, UserPasswordAuthRecord,
-    UserRecord, UserSessionRecord, UserStatus, budget_window_utc,
+    UserRecord, UserSessionRecord, UserStatus, VERTEX_TEXT_EMBEDDING_MODEL_IDS, budget_window_utc,
+    is_supported_vertex_text_embedding_model_id, is_supported_vertex_text_embedding_upstream_model,
+    vertex_text_embedding_capabilities,
 };
 pub use error::{AuthError, GatewayError, ProviderError, RouteError, StoreError};
 pub use gateway_keys::{

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -720,7 +720,10 @@ fn vertex_embedding_max_dimensions(model_id: &str) -> i64 {
     match model_id {
         "gemini-embedding-001" | "gemini-embedding-2" => 3072,
         "text-embedding-005" | "text-multilingual-embedding-002" => 768,
-        _ => 3072,
+        _ => unreachable!(
+            "model_id is pre-validated by validate_vertex_embedding_model; \
+             add a new arm here whenever VERTEX_TEXT_EMBEDDING_MODEL_IDS is extended"
+        ),
     }
 }
 

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -176,12 +176,8 @@ struct GoogleEmbeddingOutput {
     token_count: Option<i64>,
 }
 
-fn is_supported_vertex_embedding_model(model_id: &str) -> bool {
-    is_supported_vertex_text_embedding_model_id(model_id)
-}
-
 fn validate_vertex_embedding_model(model_id: &str) -> Result<(), ProviderError> {
-    if is_supported_vertex_embedding_model(model_id) {
+    if is_supported_vertex_text_embedding_model_id(model_id) {
         return Ok(());
     }
 

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -164,6 +164,8 @@ const VERTEX_EMBEDDING_TASK_TYPES: &[&str] = &[
     "CODE_RETRIEVAL_QUERY",
 ];
 
+const VERTEX_EMBED_CONTENT_MODEL_IDS: &[&str] = &["gemini-embedding-2"];
+
 #[derive(Debug)]
 struct GoogleEmbeddingRequestMapping {
     bodies: Vec<Value>,
@@ -185,6 +187,18 @@ fn validate_vertex_embedding_model(model_id: &str) -> Result<(), ProviderError> 
         "vertex embeddings route google/{model_id} is not a supported text embedding model; supported models are {}",
         VERTEX_TEXT_EMBEDDING_MODEL_IDS.join(", ")
     )))
+}
+
+fn uses_vertex_embed_content(model_id: &str) -> bool {
+    VERTEX_EMBED_CONTENT_MODEL_IDS.contains(&model_id)
+}
+
+fn vertex_embedding_method(model_id: &str) -> &'static str {
+    if uses_vertex_embed_content(model_id) {
+        "embedContent"
+    } else {
+        "predict"
+    }
 }
 
 #[async_trait]
@@ -308,28 +322,59 @@ impl ProviderClient for VertexProvider {
         validate_vertex_embedding_model(model_id)?;
 
         let mapped = map_google_embedding_request(request, context, model_id)?;
-        let endpoint = self.model_endpoint(publisher, model_id, "predict");
+        let endpoint = self.model_endpoint(publisher, model_id, vertex_embedding_method(model_id));
         let mut outputs = Vec::with_capacity(mapped.bodies.len());
         for (index, body) in mapped.bodies.iter().enumerate() {
             let request = self.build_request(&endpoint, body, context).await?;
-            let response = self
-                .client
-                .execute(request)
-                .await
-                .map_err(map_reqwest_error)?;
+            let response = match self.client.execute(request).await {
+                Ok(response) => response,
+                Err(error) => {
+                    return Err(partial_google_embedding_failure(
+                        map_reqwest_error(error),
+                        &outputs,
+                        false,
+                    ));
+                }
+            };
             let status = response.status();
-            let text = response.text().await.map_err(map_reqwest_error)?;
+            let text = match response.text().await {
+                Ok(text) => text,
+                Err(error) => {
+                    return Err(partial_google_embedding_failure(
+                        map_reqwest_error(error),
+                        &outputs,
+                        true,
+                    ));
+                }
+            };
             if !status.is_success() {
-                return Err(ProviderError::UpstreamHttp {
-                    status: status.as_u16(),
-                    body: text,
-                });
+                return Err(partial_google_embedding_failure(
+                    ProviderError::UpstreamHttp {
+                        status: status.as_u16(),
+                        body: text,
+                    },
+                    &outputs,
+                    false,
+                ));
             }
 
-            let value: Value = serde_json::from_str(&text).map_err(|error| {
-                ProviderError::Transport(format!("invalid JSON from vertex embeddings: {error}"))
-            })?;
-            outputs.push(extract_google_embedding_output(&value, index)?);
+            let value: Value = match serde_json::from_str(&text) {
+                Ok(value) => value,
+                Err(error) => {
+                    return Err(partial_google_embedding_failure(
+                        ProviderError::Transport(format!(
+                            "invalid JSON from vertex embeddings: {error}"
+                        )),
+                        &outputs,
+                        true,
+                    ));
+                }
+            };
+            let output = match extract_google_embedding_output(&value, index, model_id) {
+                Ok(output) => output,
+                Err(error) => return Err(partial_google_embedding_failure(error, &outputs, true)),
+            };
+            outputs.push(output);
         }
 
         normalize_google_embedding_outputs(outputs, context)
@@ -446,6 +491,11 @@ fn map_google_embedding_request(
     validate_vertex_embedding_encoding_format(extra.remove("encoding_format"))?;
     let output_dimensionality =
         extract_vertex_embedding_output_dimensionality(&mut extra, model_id)?;
+
+    if uses_vertex_embed_content(model_id) {
+        return map_google_embed_content_request(inputs, extra, output_dimensionality, context);
+    }
+
     let task_type = extract_vertex_embedding_task_type(&mut extra)?;
     let title = extract_optional_string_field(&mut extra, "title")?;
     if title.is_some() && task_type.as_deref() != Some("RETRIEVAL_DOCUMENT") {
@@ -455,7 +505,6 @@ fn map_google_embedding_request(
         ));
     }
     let auto_truncate = extract_vertex_embedding_auto_truncate(&mut extra)?;
-
     if !extra.is_empty() {
         let unsupported = extra.keys().cloned().collect::<Vec<_>>().join(", ");
         return Err(ProviderError::InvalidRequest(format!(
@@ -499,6 +548,65 @@ fn map_google_embedding_request(
     }
 
     Ok(GoogleEmbeddingRequestMapping { bodies })
+}
+
+fn map_google_embed_content_request(
+    inputs: Vec<String>,
+    mut extra: BTreeMap<String, Value>,
+    output_dimensionality: Option<i64>,
+    context: &ProviderRequestContext,
+) -> Result<GoogleEmbeddingRequestMapping, ProviderError> {
+    reject_vertex_embed_content_only_field(&mut extra, "task_type")?;
+    reject_vertex_embed_content_only_field(&mut extra, "input_type")?;
+    reject_vertex_embed_content_only_field(&mut extra, "title")?;
+    reject_vertex_embed_content_only_field(&mut extra, "auto_truncate")?;
+    reject_vertex_embed_content_only_field(&mut extra, "autoTruncate")?;
+
+    if !extra.is_empty() {
+        let unsupported = extra.keys().cloned().collect::<Vec<_>>().join(", ");
+        return Err(ProviderError::InvalidRequest(format!(
+            "unsupported vertex embeddings request field(s): {unsupported}"
+        )));
+    }
+
+    let mut bodies = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        let mut body = Map::new();
+        body.insert(
+            "content".to_string(),
+            json!({
+                "parts": [
+                    { "text": input }
+                ]
+            }),
+        );
+
+        if let Some(output_dimensionality) = output_dimensionality {
+            body.insert(
+                "embedContentConfig".to_string(),
+                json!({
+                    "outputDimensionality": output_dimensionality
+                }),
+            );
+        }
+
+        merge_object_overrides(&mut body, &context.extra_body);
+        bodies.push(Value::Object(body));
+    }
+
+    Ok(GoogleEmbeddingRequestMapping { bodies })
+}
+
+fn reject_vertex_embed_content_only_field(
+    extra: &mut BTreeMap<String, Value>,
+    field: &str,
+) -> Result<(), ProviderError> {
+    match extra.remove(field) {
+        None | Some(Value::Null) => Ok(()),
+        Some(_) => Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings google/gemini-embedding-2 does not support `{field}`; put task instructions in the input text"
+        ))),
+    }
 }
 
 fn vertex_embedding_inputs(input: &Value) -> Result<Vec<String>, ProviderError> {
@@ -610,7 +718,7 @@ fn positive_i64_field(field: &str, value: &Value) -> Result<i64, ProviderError> 
 
 fn vertex_embedding_max_dimensions(model_id: &str) -> i64 {
     match model_id {
-        "gemini-embedding-001" => 3072,
+        "gemini-embedding-001" | "gemini-embedding-2" => 3072,
         "text-embedding-005" | "text-multilingual-embedding-002" => 768,
         _ => 3072,
     }
@@ -1732,7 +1840,11 @@ fn normalize_google_response(value: &Value, context: &ProviderRequestContext) ->
 fn extract_google_embedding_output(
     value: &Value,
     index: usize,
+    model_id: &str,
 ) -> Result<GoogleEmbeddingOutput, ProviderError> {
+    if uses_vertex_embed_content(model_id) {
+        return extract_google_embed_content_output(value, index);
+    }
     let prediction = value
         .get("predictions")
         .and_then(Value::as_array)
@@ -1769,13 +1881,60 @@ fn extract_google_embedding_output(
     })
 }
 
-fn normalize_google_embedding_outputs(
-    outputs: Vec<GoogleEmbeddingOutput>,
-    context: &ProviderRequestContext,
-) -> Result<Value, ProviderError> {
-    let mut data = Vec::with_capacity(outputs.len());
-    let mut total_tokens: Option<i64> = Some(0);
+fn extract_google_embed_content_output(
+    value: &Value,
+    index: usize,
+) -> Result<GoogleEmbeddingOutput, ProviderError> {
+    let embedding = value
+        .get("embedding")
+        .and_then(|embedding| embedding.get("values"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            ProviderError::Transport(
+                "invalid JSON from vertex embeddings: missing embedding.values".to_string(),
+            )
+        })?;
+    if embedding.iter().any(|value| value.as_f64().is_none()) {
+        return Err(ProviderError::Transport(
+            "invalid JSON from vertex embeddings: embedding values must be numbers".to_string(),
+        ));
+    }
+    let token_count = value
+        .get("usageMetadata")
+        .and_then(|usage| usage.get("promptTokenCount"))
+        .or_else(|| {
+            value
+                .get("usageMetadata")
+                .and_then(|usage| usage.get("totalTokenCount"))
+        })
+        .and_then(Value::as_i64);
 
+    Ok(GoogleEmbeddingOutput {
+        index,
+        embedding: Value::Array(embedding.clone()),
+        token_count,
+    })
+}
+
+fn partial_google_embedding_failure(
+    source: ProviderError,
+    outputs: &[GoogleEmbeddingOutput],
+    record_empty_usage: bool,
+) -> ProviderError {
+    if outputs.is_empty() && !record_empty_usage {
+        return source;
+    }
+
+    ProviderError::PartialUsage {
+        source: Box::new(source),
+        provider_usage: google_embedding_usage_from_outputs(outputs).unwrap_or(None),
+    }
+}
+
+fn google_embedding_usage_from_outputs(
+    outputs: &[GoogleEmbeddingOutput],
+) -> Result<Option<Value>, ProviderError> {
+    let mut total_tokens: Option<i64> = Some(0);
     for output in outputs {
         if let (Some(current), Some(token_count)) = (total_tokens, output.token_count) {
             total_tokens = Some(current.checked_add(token_count).ok_or_else(|| {
@@ -1786,7 +1945,24 @@ fn normalize_google_embedding_outputs(
         } else {
             total_tokens = None;
         }
+    }
 
+    Ok(total_tokens.map(|total_tokens| {
+        json!({
+            "prompt_tokens": total_tokens,
+            "total_tokens": total_tokens
+        })
+    }))
+}
+
+fn normalize_google_embedding_outputs(
+    outputs: Vec<GoogleEmbeddingOutput>,
+    context: &ProviderRequestContext,
+) -> Result<Value, ProviderError> {
+    let mut data = Vec::with_capacity(outputs.len());
+    let usage = google_embedding_usage_from_outputs(&outputs)?;
+
+    for output in outputs {
         data.push(json!({
             "object": "embedding",
             "index": output.index,
@@ -1801,14 +1977,8 @@ fn normalize_google_embedding_outputs(
         "model".to_string(),
         Value::String(context.model_key.clone()),
     );
-    if let Some(total_tokens) = total_tokens {
-        response.insert(
-            "usage".to_string(),
-            json!({
-                "prompt_tokens": total_tokens,
-                "total_tokens": total_tokens
-            }),
-        );
+    if let Some(usage) = usage {
+        response.insert("usage".to_string(), usage);
     }
 
     Ok(Value::Object(response))
@@ -3822,6 +3992,214 @@ mod tests {
         assert_eq!(request_payloads.len(), 2);
         assert_eq!(request_payloads[0]["instances"][0]["content"], "first");
         assert_eq!(request_payloads[1]["instances"][0]["content"], "second");
+    }
+
+    #[tokio::test]
+    async fn vertex_provider_google_gemini_embedding_2_executes_embed_content_mapping() {
+        let captured = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let state = captured.clone();
+        let app =
+            Router::new()
+                .route(
+                    "/v1/{*path}",
+                    post(
+                        |Path(path): Path<String>,
+                         State(captured): State<Arc<Mutex<Vec<Value>>>>,
+                         Json(payload): Json<Value>| async move {
+                            assert!(path.ends_with(
+                                "publishers/google/models/gemini-embedding-2:embedContent"
+                            ));
+                            let text = payload["content"]["parts"][0]["text"]
+                                .as_str()
+                                .expect("text part")
+                                .to_string();
+                            captured.lock().await.push(payload);
+                            match text.as_str() {
+                                "first" => Json(json!({
+                                    "embedding": {"values": [1.0, 1.5]},
+                                    "usageMetadata": {
+                                        "promptTokenCount": 2,
+                                        "totalTokenCount": 999
+                                    }
+                                })),
+                                "second" => Json(json!({
+                                    "embedding": {"values": [2.0, 2.5]},
+                                    "usageMetadata": {
+                                        "promptTokenCount": 5,
+                                        "totalTokenCount": 999
+                                    }
+                                })),
+                                other => panic!("unexpected embedding text: {other}"),
+                            }
+                        },
+                    ),
+                )
+                .with_state(state);
+
+        let host = start_router(app).await;
+        let provider = vertex_provider_for_test(format!("http://{host}"));
+        let mut request = embedding_request(json!(["first", "second"]));
+        request.extra.insert("dimensions".to_string(), json!(256));
+        request
+            .extra
+            .insert("output_dimensionality".to_string(), json!(256));
+        request
+            .extra
+            .insert("outputDimensionality".to_string(), json!(256));
+
+        let response = provider
+            .embeddings(&request, &context("google/gemini-embedding-2"))
+            .await
+            .expect("embedding response");
+
+        assert_eq!(response["object"], "list");
+        assert_eq!(response["model"], "fast");
+        assert_eq!(response["data"][0]["index"], 0);
+        assert_eq!(response["data"][0]["embedding"], json!([1.0, 1.5]));
+        assert_eq!(response["data"][1]["index"], 1);
+        assert_eq!(response["data"][1]["embedding"], json!([2.0, 2.5]));
+        assert_eq!(
+            response["usage"],
+            json!({"prompt_tokens": 7, "total_tokens": 7})
+        );
+
+        let request_payloads = captured.lock().await.clone();
+        assert_eq!(request_payloads.len(), 2);
+        assert_eq!(
+            request_payloads[0],
+            json!({
+                "content": {"parts": [{"text": "first"}]},
+                "embedContentConfig": {"outputDimensionality": 256}
+            })
+        );
+        assert_eq!(
+            request_payloads[1],
+            json!({
+                "content": {"parts": [{"text": "second"}]},
+                "embedContentConfig": {"outputDimensionality": 256}
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn vertex_provider_google_gemini_embedding_2_rejects_predict_only_fields_before_http() {
+        let requests_seen = Arc::new(Mutex::new(0usize));
+        let state = requests_seen.clone();
+        let app = Router::new()
+            .route(
+                "/v1/{*path}",
+                post(
+                    |State(requests_seen): State<Arc<Mutex<usize>>>| async move {
+                        *requests_seen.lock().await += 1;
+                        Json(json!({
+                            "embedding": {"values": [0.25]},
+                            "usageMetadata": {"promptTokenCount": 1}
+                        }))
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let host = start_router(app).await;
+        let provider = vertex_provider_for_test(format!("http://{host}"));
+        let cases = [
+            ("task_type", json!("RETRIEVAL_QUERY")),
+            ("input_type", json!("query")),
+            ("title", json!("Doc title")),
+            ("auto_truncate", json!(false)),
+        ];
+
+        for (field, value) in cases {
+            let mut request = embedding_request(json!("hello embeddings"));
+            request.extra.insert(field.to_string(), value);
+
+            let error = provider
+                .embeddings(&request, &context("google/gemini-embedding-2"))
+                .await
+                .expect_err(field)
+                .to_string();
+
+            assert!(
+                error.contains(&format!("does not support `{field}`")),
+                "{field}: unexpected error `{error}`"
+            );
+        }
+        assert_eq!(*requests_seen.lock().await, 0);
+    }
+
+    #[tokio::test]
+    async fn vertex_provider_google_gemini_embedding_2_returns_partial_usage_after_fanout_failure()
+    {
+        let captured = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let state = captured.clone();
+        let app =
+            Router::new()
+                .route(
+                    "/v1/{*path}",
+                    post(
+                        |Path(path): Path<String>,
+                         State(captured): State<Arc<Mutex<Vec<Value>>>>,
+                         Json(payload): Json<Value>| async move {
+                            assert!(path.ends_with(
+                                "publishers/google/models/gemini-embedding-2:embedContent"
+                            ));
+                            let text = payload["content"]["parts"][0]["text"]
+                                .as_str()
+                                .expect("text part")
+                                .to_string();
+                            captured.lock().await.push(payload);
+                            match text.as_str() {
+                                "first" => (
+                                    StatusCode::OK,
+                                    Json(json!({
+                                        "embedding": {"values": [1.0, 1.5]},
+                                        "usageMetadata": {"promptTokenCount": 4}
+                                    })),
+                                ),
+                                "second" => (
+                                    StatusCode::TOO_MANY_REQUESTS,
+                                    Json(json!({"error": {"message": "quota exhausted"}})),
+                                ),
+                                other => panic!("unexpected embedding text: {other}"),
+                            }
+                        },
+                    ),
+                )
+                .with_state(state);
+
+        let host = start_router(app).await;
+        let provider = vertex_provider_for_test(format!("http://{host}"));
+        let request = embedding_request(json!(["first", "second"]));
+
+        let error = provider
+            .embeddings(&request, &context("google/gemini-embedding-2"))
+            .await
+            .expect_err("second fan-out call should return provider error with partial usage");
+
+        match error {
+            ProviderError::PartialUsage {
+                source,
+                provider_usage,
+            } => {
+                assert_eq!(
+                    provider_usage,
+                    Some(json!({"prompt_tokens": 4, "total_tokens": 4}))
+                );
+                match *source {
+                    ProviderError::UpstreamHttp { status, body } => {
+                        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS.as_u16());
+                        assert!(body.contains("quota exhausted"));
+                    }
+                    other => panic!("unexpected partial usage source: {other}"),
+                }
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let request_payloads = captured.lock().await.clone();
+        assert_eq!(request_payloads.len(), 2);
+        assert_eq!(request_payloads[0]["content"]["parts"][0]["text"], "first");
+        assert_eq!(request_payloads[1]["content"]["parts"][0]["text"], "second");
     }
 
     #[test]

--- a/crates/gateway-providers/src/vertex.rs
+++ b/crates/gateway-providers/src/vertex.rs
@@ -7,7 +7,8 @@ use futures_util::StreamExt;
 use gateway_core::{
     CoreChatMessage, CoreChatRequest, CoreEmbeddingsRequest, CoreResponsesRequest,
     ProviderCapabilities, ProviderClient, ProviderError, ProviderRequestContext, ProviderStream,
-    SseEventParser, Utf8ChunkDecoder,
+    SseEventParser, Utf8ChunkDecoder, VERTEX_TEXT_EMBEDDING_MODEL_IDS,
+    is_supported_vertex_text_embedding_model_id,
 };
 use serde_json::{Map, Value, json};
 use time::OffsetDateTime;
@@ -152,6 +153,44 @@ fn parse_upstream_model(
     Ok((family, publisher, model_id))
 }
 
+const VERTEX_EMBEDDING_TASK_TYPES: &[&str] = &[
+    "RETRIEVAL_QUERY",
+    "RETRIEVAL_DOCUMENT",
+    "SEMANTIC_SIMILARITY",
+    "CLASSIFICATION",
+    "CLUSTERING",
+    "QUESTION_ANSWERING",
+    "FACT_VERIFICATION",
+    "CODE_RETRIEVAL_QUERY",
+];
+
+#[derive(Debug)]
+struct GoogleEmbeddingRequestMapping {
+    bodies: Vec<Value>,
+}
+
+#[derive(Debug)]
+struct GoogleEmbeddingOutput {
+    index: usize,
+    embedding: Value,
+    token_count: Option<i64>,
+}
+
+fn is_supported_vertex_embedding_model(model_id: &str) -> bool {
+    is_supported_vertex_text_embedding_model_id(model_id)
+}
+
+fn validate_vertex_embedding_model(model_id: &str) -> Result<(), ProviderError> {
+    if is_supported_vertex_embedding_model(model_id) {
+        return Ok(());
+    }
+
+    Err(ProviderError::InvalidRequest(format!(
+        "vertex embeddings route google/{model_id} is not a supported text embedding model; supported models are {}",
+        VERTEX_TEXT_EMBEDDING_MODEL_IDS.join(", ")
+    )))
+}
+
 #[async_trait]
 impl ProviderClient for VertexProvider {
     fn provider_key(&self) -> &str {
@@ -260,12 +299,44 @@ impl ProviderClient for VertexProvider {
 
     async fn embeddings(
         &self,
-        _request: &CoreEmbeddingsRequest,
-        _context: &ProviderRequestContext,
+        request: &CoreEmbeddingsRequest,
+        context: &ProviderRequestContext,
     ) -> Result<Value, ProviderError> {
-        Err(ProviderError::InvalidRequest(
-            "vertex embeddings are not supported in this v1 runtime".to_string(),
-        ))
+        let (family, publisher, model_id) = parse_upstream_model(&context.upstream_model)?;
+        if family != PublisherFamily::Google {
+            return Err(ProviderError::InvalidRequest(
+                "vertex embeddings are only supported for google/* text embedding models"
+                    .to_string(),
+            ));
+        }
+        validate_vertex_embedding_model(model_id)?;
+
+        let mapped = map_google_embedding_request(request, context, model_id)?;
+        let endpoint = self.model_endpoint(publisher, model_id, "predict");
+        let mut outputs = Vec::with_capacity(mapped.bodies.len());
+        for (index, body) in mapped.bodies.iter().enumerate() {
+            let request = self.build_request(&endpoint, body, context).await?;
+            let response = self
+                .client
+                .execute(request)
+                .await
+                .map_err(map_reqwest_error)?;
+            let status = response.status();
+            let text = response.text().await.map_err(map_reqwest_error)?;
+            if !status.is_success() {
+                return Err(ProviderError::UpstreamHttp {
+                    status: status.as_u16(),
+                    body: text,
+                });
+            }
+
+            let value: Value = serde_json::from_str(&text).map_err(|error| {
+                ProviderError::Transport(format!("invalid JSON from vertex embeddings: {error}"))
+            })?;
+            outputs.push(extract_google_embedding_output(&value, index)?);
+        }
+
+        normalize_google_embedding_outputs(outputs, context)
     }
 
     async fn responses(
@@ -363,6 +434,295 @@ fn map_google_request(
     merge_object_overrides(&mut body, &context.extra_body);
     validate_google_stream_candidate_count(&body, stream)?;
     Ok(Value::Object(body))
+}
+
+fn map_google_embedding_request(
+    request: &CoreEmbeddingsRequest,
+    context: &ProviderRequestContext,
+    model_id: &str,
+) -> Result<GoogleEmbeddingRequestMapping, ProviderError> {
+    let inputs = vertex_embedding_inputs(&request.input)?;
+    let mut extra = request.extra.clone();
+    extra.remove("model");
+    extra.remove("input");
+    extra.remove("user");
+
+    validate_vertex_embedding_encoding_format(extra.remove("encoding_format"))?;
+    let output_dimensionality =
+        extract_vertex_embedding_output_dimensionality(&mut extra, model_id)?;
+    let task_type = extract_vertex_embedding_task_type(&mut extra)?;
+    let title = extract_optional_string_field(&mut extra, "title")?;
+    if title.is_some() && task_type.as_deref() != Some("RETRIEVAL_DOCUMENT") {
+        return Err(ProviderError::InvalidRequest(
+            "vertex embeddings title is only supported with task_type RETRIEVAL_DOCUMENT"
+                .to_string(),
+        ));
+    }
+    let auto_truncate = extract_vertex_embedding_auto_truncate(&mut extra)?;
+
+    if !extra.is_empty() {
+        let unsupported = extra.keys().cloned().collect::<Vec<_>>().join(", ");
+        return Err(ProviderError::InvalidRequest(format!(
+            "unsupported vertex embeddings request field(s): {unsupported}"
+        )));
+    }
+
+    let mut bodies = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        let mut instance = Map::new();
+        instance.insert("content".to_string(), Value::String(input));
+        if let Some(task_type) = &task_type {
+            instance.insert("task_type".to_string(), Value::String(task_type.clone()));
+        }
+        if let Some(title) = &title {
+            instance.insert("title".to_string(), Value::String(title.clone()));
+        }
+
+        let mut body = Map::new();
+        body.insert(
+            "instances".to_string(),
+            Value::Array(vec![Value::Object(instance)]),
+        );
+
+        let mut parameters = Map::new();
+        if let Some(output_dimensionality) = output_dimensionality {
+            parameters.insert(
+                "outputDimensionality".to_string(),
+                Value::Number(output_dimensionality.into()),
+            );
+        }
+        if let Some(auto_truncate) = auto_truncate {
+            parameters.insert("autoTruncate".to_string(), Value::Bool(auto_truncate));
+        }
+        if !parameters.is_empty() {
+            body.insert("parameters".to_string(), Value::Object(parameters));
+        }
+
+        merge_object_overrides(&mut body, &context.extra_body);
+        bodies.push(Value::Object(body));
+    }
+
+    Ok(GoogleEmbeddingRequestMapping { bodies })
+}
+
+fn vertex_embedding_inputs(input: &Value) -> Result<Vec<String>, ProviderError> {
+    match input {
+        Value::String(value) => {
+            let value = validate_vertex_embedding_input_text(value)?;
+            Ok(vec![value.to_string()])
+        }
+        Value::Array(values) => {
+            if values.is_empty() {
+                return Err(ProviderError::InvalidRequest(
+                    "vertex embeddings input array must contain at least one string".to_string(),
+                ));
+            }
+
+            values
+                .iter()
+                .map(|value| {
+                    let Some(text) = value.as_str() else {
+                        return Err(ProviderError::InvalidRequest(
+                            "vertex embeddings input must be a string or array of strings; token arrays and multimodal inputs are not supported".to_string(),
+                        ));
+                    };
+                    validate_vertex_embedding_input_text(text).map(str::to_string)
+                })
+                .collect()
+        }
+        _ => Err(ProviderError::InvalidRequest(
+            "vertex embeddings input must be a string or array of strings".to_string(),
+        )),
+    }
+}
+
+fn validate_vertex_embedding_input_text(value: &str) -> Result<&str, ProviderError> {
+    if value.is_empty() {
+        return Err(ProviderError::InvalidRequest(
+            "vertex embeddings input strings must not be empty".to_string(),
+        ));
+    }
+    Ok(value)
+}
+
+fn validate_vertex_embedding_encoding_format(value: Option<Value>) -> Result<(), ProviderError> {
+    match value {
+        None | Some(Value::Null) => Ok(()),
+        Some(Value::String(value)) if value == "float" => Ok(()),
+        Some(Value::String(value)) => Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings encoding_format `{value}` is not supported; use `float`"
+        ))),
+        Some(_) => Err(ProviderError::InvalidRequest(
+            "vertex embeddings encoding_format must be a string".to_string(),
+        )),
+    }
+}
+
+fn extract_vertex_embedding_output_dimensionality(
+    extra: &mut BTreeMap<String, Value>,
+    model_id: &str,
+) -> Result<Option<i64>, ProviderError> {
+    let mut selected: Option<(&'static str, i64)> = None;
+    for field in [
+        "dimensions",
+        "output_dimensionality",
+        "outputDimensionality",
+    ] {
+        let Some(value) = extra.remove(field) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        let dimension = positive_i64_field(field, &value)?;
+        if let Some((selected_field, selected_dimension)) = selected {
+            if selected_dimension != dimension {
+                return Err(ProviderError::InvalidRequest(format!(
+                    "conflicting vertex embeddings dimensionality fields `{selected_field}` and `{field}`"
+                )));
+            }
+        } else {
+            selected = Some((field, dimension));
+        }
+    }
+
+    let Some((field, dimension)) = selected else {
+        return Ok(None);
+    };
+    let max_dimension = vertex_embedding_max_dimensions(model_id);
+    if dimension > max_dimension {
+        return Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings {field} must be <= {max_dimension} for google/{model_id}"
+        )));
+    }
+    Ok(Some(dimension))
+}
+
+fn positive_i64_field(field: &str, value: &Value) -> Result<i64, ProviderError> {
+    let Some(value) = value.as_i64() else {
+        return Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings {field} must be a positive integer"
+        )));
+    };
+    if value <= 0 {
+        return Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings {field} must be a positive integer"
+        )));
+    }
+    Ok(value)
+}
+
+fn vertex_embedding_max_dimensions(model_id: &str) -> i64 {
+    match model_id {
+        "gemini-embedding-001" => 3072,
+        "text-embedding-005" | "text-multilingual-embedding-002" => 768,
+        _ => 3072,
+    }
+}
+
+fn extract_vertex_embedding_task_type(
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<Option<String>, ProviderError> {
+    let task_type = extra
+        .remove("task_type")
+        .map(|value| canonical_vertex_embedding_task_type("task_type", &value))
+        .transpose()?
+        .flatten();
+    let input_type = extra
+        .remove("input_type")
+        .map(|value| canonical_vertex_embedding_task_type("input_type", &value))
+        .transpose()?
+        .flatten();
+
+    match (task_type, input_type) {
+        (Some(task_type), Some(input_type)) if task_type != input_type => {
+            Err(ProviderError::InvalidRequest(
+                "conflicting vertex embeddings task_type and input_type fields".to_string(),
+            ))
+        }
+        (Some(task_type), _) | (_, Some(task_type)) => Ok(Some(task_type)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn canonical_vertex_embedding_task_type(
+    field: &str,
+    value: &Value,
+) -> Result<Option<String>, ProviderError> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(value) = value.as_str() else {
+        return Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings {field} must be a string"
+        )));
+    };
+    let normalized = value.trim().replace(['-', ' '], "_").to_ascii_uppercase();
+    let canonical = match normalized.as_str() {
+        "QUERY" | "RETRIEVAL_QUERY" => "RETRIEVAL_QUERY",
+        "DOCUMENT" | "RETRIEVAL_DOCUMENT" => "RETRIEVAL_DOCUMENT",
+        "SEMANTIC_SIMILARITY" => "SEMANTIC_SIMILARITY",
+        "CLASSIFICATION" => "CLASSIFICATION",
+        "CLUSTERING" => "CLUSTERING",
+        "QUESTION_ANSWERING" => "QUESTION_ANSWERING",
+        "FACT_VERIFICATION" => "FACT_VERIFICATION",
+        "CODE_RETRIEVAL_QUERY" => "CODE_RETRIEVAL_QUERY",
+        _ => {
+            return Err(ProviderError::InvalidRequest(format!(
+                "unsupported vertex embeddings {field} `{value}`; supported task types are {}",
+                VERTEX_EMBEDDING_TASK_TYPES.join(", ")
+            )));
+        }
+    };
+    Ok(Some(canonical.to_string()))
+}
+
+fn extract_optional_string_field(
+    extra: &mut BTreeMap<String, Value>,
+    field: &str,
+) -> Result<Option<String>, ProviderError> {
+    match extra.remove(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) if !value.is_empty() => Ok(Some(value)),
+        Some(Value::String(_)) => Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings {field} must not be empty"
+        ))),
+        Some(_) => Err(ProviderError::InvalidRequest(format!(
+            "vertex embeddings {field} must be a string"
+        ))),
+    }
+}
+
+fn extract_vertex_embedding_auto_truncate(
+    extra: &mut BTreeMap<String, Value>,
+) -> Result<Option<bool>, ProviderError> {
+    let snake = extra
+        .remove("auto_truncate")
+        .map(|value| optional_bool_field("auto_truncate", &value))
+        .transpose()?
+        .flatten();
+    let camel = extra
+        .remove("autoTruncate")
+        .map(|value| optional_bool_field("autoTruncate", &value))
+        .transpose()?
+        .flatten();
+
+    match (snake, camel) {
+        (Some(snake), Some(camel)) if snake != camel => Err(ProviderError::InvalidRequest(
+            "conflicting vertex embeddings auto_truncate and autoTruncate fields".to_string(),
+        )),
+        (Some(value), _) | (_, Some(value)) => Ok(Some(value)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn optional_bool_field(field: &str, value: &Value) -> Result<Option<bool>, ProviderError> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    value.as_bool().map(Some).ok_or_else(|| {
+        ProviderError::InvalidRequest(format!("vertex embeddings {field} must be a boolean"))
+    })
 }
 
 fn map_anthropic_request(
@@ -1373,6 +1733,91 @@ fn normalize_google_response(value: &Value, context: &ProviderRequestContext) ->
     Value::Object(completion)
 }
 
+fn extract_google_embedding_output(
+    value: &Value,
+    index: usize,
+) -> Result<GoogleEmbeddingOutput, ProviderError> {
+    let prediction = value
+        .get("predictions")
+        .and_then(Value::as_array)
+        .and_then(|predictions| predictions.first())
+        .ok_or_else(|| {
+            ProviderError::Transport(
+                "invalid JSON from vertex embeddings: missing predictions[0]".to_string(),
+            )
+        })?;
+    let embedding = prediction
+        .get("embeddings")
+        .and_then(|embeddings| embeddings.get("values"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            ProviderError::Transport(
+                "invalid JSON from vertex embeddings: missing embeddings.values".to_string(),
+            )
+        })?;
+    if embedding.iter().any(|value| value.as_f64().is_none()) {
+        return Err(ProviderError::Transport(
+            "invalid JSON from vertex embeddings: embedding values must be numbers".to_string(),
+        ));
+    }
+    let token_count = prediction
+        .get("embeddings")
+        .and_then(|embeddings| embeddings.get("statistics"))
+        .and_then(|statistics| statistics.get("token_count"))
+        .and_then(Value::as_i64);
+
+    Ok(GoogleEmbeddingOutput {
+        index,
+        embedding: Value::Array(embedding.clone()),
+        token_count,
+    })
+}
+
+fn normalize_google_embedding_outputs(
+    outputs: Vec<GoogleEmbeddingOutput>,
+    context: &ProviderRequestContext,
+) -> Result<Value, ProviderError> {
+    let mut data = Vec::with_capacity(outputs.len());
+    let mut total_tokens: Option<i64> = Some(0);
+
+    for output in outputs {
+        if let (Some(current), Some(token_count)) = (total_tokens, output.token_count) {
+            total_tokens = Some(current.checked_add(token_count).ok_or_else(|| {
+                ProviderError::Transport(
+                    "invalid JSON from vertex embeddings: token_count overflow".to_string(),
+                )
+            })?);
+        } else {
+            total_tokens = None;
+        }
+
+        data.push(json!({
+            "object": "embedding",
+            "index": output.index,
+            "embedding": output.embedding
+        }));
+    }
+
+    let mut response = Map::new();
+    response.insert("object".to_string(), Value::String("list".to_string()));
+    response.insert("data".to_string(), Value::Array(data));
+    response.insert(
+        "model".to_string(),
+        Value::String(context.model_key.clone()),
+    );
+    if let Some(total_tokens) = total_tokens {
+        response.insert(
+            "usage".to_string(),
+            json!({
+                "prompt_tokens": total_tokens,
+                "total_tokens": total_tokens
+            }),
+        );
+    }
+
+    Ok(Value::Object(response))
+}
+
 fn normalize_anthropic_response(value: &Value, context: &ProviderRequestContext) -> Value {
     let id = value
         .get("id")
@@ -2295,14 +2740,17 @@ mod tests {
     use bytes::Bytes;
     use futures_util::StreamExt;
     use futures_util::stream;
-    use gateway_core::{CoreChatMessage, CoreChatRequest, ProviderClient, ProviderRequestContext};
+    use gateway_core::{
+        CoreChatMessage, CoreChatRequest, CoreEmbeddingsRequest, ProviderClient,
+        ProviderRequestContext,
+    };
     use serde_json::{Map, Value, json};
     use tokio::{net::TcpListener, sync::Mutex};
 
     use super::{
         JsonObjectParser, SseEventParser, VertexAuthConfig, VertexProvider, VertexProviderConfig,
-        map_anthropic_request, map_google_request, normalize_anthropic_response,
-        normalize_google_response, parse_upstream_model,
+        map_anthropic_request, map_google_embedding_request, map_google_request,
+        normalize_anthropic_response, normalize_google_response, parse_upstream_model,
     };
     use gateway_core::ProviderError;
 
@@ -3055,6 +3503,332 @@ mod tests {
     }
 
     #[test]
+    fn maps_vertex_embedding_aliases_to_predict_payload() {
+        let mut request = embedding_request(json!("document text"));
+        request.extra.insert("dimensions".to_string(), json!(128));
+        request
+            .extra
+            .insert("output_dimensionality".to_string(), json!(128));
+        request
+            .extra
+            .insert("outputDimensionality".to_string(), json!(128));
+        request
+            .extra
+            .insert("task_type".to_string(), json!("retrieval document"));
+        request
+            .extra
+            .insert("input_type".to_string(), json!("document"));
+        request
+            .extra
+            .insert("title".to_string(), json!("Doc title"));
+        request
+            .extra
+            .insert("auto_truncate".to_string(), json!(false));
+        request
+            .extra
+            .insert("autoTruncate".to_string(), json!(false));
+
+        let mapped = map_google_embedding_request(
+            &request,
+            &context("google/gemini-embedding-001"),
+            "gemini-embedding-001",
+        )
+        .expect("mapped embeddings request");
+
+        assert_eq!(mapped.bodies.len(), 1);
+        assert_eq!(mapped.bodies[0]["instances"][0]["content"], "document text");
+        assert_eq!(
+            mapped.bodies[0]["instances"][0]["task_type"],
+            "RETRIEVAL_DOCUMENT"
+        );
+        assert_eq!(mapped.bodies[0]["instances"][0]["title"], "Doc title");
+        assert_eq!(mapped.bodies[0]["parameters"]["outputDimensionality"], 128);
+        assert_eq!(mapped.bodies[0]["parameters"]["autoTruncate"], false);
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_vertex_embedding_inputs_and_alias_conflicts() {
+        let cases = [
+            (
+                "base64 encoding",
+                json!("hello"),
+                vec![("encoding_format", json!("base64"))],
+                "encoding_format `base64` is not supported",
+            ),
+            (
+                "token array",
+                json!([1, 2, 3]),
+                Vec::new(),
+                "input must be a string or array of strings",
+            ),
+            (
+                "nested array",
+                json!([["hello"]]),
+                Vec::new(),
+                "input must be a string or array of strings",
+            ),
+            (
+                "non-string scalar",
+                json!(42),
+                Vec::new(),
+                "input must be a string or array of strings",
+            ),
+            (
+                "empty string",
+                json!(""),
+                Vec::new(),
+                "input strings must not be empty",
+            ),
+            (
+                "empty array",
+                json!([]),
+                Vec::new(),
+                "input array must contain at least one string",
+            ),
+            (
+                "invalid task",
+                json!("hello"),
+                vec![("task_type", json!("search"))],
+                "unsupported vertex embeddings task_type",
+            ),
+            (
+                "conflicting dimensions",
+                json!("hello"),
+                vec![
+                    ("dimensions", json!(128)),
+                    ("outputDimensionality", json!(256)),
+                ],
+                "conflicting vertex embeddings dimensionality fields",
+            ),
+            (
+                "conflicting task aliases",
+                json!("hello"),
+                vec![
+                    ("task_type", json!("RETRIEVAL_QUERY")),
+                    ("input_type", json!("RETRIEVAL_DOCUMENT")),
+                ],
+                "conflicting vertex embeddings task_type and input_type fields",
+            ),
+            (
+                "conflicting auto truncate aliases",
+                json!("hello"),
+                vec![
+                    ("auto_truncate", json!(true)),
+                    ("autoTruncate", json!(false)),
+                ],
+                "conflicting vertex embeddings auto_truncate and autoTruncate fields",
+            ),
+        ];
+        let provider = vertex_provider_for_test("http://127.0.0.1:1".to_string());
+
+        for (name, input, extra, expected) in cases {
+            let mut request = embedding_request(input);
+            for (key, value) in extra {
+                request.extra.insert(key.to_string(), value);
+            }
+
+            let error = provider
+                .embeddings(&request, &context("google/gemini-embedding-001"))
+                .await
+                .expect_err(name)
+                .to_string();
+
+            assert!(
+                error.contains(expected),
+                "{name}: expected `{error}` to contain `{expected}`"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn vertex_embeddings_rejects_unsupported_google_chat_model_before_http() {
+        let provider = vertex_provider_for_test("http://127.0.0.1:1".to_string());
+        let request = embedding_request(json!("hello"));
+
+        let error = provider
+            .embeddings(&request, &context("google/gemini-2.0-flash"))
+            .await
+            .expect_err("chat model must not be accepted for embeddings")
+            .to_string();
+
+        assert!(error.contains("not a supported text embedding model"));
+        assert!(error.contains("gemini-embedding-001"));
+    }
+
+    #[tokio::test]
+    async fn vertex_embeddings_rejects_title_without_document_task_before_http() {
+        let requests_seen = Arc::new(Mutex::new(0usize));
+        let state = requests_seen.clone();
+        let app = Router::new()
+            .route(
+                "/v1/{*path}",
+                post(
+                    |State(requests_seen): State<Arc<Mutex<usize>>>| async move {
+                        *requests_seen.lock().await += 1;
+                        Json(json!({
+                            "predictions": [{
+                                "embeddings": {
+                                    "values": [0.25],
+                                    "statistics": {"token_count": 1}
+                                }
+                            }]
+                        }))
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let host = start_router(app).await;
+        let provider = vertex_provider_for_test(format!("http://{host}"));
+        let mut request = embedding_request(json!("query text"));
+        request
+            .extra
+            .insert("task_type".to_string(), json!("RETRIEVAL_QUERY"));
+        request
+            .extra
+            .insert("title".to_string(), json!("Doc title"));
+
+        let error = provider
+            .embeddings(&request, &context("google/gemini-embedding-001"))
+            .await
+            .expect_err("title must require RETRIEVAL_DOCUMENT")
+            .to_string();
+
+        assert!(error.contains("title is only supported with task_type RETRIEVAL_DOCUMENT"));
+        assert_eq!(*requests_seen.lock().await, 0);
+    }
+
+    #[tokio::test]
+    async fn vertex_provider_google_embedding_string_executes_predict_mapping() {
+        let captured = Arc::new(Mutex::new(None::<Value>));
+        let state = captured.clone();
+        let app = Router::new()
+            .route(
+                "/v1/{*path}",
+                post(
+                    |Path(path): Path<String>,
+                     State(captured): State<Arc<Mutex<Option<Value>>>>,
+                     headers: HeaderMap,
+                     Json(payload): Json<Value>| async move {
+                        assert!(path.ends_with(
+                            "publishers/google/models/gemini-embedding-001:predict"
+                        ));
+                        assert_eq!(
+                            headers
+                                .get("authorization")
+                                .and_then(|value| value.to_str().ok()),
+                            Some("Bearer test-token")
+                        );
+                        *captured.lock().await = Some(payload);
+                        Json(json!({
+                            "predictions": [{
+                                "embeddings": {
+                                    "values": [0.25, 0.5],
+                                    "statistics": {"token_count": 3, "billable_character_count": 999}
+                                }
+                            }]
+                        }))
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let host = start_router(app).await;
+        let provider = vertex_provider_for_test(format!("http://{host}"));
+        let request = embedding_request(json!("hello embeddings"));
+
+        let response = provider
+            .embeddings(&request, &context("google/gemini-embedding-001"))
+            .await
+            .expect("embedding response");
+
+        assert_eq!(response["object"], "list");
+        assert_eq!(response["model"], "fast");
+        assert_eq!(response["data"][0]["object"], "embedding");
+        assert_eq!(response["data"][0]["index"], 0);
+        assert_eq!(response["data"][0]["embedding"], json!([0.25, 0.5]));
+        assert_eq!(
+            response["usage"],
+            json!({"prompt_tokens": 3, "total_tokens": 3})
+        );
+
+        let request_payload = captured.lock().await.clone().expect("captured request");
+        assert_eq!(
+            request_payload,
+            json!({
+                "instances": [{"content": "hello embeddings"}]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn vertex_provider_google_embedding_array_fans_out_and_preserves_order() {
+        let captured = Arc::new(Mutex::new(Vec::<Value>::new()));
+        let state = captured.clone();
+        let app = Router::new()
+            .route(
+                "/v1/{*path}",
+                post(
+                    |Path(path): Path<String>,
+                     State(captured): State<Arc<Mutex<Vec<Value>>>>,
+                     Json(payload): Json<Value>| async move {
+                        assert!(path.ends_with(
+                            "publishers/google/models/text-embedding-005:predict"
+                        ));
+                        let content = payload["instances"][0]["content"]
+                            .as_str()
+                            .expect("string content")
+                            .to_string();
+                        captured.lock().await.push(payload);
+                        match content.as_str() {
+                            "first" => Json(json!({
+                                "predictions": [{
+                                    "embeddings": {
+                                        "values": [1.0, 1.5],
+                                        "statistics": {"token_count": 2, "billable_character_count": 999}
+                                    }
+                                }]
+                            })),
+                            "second" => Json(json!({
+                                "predictions": [{
+                                    "embeddings": {
+                                        "values": [2.0, 2.5],
+                                        "statistics": {"token_count": 5, "billable_character_count": 999}
+                                    }
+                                }]
+                            })),
+                            other => panic!("unexpected embedding content: {other}"),
+                        }
+                    },
+                ),
+            )
+            .with_state(state);
+
+        let host = start_router(app).await;
+        let provider = vertex_provider_for_test(format!("http://{host}"));
+        let request = embedding_request(json!(["first", "second"]));
+
+        let response = provider
+            .embeddings(&request, &context("google/text-embedding-005"))
+            .await
+            .expect("embedding response");
+
+        assert_eq!(response["data"][0]["index"], 0);
+        assert_eq!(response["data"][0]["embedding"], json!([1.0, 1.5]));
+        assert_eq!(response["data"][1]["index"], 1);
+        assert_eq!(response["data"][1]["embedding"], json!([2.0, 2.5]));
+        assert_eq!(
+            response["usage"],
+            json!({"prompt_tokens": 7, "total_tokens": 7})
+        );
+
+        let request_payloads = captured.lock().await.clone();
+        assert_eq!(request_payloads.len(), 2);
+        assert_eq!(request_payloads[0]["instances"][0]["content"], "first");
+        assert_eq!(request_payloads[1]["instances"][0]["content"], "second");
+    }
+
+    #[test]
     fn normalizes_google_response_into_openai_shape() {
         let response = json!({
             "responseId": "resp-123",
@@ -3451,6 +4225,14 @@ data: {"type":"vertex_event"}
             model: "fast".to_string(),
             messages,
             stream: false,
+            extra: BTreeMap::new(),
+        }
+    }
+
+    fn embedding_request(input: Value) -> CoreEmbeddingsRequest {
+        CoreEmbeddingsRequest {
+            model: "fast".to_string(),
+            input,
             extra: BTreeMap::new(),
         }
     }

--- a/crates/gateway-service/data/pricing_catalog_fallback.json
+++ b/crates/gateway-service/data/pricing_catalog_fallback.json
@@ -3764,6 +3764,33 @@
             ]
           }
         },
+        "gemini-embedding-2": {
+          "id": "gemini-embedding-2",
+          "display_name": "Gemini Embedding 2",
+          "release_date": "2026-04-22",
+          "last_updated": "2026-07-01",
+          "cost": {
+            "input": "0.2000",
+            "output": "0.0000",
+            "cache_read": null,
+            "cache_write": null,
+            "input_audio": null,
+            "output_audio": null
+          },
+          "limit": {
+            "context": 8192,
+            "input": null,
+            "output": 1
+          },
+          "modalities": {
+            "input": [
+              "text"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
         "gemini-flash-latest": {
           "id": "gemini-flash-latest",
           "display_name": "Gemini Flash Latest",

--- a/crates/gateway-service/src/admin_models.rs
+++ b/crates/gateway-service/src/admin_models.rs
@@ -11,7 +11,8 @@ use gateway_client_config::{
 use gateway_core::{
     GatewayError, GatewayModel, ModelPricingRecord, ModelRepository, ModelRoute,
     PricingCatalogRepository, PricingModalities, ProviderCapabilities, ProviderConnection,
-    ProviderRepository,
+    ProviderRepository, is_supported_vertex_text_embedding_upstream_model,
+    vertex_text_embedding_capabilities,
 };
 use time::OffsetDateTime;
 use tracing::warn;
@@ -418,12 +419,7 @@ fn provider_capabilities(
         "openai_compat" | "gcp_cloud_run_openai_compat" => {
             ProviderCapabilities::openai_compat_baseline()
         }
-        "gcp_vertex"
-            if route.is_some_and(|route| route.upstream_model.starts_with("anthropic/")) =>
-        {
-            ProviderCapabilities::with_dimensions(true, true, false, true, true, false, true)
-        }
-        "gcp_vertex" => ProviderCapabilities::chat_only_streaming(),
+        "gcp_vertex" => vertex_route_capabilities(route),
         "aws_bedrock" => ProviderCapabilities {
             chat_completions: true,
             responses: true,
@@ -436,6 +432,22 @@ fn provider_capabilities(
         },
         _ => ProviderCapabilities::all_enabled(),
     }
+}
+
+fn vertex_route_capabilities(route: Option<&ModelRoute>) -> ProviderCapabilities {
+    let Some(route) = route else {
+        return ProviderCapabilities::chat_only_streaming();
+    };
+
+    if is_supported_vertex_text_embedding_upstream_model(&route.upstream_model) {
+        return vertex_text_embedding_capabilities();
+    }
+
+    if route.upstream_model.starts_with("anthropic/") {
+        return ProviderCapabilities::with_dimensions(true, true, false, true, true, false, true);
+    }
+
+    ProviderCapabilities::chat_only_streaming()
 }
 
 async fn resolve_display_pricing<R>(
@@ -535,7 +547,10 @@ mod tests {
     use time::OffsetDateTime;
     use uuid::Uuid;
 
-    use super::{AdminModelStatus, AdminModelsService, provider_capabilities};
+    use super::{
+        AdminModelStatus, AdminModelsService, effective_provider_route_capabilities,
+        provider_capabilities,
+    };
 
     #[derive(Default)]
     struct CountingRepo {
@@ -746,6 +761,88 @@ mod tests {
             created_at: now,
             updated_at: now,
         }
+    }
+
+    fn provider_connection(provider_type: &str) -> ProviderConnection {
+        ProviderConnection {
+            provider_key: "vertex".to_string(),
+            provider_type: provider_type.to_string(),
+            config: json!({}),
+            secrets: None,
+        }
+    }
+
+    fn model_route(upstream_model: &str, capabilities: ProviderCapabilities) -> ModelRoute {
+        ModelRoute {
+            id: Uuid::new_v4(),
+            model_id: Uuid::new_v4(),
+            provider_key: "vertex".to_string(),
+            upstream_model: upstream_model.to_string(),
+            priority: 0,
+            weight: 1.0,
+            enabled: true,
+            extra_headers: Default::default(),
+            extra_body: Default::default(),
+            capabilities,
+            compatibility: Default::default(),
+        }
+    }
+
+    #[test]
+    fn vertex_provider_capabilities_are_route_aware_for_embeddings() {
+        let provider = provider_connection("gcp_vertex");
+
+        let embedding_route = model_route(
+            "google/gemini-embedding-001",
+            ProviderCapabilities::all_enabled(),
+        );
+        let embedding_capabilities = provider_capabilities(&provider, Some(&embedding_route));
+        assert!(embedding_capabilities.embeddings);
+        assert!(!embedding_capabilities.chat_completions);
+        assert!(!embedding_capabilities.responses);
+        assert!(!embedding_capabilities.stream);
+        assert!(!embedding_capabilities.tools);
+
+        let chat_route = model_route(
+            "google/gemini-2.0-flash",
+            ProviderCapabilities::all_enabled(),
+        );
+        let chat_capabilities = provider_capabilities(&provider, Some(&chat_route));
+        assert!(chat_capabilities.chat_completions);
+        assert!(chat_capabilities.stream);
+        assert!(!chat_capabilities.embeddings);
+        assert!(!chat_capabilities.tools);
+
+        let anthropic_route = model_route(
+            "anthropic/claude-sonnet-4-6",
+            ProviderCapabilities::all_enabled(),
+        );
+        let anthropic_capabilities = provider_capabilities(&provider, Some(&anthropic_route));
+        assert!(anthropic_capabilities.chat_completions);
+        assert!(!anthropic_capabilities.embeddings);
+        assert!(anthropic_capabilities.tools);
+    }
+
+    #[test]
+    fn vertex_embedding_effective_capabilities_require_route_embedding_capability() {
+        let provider = provider_connection("gcp_vertex");
+        let route = model_route(
+            "google/text-multilingual-embedding-002",
+            ProviderCapabilities {
+                embeddings: false,
+                ..ProviderCapabilities::all_enabled()
+            },
+        );
+
+        let capabilities = effective_provider_route_capabilities(
+            Some(route.capabilities),
+            Some(&provider),
+            Some(&route),
+        );
+
+        assert!(!capabilities.embeddings);
+        assert!(!capabilities.chat_completions);
+        assert!(!capabilities.tools);
     }
 
     #[tokio::test]

--- a/crates/gateway-service/src/admin_models.rs
+++ b/crates/gateway-service/src/admin_models.rs
@@ -11,8 +11,7 @@ use gateway_client_config::{
 use gateway_core::{
     GatewayError, GatewayModel, ModelPricingRecord, ModelRepository, ModelRoute,
     PricingCatalogRepository, PricingModalities, ProviderCapabilities, ProviderConnection,
-    ProviderRepository, is_supported_vertex_text_embedding_upstream_model,
-    vertex_text_embedding_capabilities,
+    ProviderRepository, vertex_route_capabilities_for_upstream_model,
 };
 use time::OffsetDateTime;
 use tracing::warn;
@@ -435,19 +434,7 @@ fn provider_capabilities(
 }
 
 fn vertex_route_capabilities(route: Option<&ModelRoute>) -> ProviderCapabilities {
-    let Some(route) = route else {
-        return ProviderCapabilities::chat_only_streaming();
-    };
-
-    if is_supported_vertex_text_embedding_upstream_model(&route.upstream_model) {
-        return vertex_text_embedding_capabilities();
-    }
-
-    if route.upstream_model.starts_with("anthropic/") {
-        return ProviderCapabilities::with_dimensions(true, true, false, true, true, false, true);
-    }
-
-    ProviderCapabilities::chat_only_streaming()
+    vertex_route_capabilities_for_upstream_model(route.map(|route| route.upstream_model.as_str()))
 }
 
 async fn resolve_display_pricing<R>(

--- a/crates/gateway-service/src/pricing_catalog.rs
+++ b/crates/gateway-service/src/pricing_catalog.rs
@@ -1164,38 +1164,66 @@ mod tests {
                         "google-vertex".to_string(),
                         PricingCatalogProviderDocument {
                             display_name: "Vertex".to_string(),
-                            models: BTreeMap::from([(
-                                "gemini-2.5-flash".to_string(),
-                                PricingCatalogModelDocument {
-                                    id: "gemini-2.5-flash".to_string(),
-                                    display_name: "Gemini 2.5 Flash".to_string(),
-                                    release_date: "2025-06-17".to_string(),
-                                    last_updated: "2025-06-17".to_string(),
-                                    cost: PricingCatalogCostDocument {
-                                        input: Some("0.3000".to_string()),
-                                        output: Some("2.5000".to_string()),
-                                        cache_read: Some("0.0750".to_string()),
-                                        cache_write: Some("0.3830".to_string()),
-                                        input_audio: None,
-                                        output_audio: None,
+                            models: BTreeMap::from([
+                                (
+                                    "gemini-2.5-flash".to_string(),
+                                    PricingCatalogModelDocument {
+                                        id: "gemini-2.5-flash".to_string(),
+                                        display_name: "Gemini 2.5 Flash".to_string(),
+                                        release_date: "2025-06-17".to_string(),
+                                        last_updated: "2025-06-17".to_string(),
+                                        cost: PricingCatalogCostDocument {
+                                            input: Some("0.3000".to_string()),
+                                            output: Some("2.5000".to_string()),
+                                            cache_read: Some("0.0750".to_string()),
+                                            cache_write: Some("0.3830".to_string()),
+                                            input_audio: None,
+                                            output_audio: None,
+                                        },
+                                        limit: PricingCatalogLimitDocument {
+                                            context: Some(1_048_576),
+                                            input: None,
+                                            output: Some(65_536),
+                                        },
+                                        modalities: PricingCatalogModalitiesDocument {
+                                            input: vec![
+                                                "text".to_string(),
+                                                "image".to_string(),
+                                                "audio".to_string(),
+                                                "video".to_string(),
+                                                "pdf".to_string(),
+                                            ],
+                                            output: vec!["text".to_string()],
+                                        },
                                     },
-                                    limit: PricingCatalogLimitDocument {
-                                        context: Some(1_048_576),
-                                        input: None,
-                                        output: Some(65_536),
+                                ),
+                                (
+                                    "gemini-embedding-001".to_string(),
+                                    PricingCatalogModelDocument {
+                                        id: "gemini-embedding-001".to_string(),
+                                        display_name: "Gemini Embedding".to_string(),
+                                        release_date: "2025-05-20".to_string(),
+                                        last_updated: "2025-05-20".to_string(),
+                                        cost: PricingCatalogCostDocument {
+                                            input: Some("0.1500".to_string()),
+                                            output: None,
+                                            cache_read: None,
+                                            cache_write: None,
+                                            input_audio: None,
+                                            output_audio: None,
+                                        },
+                                        limit: PricingCatalogLimitDocument {
+                                            context: Some(2_048),
+                                            input: None,
+                                            output: None,
+                                        },
+                                        modalities: PricingCatalogModalitiesDocument {
+                                            input: vec!["text".to_string()],
+                                            output: vec!["embedding".to_string()],
+                                        },
                                     },
-                                    modalities: PricingCatalogModalitiesDocument {
-                                        input: vec![
-                                            "text".to_string(),
-                                            "image".to_string(),
-                                            "audio".to_string(),
-                                            "video".to_string(),
-                                            "pdf".to_string(),
-                                        ],
-                                        output: vec!["text".to_string()],
-                                    },
-                                },
-                            )]),
+                                ),
+                            ]),
                         },
                     ),
                     (
@@ -1295,6 +1323,36 @@ mod tests {
                 assert_eq!(pricing.model_id, "claude-sonnet-4-6@default");
             }
             other => panic!("unexpected anthropic resolution: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn gcp_vertex_embedding_model_resolves_exact_google_vertex_pricing() {
+        let catalog = empty_catalog(
+            Arc::new(InMemoryRepo::default()),
+            "http://127.0.0.1:9/api.json".to_string(),
+        );
+
+        let resolved = catalog
+            .resolve_for_provider_connection(
+                &vertex_provider("global"),
+                &route("vertex-prod", "google/gemini-embedding-001"),
+                test_time(),
+            )
+            .await
+            .expect("resolve vertex embedding pricing");
+
+        match resolved {
+            PricingResolution::Exact { pricing } => {
+                assert_eq!(pricing.pricing_provider_id, "google-vertex");
+                assert_eq!(pricing.model_id, "gemini-embedding-001");
+                assert_eq!(
+                    pricing.input_cost_per_million_tokens,
+                    Some(Money4::from_decimal_str("0.1500").expect("money"))
+                );
+                assert_eq!(pricing.output_cost_per_million_tokens, None);
+            }
+            other => panic!("unexpected embedding pricing resolution: {other:?}"),
         }
     }
 

--- a/crates/gateway-service/src/request_logging.rs
+++ b/crates/gateway-service/src/request_logging.rs
@@ -1254,10 +1254,12 @@ mod tests {
     use async_trait::async_trait;
     use gateway_core::{
         ApiKeyModelGrantMode, ApiKeyOwnerKind, AuthMode, AuthenticatedApiKey,
-        ChatCompletionsRequest, GlobalRole, IdentityRepository, ModelAccessMode, RequestLogDetail,
-        RequestLogPage, RequestLogPayloadRecord, RequestLogPurgeResult, RequestLogQuery,
-        RequestLogRecord, RequestLogRepository, RequestLogRetentionWindow, RequestTag, RequestTags,
-        StoreError, TeamMembershipRecord, TeamRecord, UserRecord, UserStatus,
+        ChatCompletionsRequest, EmbeddingsRequest, GatewayError, GlobalRole, IdentityRepository,
+        ModelAccessMode, ProviderError, RequestAttemptRecord, RequestAttemptStatus,
+        RequestLogDetail, RequestLogPage, RequestLogPayloadRecord, RequestLogPurgeResult,
+        RequestLogQuery, RequestLogRecord, RequestLogRepository, RequestLogRetentionWindow,
+        RequestTag, RequestTags, StoreError, TeamMembershipRecord, TeamRecord, UserRecord,
+        UserStatus,
     };
     use serde_json::{Value, json};
     use time::OffsetDateTime;
@@ -1280,6 +1282,7 @@ mod tests {
         users: Arc<Mutex<Vec<UserRecord>>>,
         logs: Arc<Mutex<Vec<RequestLogRecord>>>,
         payloads: Arc<Mutex<Vec<RequestLogPayloadRecord>>>,
+        attempts: Arc<Mutex<Vec<RequestAttemptRecord>>>,
     }
 
     #[test]
@@ -1443,6 +1446,20 @@ mod tests {
             Ok(())
         }
 
+        async fn insert_request_log_with_attempts(
+            &self,
+            log: &RequestLogRecord,
+            payload: Option<&RequestLogPayloadRecord>,
+            attempts: &[RequestAttemptRecord],
+        ) -> Result<(), StoreError> {
+            self.insert_request_log(log, payload).await?;
+            self.attempts
+                .lock()
+                .expect("attempts lock")
+                .extend(attempts.iter().cloned());
+            Ok(())
+        }
+
         async fn list_request_logs(
             &self,
             _query: &RequestLogQuery,
@@ -1476,10 +1493,18 @@ mod tests {
                 .iter()
                 .find(|payload| payload.request_log_id == request_log_id)
                 .cloned();
+            let attempts = self
+                .attempts
+                .lock()
+                .expect("attempts lock")
+                .iter()
+                .filter(|attempt| attempt.request_log_id == request_log_id)
+                .cloned()
+                .collect();
             Ok(RequestLogDetail {
                 log,
                 payload,
-                attempts: Vec::new(),
+                attempts,
             })
         }
 
@@ -1577,6 +1602,57 @@ mod tests {
         }
     }
 
+    fn sample_embeddings_request() -> EmbeddingsRequest {
+        EmbeddingsRequest {
+            model: "embeddings".to_string(),
+            input: json!("hello"),
+            extra: BTreeMap::new(),
+        }
+    }
+
+    fn sample_attempt(
+        request_log_id: Uuid,
+        request_id: &str,
+        status: RequestAttemptStatus,
+    ) -> RequestAttemptRecord {
+        RequestAttemptRecord {
+            request_attempt_id: Uuid::new_v4(),
+            request_log_id,
+            request_id: request_id.to_string(),
+            attempt_number: 1,
+            route_id: Uuid::new_v4(),
+            provider_key: "vertex-prod".to_string(),
+            upstream_model: "google/gemini-embedding-001".to_string(),
+            status,
+            status_code: match status {
+                RequestAttemptStatus::Success => Some(200),
+                RequestAttemptStatus::ProviderError => Some(502),
+                RequestAttemptStatus::StreamStartError | RequestAttemptStatus::StreamError => None,
+            },
+            error_code: match status {
+                RequestAttemptStatus::Success => None,
+                RequestAttemptStatus::ProviderError => Some("upstream_transport".to_string()),
+                RequestAttemptStatus::StreamStartError | RequestAttemptStatus::StreamError => {
+                    Some("stream_error".to_string())
+                }
+            },
+            error_detail: match status {
+                RequestAttemptStatus::Success => None,
+                RequestAttemptStatus::ProviderError => Some("connection reset".to_string()),
+                RequestAttemptStatus::StreamStartError | RequestAttemptStatus::StreamError => None,
+            },
+            error_detail_truncated: false,
+            retryable: matches!(status, RequestAttemptStatus::ProviderError),
+            terminal: true,
+            produced_final_response: matches!(status, RequestAttemptStatus::Success),
+            stream: false,
+            started_at: OffsetDateTime::now_utc(),
+            completed_at: Some(OffsetDateTime::now_utc()),
+            latency_ms: Some(42),
+            metadata: Default::default(),
+        }
+    }
+
     fn sample_log(request_id: &str, occurred_at: OffsetDateTime) -> RequestLogRecord {
         RequestLogRecord {
             request_log_id: Uuid::new_v4(),
@@ -1668,6 +1744,7 @@ mod tests {
             users: Arc::new(Mutex::new(vec![user_record(user_id, false)])),
             logs: Arc::new(Mutex::new(Vec::new())),
             payloads: Arc::new(Mutex::new(Vec::new())),
+            attempts: Arc::new(Mutex::new(Vec::new())),
         });
         let logging = RequestLogging::new(repo.clone());
         let auth = sample_auth(user_id);
@@ -1716,6 +1793,7 @@ mod tests {
                 sample_log("young", now),
             ])),
             payloads: Arc::new(Mutex::new(Vec::new())),
+            attempts: Arc::new(Mutex::new(Vec::new())),
         });
         let logging = RequestLogging::new(repo.clone());
 
@@ -1818,6 +1896,143 @@ mod tests {
         assert_eq!(logs[0].metadata["stream"], Value::Bool(false));
         assert!(logs[0].metadata.get("fallback_used").is_none());
         assert!(logs[0].metadata.get("attempt_count").is_none());
+    }
+
+    #[tokio::test]
+    async fn embeddings_success_log_records_operation_usage_payload_and_attempt() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new(repo.clone());
+        let auth = sample_service_account_auth();
+        let context = logging.begin_embeddings_request(
+            "req_embeddings_success",
+            "embeddings",
+            "embeddings",
+            &sample_embeddings_request(),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+        let attempt = sample_attempt(
+            context.request_log_id,
+            &context.request_id,
+            RequestAttemptStatus::Success,
+        );
+
+        let wrote = logging
+            .log_non_stream_success(
+                &auth,
+                &context,
+                "vertex-prod",
+                sample_icon_metadata(),
+                75,
+                0,
+                &json!({
+                    "object": "list",
+                    "model": "embeddings",
+                    "data": [{"object": "embedding", "index": 0, "embedding": [0.1]}],
+                    "usage": {"prompt_tokens": 7, "total_tokens": 7}
+                }),
+                vec![attempt],
+            )
+            .await
+            .expect("embeddings success log");
+
+        assert!(wrote.wrote);
+        let detail = repo
+            .get_request_log_detail(wrote.request_log_id)
+            .await
+            .expect("request log detail");
+        assert_eq!(detail.log.request_id, "req_embeddings_success");
+        assert_eq!(detail.log.provider_key, "vertex-prod");
+        assert_eq!(detail.log.status_code, Some(200));
+        assert_eq!(detail.log.prompt_tokens, Some(7));
+        assert_eq!(detail.log.total_tokens, Some(7));
+        assert_eq!(
+            detail.log.metadata["operation"],
+            Value::String("embeddings".to_string())
+        );
+        assert_eq!(
+            detail
+                .payload
+                .as_ref()
+                .expect("captured payload")
+                .request_json["body"]["input"],
+            "hello"
+        );
+        assert_eq!(detail.attempts.len(), 1);
+        assert_eq!(detail.attempts[0].status, RequestAttemptStatus::Success);
+        assert_eq!(
+            detail.attempts[0].upstream_model,
+            "google/gemini-embedding-001"
+        );
+        assert!(detail.attempts[0].produced_final_response);
+    }
+
+    #[tokio::test]
+    async fn embeddings_provider_error_log_records_failure_payload_and_attempt() {
+        let repo = Arc::new(InMemoryRepo::default());
+        let logging = RequestLogging::new(repo.clone());
+        let auth = sample_service_account_auth();
+        let context = logging.begin_embeddings_request(
+            "req_embeddings_failure",
+            "embeddings",
+            "embeddings",
+            &sample_embeddings_request(),
+            &BTreeMap::new(),
+            RequestTags::default(),
+        );
+        let attempt = sample_attempt(
+            context.request_log_id,
+            &context.request_id,
+            RequestAttemptStatus::ProviderError,
+        );
+        let gateway_error =
+            GatewayError::Provider(ProviderError::Transport("connection reset".to_string()));
+
+        let wrote = logging
+            .log_non_stream_failure(
+                &auth,
+                &context,
+                "vertex-prod",
+                sample_icon_metadata(),
+                90,
+                &gateway_error,
+                vec![attempt],
+            )
+            .await
+            .expect("embeddings provider error log");
+
+        assert!(wrote.wrote);
+        let detail = repo
+            .get_request_log_detail(wrote.request_log_id)
+            .await
+            .expect("request log detail");
+        assert_eq!(detail.log.request_id, "req_embeddings_failure");
+        assert_eq!(detail.log.status_code, Some(502));
+        assert_eq!(detail.log.error_code.as_deref(), Some("upstream_transport"));
+        assert_eq!(
+            detail.log.metadata["operation"],
+            Value::String("embeddings".to_string())
+        );
+        assert_eq!(
+            detail
+                .payload
+                .as_ref()
+                .expect("captured payload")
+                .response_json["body"]["error"]["code"],
+            "upstream_transport"
+        );
+        assert_eq!(detail.attempts.len(), 1);
+        assert_eq!(
+            detail.attempts[0].status,
+            RequestAttemptStatus::ProviderError
+        );
+        assert_eq!(detail.attempts[0].status_code, Some(502));
+        assert_eq!(
+            detail.attempts[0].error_code.as_deref(),
+            Some("upstream_transport")
+        );
+        assert!(detail.attempts[0].retryable);
+        assert!(!detail.attempts[0].produced_final_response);
     }
 
     #[tokio::test]

--- a/crates/gateway-service/src/service.rs
+++ b/crates/gateway-service/src/service.rs
@@ -693,3 +693,412 @@ fn unpriced_reason_string(reason: &PricingUnpricedReason) -> String {
         PricingUnpricedReason::ModelNotFound => "model_not_found".to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use gateway_core::{
+        ApiKeyModelGrantMode, ApiKeyOwnerKind, ApiKeyRecord, ApiKeyRepository, AuthenticatedApiKey,
+        BudgetAlertRepository, BudgetRecord, BudgetRepository, BudgetScope, GatewayModel,
+        IdentityRepository, McpToolInvocationDetail, McpToolInvocationPage,
+        McpToolInvocationPayloadRecord, McpToolInvocationQuery, McpToolInvocationRecord,
+        McpToolInvocationRepository, ModelRepository, ModelRoute, Money4,
+        PricingCatalogCacheRecord, PricingCatalogRepository, ProviderCapabilities,
+        ProviderConnection, ProviderRepository, RequestLogDetail, RequestLogPage,
+        RequestLogPayloadRecord, RequestLogPurgeResult, RequestLogQuery, RequestLogRecord,
+        RequestLogRepository, RouteError, RoutePlanner, StoreError, StoreHealth,
+        TeamMembershipRecord, TeamRecord, UsageLedgerRecord, UsagePricingStatus, UserRecord,
+    };
+    use serde_json::{Map, json};
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    use super::GatewayService;
+
+    #[derive(Clone, Default)]
+    struct UsageAccountingRepo {
+        events: Arc<Mutex<Vec<UsageLedgerRecord>>>,
+    }
+
+    struct PassThroughPlanner;
+
+    impl RoutePlanner for PassThroughPlanner {
+        fn plan_routes(&self, routes: &[ModelRoute]) -> Result<Vec<ModelRoute>, RouteError> {
+            Ok(routes.to_vec())
+        }
+    }
+
+    #[async_trait]
+    impl ApiKeyRepository for UsageAccountingRepo {
+        async fn get_api_key_by_public_id(
+            &self,
+            _public_id: &str,
+        ) -> Result<Option<ApiKeyRecord>, StoreError> {
+            Ok(None)
+        }
+
+        async fn touch_api_key_last_used(&self, _api_key_id: Uuid) -> Result<(), StoreError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl BudgetAlertRepository for UsageAccountingRepo {}
+
+    #[async_trait]
+    impl BudgetRepository for UsageAccountingRepo {
+        async fn get_active_budget_by_scope(
+            &self,
+            _scope: &BudgetScope,
+        ) -> Result<Option<BudgetRecord>, StoreError> {
+            Ok(None)
+        }
+
+        async fn upsert_active_budget(
+            &self,
+            _scope: &BudgetScope,
+            _settings: &gateway_core::BudgetSettings,
+            _updated_at: OffsetDateTime,
+        ) -> Result<BudgetRecord, StoreError> {
+            Err(StoreError::Unexpected(
+                "upsert_active_budget is not used by usage accounting tests".to_string(),
+            ))
+        }
+
+        async fn deactivate_active_budget(
+            &self,
+            _scope: &BudgetScope,
+            _updated_at: OffsetDateTime,
+        ) -> Result<bool, StoreError> {
+            Ok(false)
+        }
+
+        async fn get_usage_ledger_by_request_and_scope(
+            &self,
+            request_id: &str,
+            ownership_scope_key: &str,
+        ) -> Result<Option<UsageLedgerRecord>, StoreError> {
+            Ok(self
+                .events
+                .lock()
+                .expect("events lock")
+                .iter()
+                .find(|event| {
+                    event.request_id == request_id
+                        && event.ownership_scope_key == ownership_scope_key
+                })
+                .cloned())
+        }
+
+        async fn sum_usage_cost_for_budget_scope_in_window(
+            &self,
+            _scope: &BudgetScope,
+            _window_start: OffsetDateTime,
+            _window_end: OffsetDateTime,
+        ) -> Result<Money4, StoreError> {
+            Ok(Money4::ZERO)
+        }
+
+        async fn insert_usage_ledger_if_absent(
+            &self,
+            event: &UsageLedgerRecord,
+        ) -> Result<bool, StoreError> {
+            let mut events = self.events.lock().expect("events lock");
+            if events.iter().any(|existing| {
+                existing.request_id == event.request_id
+                    && existing.ownership_scope_key == event.ownership_scope_key
+            }) {
+                return Ok(false);
+            }
+            events.push(event.clone());
+            Ok(true)
+        }
+    }
+
+    #[async_trait]
+    impl ModelRepository for UsageAccountingRepo {
+        async fn list_models(&self) -> Result<Vec<GatewayModel>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn get_model_by_key(
+            &self,
+            _model_key: &str,
+        ) -> Result<Option<GatewayModel>, StoreError> {
+            Ok(None)
+        }
+
+        async fn list_models_for_api_key(
+            &self,
+            _api_key_id: Uuid,
+        ) -> Result<Vec<GatewayModel>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_routes_for_model(
+            &self,
+            _model_id: Uuid,
+        ) -> Result<Vec<ModelRoute>, StoreError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[async_trait]
+    impl IdentityRepository for UsageAccountingRepo {
+        async fn get_user_by_id(&self, _user_id: Uuid) -> Result<Option<UserRecord>, StoreError> {
+            Ok(None)
+        }
+
+        async fn get_team_by_id(&self, _team_id: Uuid) -> Result<Option<TeamRecord>, StoreError> {
+            Ok(None)
+        }
+
+        async fn get_team_membership_for_user(
+            &self,
+            _user_id: Uuid,
+        ) -> Result<Option<TeamMembershipRecord>, StoreError> {
+            Ok(None)
+        }
+
+        async fn list_allowed_model_keys_for_user(
+            &self,
+            _user_id: Uuid,
+        ) -> Result<Vec<String>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn list_allowed_model_keys_for_team(
+            &self,
+            _team_id: Uuid,
+        ) -> Result<Vec<String>, StoreError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[async_trait]
+    impl PricingCatalogRepository for UsageAccountingRepo {
+        async fn get_pricing_catalog_cache(
+            &self,
+            _catalog_key: &str,
+        ) -> Result<Option<PricingCatalogCacheRecord>, StoreError> {
+            Ok(None)
+        }
+
+        async fn upsert_pricing_catalog_cache(
+            &self,
+            _cache: &PricingCatalogCacheRecord,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn touch_pricing_catalog_cache_fetched_at(
+            &self,
+            _catalog_key: &str,
+            _fetched_at: OffsetDateTime,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn list_active_model_pricing(
+            &self,
+        ) -> Result<Vec<gateway_core::ModelPricingRecord>, StoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn insert_model_pricing(
+            &self,
+            _record: &gateway_core::ModelPricingRecord,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn close_model_pricing(
+            &self,
+            _model_pricing_id: Uuid,
+            _effective_end_at: OffsetDateTime,
+            _updated_at: OffsetDateTime,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn resolve_model_pricing_at(
+            &self,
+            _pricing_provider_id: &str,
+            _pricing_model_id: &str,
+            _occurred_at: OffsetDateTime,
+        ) -> Result<Option<gateway_core::ModelPricingRecord>, StoreError> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl RequestLogRepository for UsageAccountingRepo {
+        async fn insert_request_log(
+            &self,
+            _log: &RequestLogRecord,
+            _payload: Option<&RequestLogPayloadRecord>,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn list_request_logs(
+            &self,
+            _query: &RequestLogQuery,
+        ) -> Result<RequestLogPage, StoreError> {
+            Ok(RequestLogPage {
+                items: Vec::new(),
+                page: 1,
+                page_size: 50,
+                total: 0,
+            })
+        }
+
+        async fn get_request_log_detail(
+            &self,
+            _request_log_id: Uuid,
+        ) -> Result<RequestLogDetail, StoreError> {
+            Err(StoreError::NotFound("request log not found".to_string()))
+        }
+
+        async fn purge_request_logs_older_than(
+            &self,
+            cutoff: OffsetDateTime,
+            dry_run: bool,
+        ) -> Result<RequestLogPurgeResult, StoreError> {
+            Ok(RequestLogPurgeResult {
+                cutoff,
+                dry_run,
+                matched_count: 0,
+                deleted_count: 0,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl McpToolInvocationRepository for UsageAccountingRepo {
+        async fn insert_mcp_tool_invocation(
+            &self,
+            _invocation: &McpToolInvocationRecord,
+            _payload: Option<&McpToolInvocationPayloadRecord>,
+        ) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn list_mcp_tool_invocations(
+            &self,
+            _query: &McpToolInvocationQuery,
+        ) -> Result<McpToolInvocationPage, StoreError> {
+            Ok(McpToolInvocationPage {
+                items: Vec::new(),
+                page: 1,
+                page_size: 50,
+                total: 0,
+            })
+        }
+
+        async fn get_mcp_tool_invocation_detail(
+            &self,
+            _mcp_tool_invocation_id: Uuid,
+        ) -> Result<McpToolInvocationDetail, StoreError> {
+            Err(StoreError::NotFound("mcp invocation not found".to_string()))
+        }
+    }
+
+    #[async_trait]
+    impl ProviderRepository for UsageAccountingRepo {
+        async fn get_provider_by_key(
+            &self,
+            _provider_key: &str,
+        ) -> Result<Option<ProviderConnection>, StoreError> {
+            Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl StoreHealth for UsageAccountingRepo {
+        async fn ping(&self) -> Result<(), StoreError> {
+            Ok(())
+        }
+    }
+
+    fn auth() -> AuthenticatedApiKey {
+        AuthenticatedApiKey {
+            id: Uuid::new_v4(),
+            public_id: "dev123".to_string(),
+            name: "dev".to_string(),
+            model_grant_mode: ApiKeyModelGrantMode::Explicit,
+            owner_kind: ApiKeyOwnerKind::User,
+            owner_user_id: Some(Uuid::new_v4()),
+            owner_team_id: None,
+            owner_service_account_id: None,
+        }
+    }
+
+    fn model(model_id: Uuid) -> GatewayModel {
+        GatewayModel {
+            id: model_id,
+            model_key: "embeddings".to_string(),
+            alias_target_model_key: None,
+            description: None,
+            tags: Vec::new(),
+            rank: 0,
+        }
+    }
+
+    fn vertex_embedding_route(model_id: Uuid) -> ModelRoute {
+        ModelRoute {
+            id: Uuid::new_v4(),
+            model_id,
+            provider_key: "vertex-prod".to_string(),
+            upstream_model: "google/gemini-embedding-001".to_string(),
+            priority: 0,
+            weight: 1.0,
+            enabled: true,
+            extra_headers: Map::new(),
+            extra_body: Map::new(),
+            capabilities: ProviderCapabilities::all_enabled(),
+            compatibility: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn record_chat_usage_keeps_embedding_usage_missing_without_token_counts() {
+        let repo = Arc::new(UsageAccountingRepo::default());
+        let service = GatewayService::new(repo.clone(), Arc::new(PassThroughPlanner));
+        let auth = auth();
+        let model_id = Uuid::new_v4();
+        let model = model(model_id);
+        let route = vertex_embedding_route(model_id);
+
+        let recorded = service
+            .record_chat_usage(
+                &auth,
+                &model,
+                &route,
+                "req_missing_embedding_usage",
+                Some(json!({"statistics": {"billable_character_count": 999}})),
+                OffsetDateTime::now_utc(),
+            )
+            .await
+            .expect("usage should be recorded");
+
+        assert_eq!(recorded.pricing_status, UsagePricingStatus::UsageMissing);
+        assert_eq!(recorded.prompt_tokens, None);
+        assert_eq!(recorded.completion_tokens, None);
+        assert_eq!(recorded.total_tokens, None);
+        assert_eq!(recorded.cost_usd, None);
+
+        let events = repo.events.lock().expect("events lock");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].pricing_status, UsagePricingStatus::UsageMissing);
+        assert_eq!(events[0].prompt_tokens, None);
+        assert_eq!(events[0].completion_tokens, None);
+        assert_eq!(events[0].total_tokens, None);
+        assert_eq!(
+            events[0].provider_usage["statistics"]["billable_character_count"],
+            999
+        );
+    }
+}

--- a/crates/gateway/src/http/handlers.rs
+++ b/crates/gateway/src/http/handlers.rs
@@ -16,11 +16,10 @@ use gateway_core::{
     CoreRequestRequirements, EmbeddingsRequest, GatewayError, ModelsListResponse,
     ProviderCapabilities, ProviderClient, ProviderError, ProviderRequestContext,
     RequestAttemptRecord, RequestAttemptStatus, RequestToolCardinality, ResponsesRequest,
-    anthropic_messages_request_to_core, core_chat_request_to_openai,
-    is_supported_vertex_text_embedding_upstream_model, openai_chat_request_to_core,
+    anthropic_messages_request_to_core, core_chat_request_to_openai, openai_chat_request_to_core,
     openai_embeddings_request_to_core, openai_responses_request_to_core,
     protocol::{anthropic::anthropic_message_from_openai_chat, openai::ModelCard},
-    vertex_text_embedding_capabilities,
+    vertex_route_capabilities_for_upstream_model,
 };
 use gateway_service::{
     McpAccess, McpTokenOverhead, McpTokenOverheadInput, RequestLogContext, RequestLogIconMetadata,
@@ -1066,13 +1065,30 @@ pub async fn v1_embeddings(
     let value = match provider.embeddings(&core_request, &context).await {
         Ok(value) => normalize_response_model(value, &resolved.selection.requested_model.model_key),
         Err(error) => {
+            let (provider_error, partial_provider_usage) = split_partial_provider_error(error);
+            if let Some(provider_usage) = partial_provider_usage {
+                finalize_successful_usage_accounting(
+                    &state,
+                    UsageAccountingContext {
+                        auth: &auth,
+                        model: &resolved.selection.execution_model,
+                        route: &route,
+                        request_id: &request_id,
+                        labels: labels.clone(),
+                        operation: "embeddings",
+                    },
+                    provider_usage,
+                )
+                .await;
+            }
+
             let (error, attempt) = provider_error_attempt(
                 &request_log_context,
                 &route,
                 RequestAttemptStatus::ProviderError,
                 false,
                 attempt_started_at,
-                error,
+                provider_error,
                 requirements,
             );
             best_effort_log_non_stream_failure(
@@ -1151,18 +1167,11 @@ fn route_effective_provider_capabilities(
     provider: &dyn ProviderClient,
     route: &gateway_core::ModelRoute,
 ) -> ProviderCapabilities {
-    let mut capabilities = provider.capabilities();
     if provider.provider_type() == "gcp_vertex" {
-        if is_supported_vertex_text_embedding_upstream_model(&route.upstream_model) {
-            return vertex_text_embedding_capabilities();
-        }
-
-        capabilities.embeddings = false;
-        if !route.upstream_model.starts_with("anthropic/") {
-            capabilities.tools = false;
-        }
+        return vertex_route_capabilities_for_upstream_model(Some(&route.upstream_model));
     }
-    capabilities
+
+    provider.capabilities()
 }
 
 fn provider_error_attempt(
@@ -1762,6 +1771,16 @@ fn usage_value_from_response(value: &Value) -> Option<Value> {
     value.get("usage").cloned()
 }
 
+fn split_partial_provider_error(error: ProviderError) -> (ProviderError, Option<Option<Value>>) {
+    match error {
+        ProviderError::PartialUsage {
+            source,
+            provider_usage,
+        } => (*source, Some(provider_usage)),
+        error => (error, None),
+    }
+}
+
 fn latency_ms_since(started_at: Instant) -> i64 {
     i64::try_from(started_at.elapsed().as_millis()).unwrap_or(i64::MAX)
 }
@@ -1918,12 +1937,13 @@ mod tests {
         GatewayError, ModelRoute, ProviderCapabilities, ProviderClient, ProviderError,
         ProviderRegistry, ProviderRequestContext, ProviderStream,
     };
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use tower_http::request_id::RequestId;
 
     use super::{
         anthropic_error_response, canonical_request_id, extract_anthropic_authorization_header,
         route_effective_provider_capabilities, select_first_eligible_route,
+        split_partial_provider_error,
     };
 
     struct StaticProvider {
@@ -2126,6 +2146,46 @@ mod tests {
             extract_anthropic_authorization_header(&headers).as_deref(),
             Some("Bearer gw-test-key")
         );
+    }
+
+    #[test]
+    fn split_partial_provider_error_preserves_usage_accounting_signal() {
+        let (source, provider_usage) = split_partial_provider_error(ProviderError::PartialUsage {
+            source: Box::new(ProviderError::UpstreamHttp {
+                status: 429,
+                body: "quota exhausted".to_string(),
+            }),
+            provider_usage: Some(json!({"prompt_tokens": 4, "total_tokens": 4})),
+        });
+
+        assert_eq!(
+            provider_usage,
+            Some(Some(json!({"prompt_tokens": 4, "total_tokens": 4})))
+        );
+        match source {
+            ProviderError::UpstreamHttp { status, body } => {
+                assert_eq!(status, 429);
+                assert_eq!(body, "quota exhausted");
+            }
+            other => panic!("unexpected provider error source: {other}"),
+        }
+
+        let (source, provider_usage) = split_partial_provider_error(ProviderError::PartialUsage {
+            source: Box::new(ProviderError::Transport("invalid json".to_string())),
+            provider_usage: None,
+        });
+
+        assert_eq!(provider_usage, Some(None));
+        match source {
+            ProviderError::Transport(message) => assert_eq!(message, "invalid json"),
+            other => panic!("unexpected provider error source: {other}"),
+        }
+
+        let (source, provider_usage) =
+            split_partial_provider_error(ProviderError::Transport("network down".to_string()));
+
+        assert!(matches!(source, ProviderError::Transport(message) if message == "network down"));
+        assert_eq!(provider_usage, None);
     }
 
     #[tokio::test]

--- a/crates/gateway/src/http/handlers.rs
+++ b/crates/gateway/src/http/handlers.rs
@@ -16,9 +16,11 @@ use gateway_core::{
     CoreRequestRequirements, EmbeddingsRequest, GatewayError, ModelsListResponse,
     ProviderCapabilities, ProviderClient, ProviderError, ProviderRequestContext,
     RequestAttemptRecord, RequestAttemptStatus, RequestToolCardinality, ResponsesRequest,
-    anthropic_messages_request_to_core, core_chat_request_to_openai, openai_chat_request_to_core,
+    anthropic_messages_request_to_core, core_chat_request_to_openai,
+    is_supported_vertex_text_embedding_upstream_model, openai_chat_request_to_core,
     openai_embeddings_request_to_core, openai_responses_request_to_core,
     protocol::{anthropic::anthropic_message_from_openai_chat, openai::ModelCard},
+    vertex_text_embedding_capabilities,
 };
 use gateway_service::{
     McpAccess, McpTokenOverhead, McpTokenOverheadInput, RequestLogContext, RequestLogIconMetadata,
@@ -1150,8 +1152,15 @@ fn route_effective_provider_capabilities(
     route: &gateway_core::ModelRoute,
 ) -> ProviderCapabilities {
     let mut capabilities = provider.capabilities();
-    if provider.provider_type() == "gcp_vertex" && !route.upstream_model.starts_with("anthropic/") {
-        capabilities.tools = false;
+    if provider.provider_type() == "gcp_vertex" {
+        if is_supported_vertex_text_embedding_upstream_model(&route.upstream_model) {
+            return vertex_text_embedding_capabilities();
+        }
+
+        capabilities.embeddings = false;
+        if !route.upstream_model.starts_with("anthropic/") {
+            capabilities.tools = false;
+        }
     }
     capabilities
 }
@@ -1898,16 +1907,182 @@ fn extract_request_headers(headers: &HeaderMap) -> BTreeMap<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
     use axum::Extension;
     use axum::body::to_bytes;
     use axum::http::{HeaderMap, HeaderValue};
-    use gateway_core::GatewayError;
+    use gateway_core::{
+        CoreChatRequest, CoreEmbeddingsRequest, CoreRequestRequirements, CoreResponsesRequest,
+        GatewayError, ModelRoute, ProviderCapabilities, ProviderClient, ProviderError,
+        ProviderRegistry, ProviderRequestContext, ProviderStream,
+    };
     use serde_json::Value;
     use tower_http::request_id::RequestId;
 
     use super::{
         anthropic_error_response, canonical_request_id, extract_anthropic_authorization_header,
+        route_effective_provider_capabilities, select_first_eligible_route,
     };
+
+    struct StaticProvider {
+        provider_type: &'static str,
+        capabilities: ProviderCapabilities,
+    }
+
+    #[async_trait]
+    impl ProviderClient for StaticProvider {
+        fn provider_key(&self) -> &str {
+            "vertex"
+        }
+
+        fn provider_type(&self) -> &str {
+            self.provider_type
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            self.capabilities
+        }
+
+        async fn chat_completions(
+            &self,
+            _request: &CoreChatRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<Value, ProviderError> {
+            Err(ProviderError::NotImplemented("test provider".to_string()))
+        }
+
+        async fn chat_completions_stream(
+            &self,
+            _request: &CoreChatRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<ProviderStream, ProviderError> {
+            Err(ProviderError::NotImplemented("test provider".to_string()))
+        }
+
+        async fn embeddings(
+            &self,
+            _request: &CoreEmbeddingsRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<Value, ProviderError> {
+            Err(ProviderError::NotImplemented("test provider".to_string()))
+        }
+
+        async fn responses(
+            &self,
+            _request: &CoreResponsesRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<Value, ProviderError> {
+            Err(ProviderError::NotImplemented("test provider".to_string()))
+        }
+
+        async fn responses_stream(
+            &self,
+            _request: &CoreResponsesRequest,
+            _context: &ProviderRequestContext,
+        ) -> Result<ProviderStream, ProviderError> {
+            Err(ProviderError::NotImplemented("test provider".to_string()))
+        }
+    }
+
+    fn route(upstream_model: &str, capabilities: ProviderCapabilities) -> ModelRoute {
+        ModelRoute {
+            id: uuid::Uuid::new_v4(),
+            model_id: uuid::Uuid::new_v4(),
+            provider_key: "vertex".to_string(),
+            upstream_model: upstream_model.to_string(),
+            priority: 0,
+            weight: 1.0,
+            enabled: true,
+            extra_headers: Default::default(),
+            extra_body: Default::default(),
+            capabilities,
+            compatibility: Default::default(),
+        }
+    }
+
+    #[test]
+    fn vertex_route_effective_capabilities_are_route_aware_for_embeddings() {
+        let provider = StaticProvider {
+            provider_type: "gcp_vertex",
+            capabilities: ProviderCapabilities::all_enabled(),
+        };
+
+        let embedding_route = route(
+            "google/gemini-embedding-001",
+            ProviderCapabilities::all_enabled(),
+        );
+        let embedding_capabilities =
+            route_effective_provider_capabilities(&provider, &embedding_route)
+                .intersect(embedding_route.capabilities);
+        assert!(embedding_capabilities.embeddings);
+        assert!(!embedding_capabilities.chat_completions);
+        assert!(!embedding_capabilities.responses);
+        assert!(!embedding_capabilities.stream);
+        assert!(!embedding_capabilities.tools);
+
+        let chat_route = route(
+            "google/gemini-2.0-flash",
+            ProviderCapabilities::all_enabled(),
+        );
+        let chat_capabilities = route_effective_provider_capabilities(&provider, &chat_route)
+            .intersect(chat_route.capabilities);
+        assert!(chat_capabilities.chat_completions);
+        assert!(chat_capabilities.stream);
+        assert!(!chat_capabilities.embeddings);
+        assert!(!chat_capabilities.tools);
+
+        let anthropic_route = route(
+            "anthropic/claude-sonnet-4-6",
+            ProviderCapabilities::all_enabled(),
+        );
+        let anthropic_capabilities =
+            route_effective_provider_capabilities(&provider, &anthropic_route)
+                .intersect(anthropic_route.capabilities);
+        assert!(anthropic_capabilities.chat_completions);
+        assert!(!anthropic_capabilities.embeddings);
+        assert!(anthropic_capabilities.tools);
+    }
+
+    #[test]
+    fn vertex_embedding_route_selection_only_uses_supported_google_text_embedding_routes() {
+        let provider = Arc::new(StaticProvider {
+            provider_type: "gcp_vertex",
+            capabilities: ProviderCapabilities::all_enabled(),
+        });
+        let mut providers = ProviderRegistry::new();
+        providers.register(provider);
+        let routes = vec![
+            route("google/gemini-2.5-pro", ProviderCapabilities::all_enabled()),
+            route(
+                "anthropic/claude-sonnet-4-6",
+                ProviderCapabilities::all_enabled(),
+            ),
+            route(
+                "google/text-embedding-005",
+                ProviderCapabilities::all_enabled(),
+            ),
+        ];
+
+        let (eligible_route_count, selected) = select_first_eligible_route(
+            &providers,
+            &routes,
+            CoreRequestRequirements {
+                embeddings: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(eligible_route_count, 1);
+        assert_eq!(
+            selected
+                .expect("supported embedding route")
+                .0
+                .upstream_model,
+            "google/text-embedding-005"
+        );
+    }
 
     #[test]
     fn canonical_request_id_returns_gateway_internal_error_when_extension_is_missing() {

--- a/docs/access/admin-control-plane.md
+++ b/docs/access/admin-control-plane.md
@@ -46,7 +46,7 @@ That split matters for admin expectations and test scope.
 The current product contract is mixed on purpose:
 
 - identity, service accounts, spend, API keys, request logs, leaderboard, and Models are live gateway-backed surfaces
-- Models still needs richer runtime capability visibility, including Responses support
+- Models still needs richer runtime capability visibility, including Responses and embeddings support
 
 Tracked follow-up:
 

--- a/docs/access/budgets.md
+++ b/docs/access/budgets.md
@@ -42,13 +42,13 @@ If a user has both a user model budget and a user budget, the model-specific bud
 
 ## Embedding Spend
 
-Embedding requests use the same budget taxonomy as chat and Responses traffic. When a native Vertex embedding request has real token usage and exact pricing, the resulting spend counts toward:
+Embedding requests use the same budget taxonomy as chat and Responses traffic. When a native Vertex embedding request has real provider token usage (`statistics.token_count` for Vertex `:predict` text-embedding models or `usageMetadata.promptTokenCount` for `google/gemini-embedding-2`) and exact pricing, the resulting spend counts toward:
 
 - the caller's user budget for human-owned API keys
 - the caller service account's service-account budget for service-account-owned API keys
 - a matching user model budget when a human user calls the specific gateway embedding model
 
-Rows that are `unpriced` or `usage_missing` stay visible in spend reporting, but they do not consume hard or soft budget windows.
+Rows that are `unpriced` or `usage_missing` stay visible in spend reporting, but they do not consume hard or soft budget windows. This can happen when a provider returns embeddings without usable token counts or when the pricing catalog does not have an exact price for the selected Vertex embedding model/location.
 
 The Google Cloud service account configured under a Vertex provider's `auth.mode: service_account` is only upstream provider credential material. It is not a gateway spend principal and does not receive a service-account budget. Gateway service-account budgets apply to service accounts created in Oceans for non-human callers.
 

--- a/docs/access/budgets.md
+++ b/docs/access/budgets.md
@@ -40,6 +40,29 @@ For service-account traffic, Oceans checks only the service-account budget.
 
 If a user has both a user model budget and a user budget, the model-specific budget is evaluated first. Both can still alert independently.
 
+## Embedding Spend
+
+Embedding requests use the same budget taxonomy as chat and Responses traffic. When a native Vertex embedding request has real token usage and exact pricing, the resulting spend counts toward:
+
+- the caller's user budget for human-owned API keys
+- the caller service account's service-account budget for service-account-owned API keys
+- a matching user model budget when a human user calls the specific gateway embedding model
+
+Rows that are `unpriced` or `usage_missing` stay visible in spend reporting, but they do not consume hard or soft budget windows.
+
+The Google Cloud service account configured under a Vertex provider's `auth.mode: service_account` is only upstream provider credential material. It is not a gateway spend principal and does not receive a service-account budget. Gateway service-account budgets apply to service accounts created in Oceans for non-human callers.
+
+To give one user a separate cap for an embedding model:
+
+1. Configure a gateway model such as `gemini-embedding` with an embedding-capable route.
+2. Open `/admin/spend-controls`.
+3. Create a User Model Budget.
+4. Select the user.
+5. Select the gateway embedding model, for example `gemini-embedding`.
+6. Choose cadence, amount, hard-limit behavior, and timezone.
+
+To cap automation that uses embeddings, create or select the gateway service account used by that workload and configure a Service Account Budget before activating its API key.
+
 ## Service Account Requirement
 
 Active service-account API keys require an active service-account budget. This is true for keys created in the admin UI and keys seeded from configuration.

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -121,7 +121,14 @@ models:
     routes:
       - provider: vertex
         upstream_model: google/gemini-2.0-flash
-```
+        capabilities:
+          chat_completions: true
+          responses: false
+          embeddings: false
+          stream: true
+          tools: false
+          vision: true
+          json_schema: false
 
 The checked-in examples are opinionated. They are not the full config space.
 
@@ -567,8 +574,10 @@ Important fields:
 Routing and pricing caveats:
 
 - `upstream_model` must use `<publisher>/<model_id>`
-- pricing identity is inferred from the publisher prefix
+- pricing identity is inferred from the publisher prefix; `google/...` routes use Google Vertex pricing and `anthropic/...` routes use Anthropic-on-Vertex pricing
 - Anthropic-on-Vertex pricing is only supported for `location=global`
+- route capabilities default permissively, so partial Vertex routes should explicitly disable unsupported API families
+- Vertex text embeddings should be configured as explicit embedding-only routes for `google/gemini-embedding-001`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002`
 - provider-specific configuration examples live in [Google Vertex AI](../providers/gcp-vertex.md)
 
 ### `aws_bedrock`
@@ -650,6 +659,24 @@ Capability flags default permissively. A route can constrain provider capability
 Compatibility metadata is separate from capabilities. Capabilities decide whether a route may execute; compatibility describes explicit request and stream-shape transforms for the selected provider route.
 
 Capability flags include API-family gates such as `chat_completions`, `responses`, and `embeddings`, plus feature gates such as `stream`, `tools`, `vision`, `json_schema`, and `developer_role`.
+
+Vertex embedding-only route:
+
+```yaml
+models:
+  - id: gemini-embedding
+    routes:
+      - provider: vertex
+        upstream_model: google/gemini-embedding-001
+        capabilities:
+          chat_completions: false
+          responses: false
+          embeddings: true
+          stream: false
+          tools: false
+          vision: false
+          json_schema: false
+```
 
 OpenAI-compatible route profile:
 

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -578,7 +578,7 @@ Routing and pricing caveats:
 - pricing identity is inferred from the publisher prefix; `google/...` routes use Google Vertex pricing and `anthropic/...` routes use Anthropic-on-Vertex pricing
 - Anthropic-on-Vertex pricing is only supported for `location=global`
 - route capabilities default permissively, so partial Vertex routes should explicitly disable unsupported API families
-- Vertex text embeddings should be configured as explicit embedding-only routes for `google/gemini-embedding-001`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002`
+- Vertex text embeddings should be configured as explicit embedding-only routes for `google/gemini-embedding-001`, `google/gemini-embedding-2`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002`
 - provider-specific configuration examples live in [Google Vertex AI](../providers/gcp-vertex.md)
 
 ### `aws_bedrock`
@@ -669,6 +669,8 @@ models:
     routes:
       - provider: vertex
         upstream_model: google/gemini-embedding-001
+        # google/gemini-embedding-2 is also supported for text-only embeddings
+        # through Vertex :embedContent.
         capabilities:
           chat_completions: false
           responses: false

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -129,6 +129,7 @@ models:
           tools: false
           vision: true
           json_schema: false
+```
 
 The checked-in examples are opinionated. They are not the full config space.
 

--- a/docs/configuration/model-routing-and-api-behavior.md
+++ b/docs/configuration/model-routing-and-api-behavior.md
@@ -113,7 +113,7 @@ Effective capability is the intersection of route metadata and provider runtime 
 - provider implementations can still reject unsupported API families
 - partial provider routes should explicitly disable unsupported API families
 
-For example, current Vertex routes support the chat path but not the Responses path. A Vertex chat route should keep `responses: false` so `/v1/responses` fails during capability filtering instead of later inside the provider adapter.
+For example, current Vertex routes support the chat path but not the Responses path. A Vertex chat route should keep `responses: false` and `embeddings: false` so `/v1/responses` or `/v1/embeddings` fails during capability filtering instead of later inside the provider adapter. A separate Vertex text-embedding route can set `embeddings: true` for supported Google embedding models.
 
 Cloud Run OpenAI-compatible routes use the same route capability model as ordinary `openai_compat` routes. If the deployed vLLM service only exposes Chat Completions, keep `responses: false` and `embeddings: false` on that route even though the provider adapter can speak those OpenAI-compatible families when the upstream supports them.
 
@@ -208,9 +208,24 @@ Important differences:
 - record the provider execution attempt when request logging writes a summary row
 - write usage when usage can be normalized
 
-Current limitation:
+Vertex text embeddings are supported only by explicit embedding routes for supported Google publisher models:
 
-- Vertex embeddings remain out of scope in this slice and should be excluded by capability gating
+- `google/gemini-embedding-001`
+- `google/text-embedding-005`
+- `google/text-multilingual-embedding-002`
+
+Those routes should set `embeddings: true` and disable unrelated API families such as `chat_completions`, `responses`, `stream`, `tools`, `vision`, and `json_schema`. Gemini chat routes should keep `embeddings: false`.
+
+The OpenAI-compatible embeddings request supports string and array-of-strings input. The Vertex mapper rejects unsupported input forms before the provider call: token arrays, nested arrays, non-string values, empty arrays, empty strings, multimodal payloads, and `encoding_format: "base64"`.
+
+Examples:
+
+| Request shape | Expected route behavior |
+| --- | --- |
+| `/v1/embeddings` against an embedding-only `google/gemini-embedding-001` route | Route can pass capability filtering and execute through Vertex `:predict`. |
+| `/v1/embeddings` against a Gemini chat route with `embeddings: false` | Capability filtering removes the route and returns an edge error before Vertex execution. |
+| `/v1/embeddings` against `google/gemini-2.0-flash` with `embeddings: true` | Provider support checks reject the unsupported embedding model instead of treating all `google/*` models as embedding-capable. |
+| `/v1/embeddings` with `input: [[1, 2, 3]]` | The embeddings mapper rejects the unsupported OpenAI token-array/nested-array form locally. |
 
 ## Route Viability Versus Capability Mismatch
 

--- a/docs/configuration/model-routing-and-api-behavior.md
+++ b/docs/configuration/model-routing-and-api-behavior.md
@@ -211,6 +211,7 @@ Important differences:
 Vertex text embeddings are supported only by explicit embedding routes for supported Google publisher models:
 
 - `google/gemini-embedding-001`
+- `google/gemini-embedding-2`
 - `google/text-embedding-005`
 - `google/text-multilingual-embedding-002`
 
@@ -222,7 +223,7 @@ Examples:
 
 | Request shape | Expected route behavior |
 | --- | --- |
-| `/v1/embeddings` against an embedding-only `google/gemini-embedding-001` route | Route can pass capability filtering and execute through Vertex `:predict`. |
+| `/v1/embeddings` against an embedding-only `google/gemini-embedding-001` or `google/gemini-embedding-2` route | Route can pass capability filtering and execute through Vertex `:predict` or `:embedContent`, respectively. |
 | `/v1/embeddings` against a Gemini chat route with `embeddings: false` | Capability filtering removes the route and returns an edge error before Vertex execution. |
 | `/v1/embeddings` against `google/gemini-2.0-flash` with `embeddings: true` | Provider support checks reject the unsupported embedding model instead of treating all `google/*` models as embedding-capable. |
 | `/v1/embeddings` with `input: [[1, 2, 3]]` | The embeddings mapper rejects the unsupported OpenAI token-array/nested-array form locally. |

--- a/docs/configuration/pricing-catalog-and-accounting.md
+++ b/docs/configuration/pricing-catalog-and-accounting.md
@@ -70,16 +70,17 @@ Known coverage constraint:
 Native Vertex text embeddings use the same exact pricing resolver as other Vertex traffic:
 
 - `upstream_model: google/gemini-embedding-001` resolves against pricing provider `google-vertex` and pricing model `gemini-embedding-001`
+- `upstream_model: google/gemini-embedding-2` resolves against pricing provider `google-vertex` and pricing model `gemini-embedding-2`
 - `upstream_model: google/text-embedding-005` resolves against pricing provider `google-vertex` and pricing model `text-embedding-005`
 - `upstream_model: google/text-multilingual-embedding-002` resolves against pricing provider `google-vertex` and pricing model `text-multilingual-embedding-002`
 
-The mapper charges only from real provider token usage. Vertex text embeddings expose token usage through `predictions[].embeddings.statistics.token_count`; the gateway aggregates those values for array input and records them as prompt/input tokens. It does not infer token counts from characters, bytes, vector dimensions, or input count.
+The mapper charges only from real provider token usage. Vertex `:predict` text embeddings expose token usage through `predictions[].embeddings.statistics.token_count`; `google/gemini-embedding-2` exposes it through `usageMetadata.promptTokenCount` on `:embedContent`. The gateway aggregates those values for array input and records them as prompt/input tokens. It does not infer token counts from characters, bytes, vector dimensions, or input count.
 
-Embedding pricing is input-token based in this slice. `dimensions`, `output_dimensionality`, `task_type`, `input_type`, `title`, and `auto_truncate` affect the provider request and resulting vectors, but they do not select a different pricing key or billing modifier. If a future provider rate differentiates one of those dimensions, that modifier must become explicit before it is charged.
+Embedding pricing is input-token based in this slice. `dimensions` and its `output_dimensionality`/`outputDimensionality` aliases affect the provider request and resulting vectors, but they do not select a different pricing key or billing modifier. For `:predict` models, `task_type`, `input_type`, `title`, and `auto_truncate` are also request-shaping fields, not pricing keys. If a future provider rate differentiates one of those dimensions, that modifier must become explicit before it is charged.
 
 Failure-to-charge states:
 
-- `usage_missing`: Vertex returned vectors but did not return usable `token_count` values.
+- `usage_missing`: Vertex returned vectors but did not return usable token-count values.
 - `unpriced`: token usage exists, but no exact catalog row/rate exists for the selected Vertex model and location.
 
 Both states remain report-visible and do not consume hard or soft budget windows.

--- a/docs/configuration/pricing-catalog-and-accounting.md
+++ b/docs/configuration/pricing-catalog-and-accounting.md
@@ -65,6 +65,25 @@ Known coverage constraint:
 
 - Anthropic-on-Vertex pricing is only supported for `location=global`
 
+## Vertex Text Embedding Pricing
+
+Native Vertex text embeddings use the same exact pricing resolver as other Vertex traffic:
+
+- `upstream_model: google/gemini-embedding-001` resolves against pricing provider `google-vertex` and pricing model `gemini-embedding-001`
+- `upstream_model: google/text-embedding-005` resolves against pricing provider `google-vertex` and pricing model `text-embedding-005`
+- `upstream_model: google/text-multilingual-embedding-002` resolves against pricing provider `google-vertex` and pricing model `text-multilingual-embedding-002`
+
+The mapper charges only from real provider token usage. Vertex text embeddings expose token usage through `predictions[].embeddings.statistics.token_count`; the gateway aggregates those values for array input and records them as prompt/input tokens. It does not infer token counts from characters, bytes, vector dimensions, or input count.
+
+Embedding pricing is input-token based in this slice. `dimensions`, `output_dimensionality`, `task_type`, `input_type`, `title`, and `auto_truncate` affect the provider request and resulting vectors, but they do not select a different pricing key or billing modifier. If a future provider rate differentiates one of those dimensions, that modifier must become explicit before it is charged.
+
+Failure-to-charge states:
+
+- `usage_missing`: Vertex returned vectors but did not return usable `token_count` values.
+- `unpriced`: token usage exists, but no exact catalog row/rate exists for the selected Vertex model and location.
+
+Both states remain report-visible and do not consume hard or soft budget windows.
+
 ## Why Requests Become `unpriced`
 
 A request can succeed and still become `unpriced`.

--- a/docs/contributing/operations/budgets-and-spending.md
+++ b/docs/contributing/operations/budgets-and-spending.md
@@ -39,7 +39,7 @@ Embedding requests use the same ledger and budget enforcement path as chat and R
 For native Vertex text embeddings:
 
 - successful priced rows record `operation: embeddings` in request-log metadata and a normal `usage_cost_events` row for the authenticated owner
-- Vertex `statistics.token_count` is normalized into prompt/input token usage
+- Vertex `statistics.token_count` (`:predict`) or `usageMetadata.promptTokenCount` (`google/gemini-embedding-2` `:embedContent`) is normalized into prompt/input token usage
 - completion/output tokens are zero or absent for pricing purposes
 - the gateway must not convert characters or bytes into token counts
 - `priced` rows count toward human user budgets, gateway service-account budgets, and matching user model budgets

--- a/docs/contributing/operations/budgets-and-spending.md
+++ b/docs/contributing/operations/budgets-and-spending.md
@@ -42,7 +42,7 @@ For native Vertex text embeddings:
 - Vertex `statistics.token_count` (`:predict`) or `usageMetadata.promptTokenCount` (`google/gemini-embedding-2` `:embedContent`) is normalized into prompt/input token usage
 - completion/output tokens are zero or absent for pricing purposes
 - the gateway must not convert characters or bytes into token counts
-- `priced` rows count toward human user budgets, gateway service-account budgets, and matching user model budgets
+- `priced` rows count toward the corresponding budget scope for the authenticated owner: user budget, service-account budget, and any matching user-model budget
 - `usage_missing` rows are written when Vertex does not return usable token counts; they remain visible but do not count toward budget windows
 - `unpriced` rows are written when usage exists but no exact pricing row can be resolved; they remain visible but do not count toward budget windows
 

--- a/docs/contributing/operations/budgets-and-spending.md
+++ b/docs/contributing/operations/budgets-and-spending.md
@@ -32,6 +32,24 @@ Pricing states are explicit:
 
 Only `priced` and `legacy_estimated` rows count toward budget windows and spend totals. `unpriced` and `usage_missing` rows remain report-visible accounting-quality signals.
 
+## Embeddings Ledger Behavior
+
+Embedding requests use the same ledger and budget enforcement path as chat and Responses requests.
+
+For native Vertex text embeddings:
+
+- successful priced rows record `operation: embeddings` in request-log metadata and a normal `usage_cost_events` row for the authenticated owner
+- Vertex `statistics.token_count` is normalized into prompt/input token usage
+- completion/output tokens are zero or absent for pricing purposes
+- the gateway must not convert characters or bytes into token counts
+- `priced` rows count toward human user budgets, gateway service-account budgets, and matching user model budgets
+- `usage_missing` rows are written when Vertex does not return usable token counts; they remain visible but do not count toward budget windows
+- `unpriced` rows are written when usage exists but no exact pricing row can be resolved; they remain visible but do not count toward budget windows
+
+The Vertex provider's Google Cloud `auth.mode: service_account` credential is not an ownership scope. Budget ownership still comes from the gateway API key: `user:<user_id>` for human callers or `service_account:<service_account_id>` for gateway service-account callers.
+
+Duplicate request-id handling is unchanged for embeddings. A repeated `(request_id, ownership_scope_key)` is rejected before another ledger write or another round of budget math.
+
 ## Budget Scopes
 
 Budgets are stored in the generic `budgets` table. `scope_key` is canonical and has one active budget at a time.

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -149,6 +149,8 @@ The summary row stores:
 
 Request-attempt rows describe upstream provider execution only. Pre-provider failures such as authentication rejection, capability mismatch, route unavailability, or budget hard-limit rejection have zero attempts. In the current runtime, successful provider-backed requests record one terminal attempt. Retry and fallback execution remain disabled until the configurable policy tracked in issue #118 is implemented.
 
+Native Vertex embeddings use the same request-log surfaces. Successful or failed provider-backed embedding requests record `operation: embeddings`; provider execution details appear as request-attempt rows when a request-log summary is written; sanitized request and response payloads follow the configured payload policy. Embedding inputs are text-only for native Vertex routes, but the redaction and byte-limit policy still applies before storage.
+
 Tool-cardinality fields are explicit nullable columns on `request_logs`.
 
 - `exposed_tool_count`: shallow count of OpenAI-compatible request tools.

--- a/docs/plans/2026-07-05-vertex-gemini-embeddings.md
+++ b/docs/plans/2026-07-05-vertex-gemini-embeddings.md
@@ -22,8 +22,8 @@ The implementation should be conservative. Do not infer token usage from charact
 
 ## Decisions Already Made
 
-1. First supported scope is broader than Gemini-only: support `gemini-embedding-001` plus verified legacy Vertex text embedding models (`text-embedding-005`, `text-multilingual-embedding-002`) when covered by the same `:predict` request/response shape.
-2. Keep the synchronous OpenAI-compatible endpoint. Async batch embeddings, vector database storage, and multimodal Gemini embeddings remain out of scope.
+1. First supported scope is broader than Gemini-only: support `gemini-embedding-001` plus verified legacy Vertex text embedding models (`text-embedding-005`, `text-multilingual-embedding-002`) when covered by the same `:predict` request/response shape. A follow-up review request expanded the text-only scope to `gemini-embedding-2` through Vertex `:embedContent`.
+2. Keep the synchronous OpenAI-compatible endpoint. Async batch embeddings, vector database storage, and multimodal Gemini Embedding 2 inputs remain out of scope.
 3. Reject unsupported OpenAI features locally for this provider path instead of forwarding malformed requests to Vertex.
 4. Preserve the existing generic handler/accounting flow. Vertex-specific work belongs in provider mapping, response normalization, and capability derivation.
 5. Keep user-facing budget setup in `docs/access/budgets.md`; keep ledger/pricing/budget internals in `docs/contributing/operations/budgets-and-spending.md` and `docs/configuration/pricing-catalog-and-accounting.md`.
@@ -61,12 +61,12 @@ Observed from the codebase:
 - `crates/gateway/src/http/handlers.rs::v1_embeddings` already performs auth, model resolution, capability filtering, request logging, pre-provider budget guard, provider execution, usage accounting, and non-stream request logging.
 - `crates/gateway-core/src/protocol/openai.rs`, `crates/gateway-core/src/protocol/core.rs`, and `crates/gateway-core/src/protocol/translate.rs` preserve embeddings requests as `model`, raw JSON `input`, and flattened `extra` fields.
 - `crates/gateway-providers/src/openai_compat.rs` already forwards embeddings to OpenAI-compatible `/embeddings` upstreams.
-- `crates/gateway-providers/src/vertex.rs::embeddings` currently returns `ProviderError::InvalidRequest("vertex embeddings are not supported in this v1 runtime")`.
-- `crates/gateway-providers/src/vertex.rs::capabilities` currently advertises `embeddings: false` for the Vertex provider.
-- `crates/gateway-service/src/admin_models.rs::provider_capabilities` currently treats non-Anthropic `gcp_vertex` as `chat_only_streaming()`, so admin/model views will not show Vertex embedding support until updated.
-- `crates/gateway-service/src/pricing_catalog.rs` already maps `gcp_vertex` `google/<model_id>` routes to pricing provider `google-vertex` and model id `<model_id>`.
-- `crates/gateway-service/data/pricing_catalog_fallback.json` contains `google-vertex/gemini-embedding-001` with input pricing in the observed provider investigation.
-- `docs/providers/gcp-vertex.md`, `docs/reference/provider-api-compatibility.md`, and `docs/configuration/model-routing-and-api-behavior.md` currently say Vertex embeddings are not implemented and should be capability-gated off.
+- Initial planning found `crates/gateway-providers/src/vertex.rs::embeddings` returning `ProviderError::InvalidRequest("vertex embeddings are not supported in this v1 runtime")`; the implementation now supports the listed text-embedding routes.
+- Initial planning found `crates/gateway-providers/src/vertex.rs::capabilities` advertising `embeddings: false` for Vertex; route-aware capability derivation now lives in shared gateway-core metadata.
+- Initial planning found `crates/gateway-service/src/admin_models.rs::provider_capabilities` treating non-Anthropic `gcp_vertex` as `chat_only_streaming()`; admin/model views now use the shared Vertex route capability metadata.
+- `crates/gateway-service/src/pricing_catalog.rs` maps `gcp_vertex` `google/<model_id>` routes to pricing provider `google-vertex` and model id `<model_id>`.
+- `crates/gateway-service/data/pricing_catalog_fallback.json` contains input pricing for `google-vertex/gemini-embedding-001` and `google-vertex/gemini-embedding-2`.
+- `docs/providers/gcp-vertex.md`, `docs/reference/provider-api-compatibility.md`, and `docs/configuration/model-routing-and-api-behavior.md` document current Vertex embedding support and capability gating.
 
 ## External API Facts Used For Planning
 
@@ -76,6 +76,7 @@ Source-backed facts from external documentation and implementation references:
 - Vertex text embeddings `:predict` endpoint: `POST https://{host}/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:predict`.
 - Vertex `:predict` request body for text embeddings uses `instances: [{ content, task_type?, title? }]` and optional `parameters: { autoTruncate?, outputDimensionality? }`.
 - Vertex `:predict` response shape includes `predictions[].embeddings.values` and `predictions[].embeddings.statistics.token_count`/`truncated` in the documented text-embedding response.
+- Vertex `:embedContent` response shape for `gemini-embedding-2` includes `embedding.values` and `usageMetadata.promptTokenCount`/`totalTokenCount`; use `promptTokenCount` as the real input token count when present.
 - `gemini-embedding-001` defaults to 3072 dimensions, has a 2048-token max sequence length in public docs, and supports lower output dimensions.
 - `text-embedding-005` and `text-multilingual-embedding-002` are older Vertex text embedding models with up to 768 dimensions.
 - Google task types include `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`, `SEMANTIC_SIMILARITY`, `CLASSIFICATION`, `CLUSTERING`, `QUESTION_ANSWERING`, `FACT_VERIFICATION`, and `CODE_RETRIEVAL_QUERY`.
@@ -143,6 +144,7 @@ Plan:
    - `upstream_model` publisher is `google`
    - model id is in the supported text-embedding set:
      - `gemini-embedding-001`
+     - `gemini-embedding-2`
      - `text-embedding-005`
      - `text-multilingual-embedding-002`
    - route capability explicitly enables `embeddings`
@@ -179,6 +181,7 @@ Add helpers in `crates/gateway-providers/src/vertex.rs`:
 - parse and require `PublisherFamily::Google`
 - classify supported text embedding models:
   - `gemini-embedding-001`
+  - `gemini-embedding-2`
   - `text-embedding-005`
   - `text-multilingual-embedding-002`
 - return `ProviderError::InvalidRequest` for:
@@ -217,7 +220,7 @@ Supported public fields:
 
 | Public field | Vertex field | Plan |
 | --- | --- | --- |
-| `dimensions` | `parameters.outputDimensionality` | Primary OpenAI-compatible field. Require positive integer. Validate known max per model where practical: 3072 for `gemini-embedding-001`, 768 for `text-embedding-005` and `text-multilingual-embedding-002`. |
+| `dimensions` | `parameters.outputDimensionality` for `:predict`; `embedContentConfig.outputDimensionality` for `gemini-embedding-2` | Primary OpenAI-compatible field. Require positive integer. Validate known max per model where practical: 3072 for `gemini-embedding-001` and `gemini-embedding-2`, 768 for `text-embedding-005` and `text-multilingual-embedding-002`. |
 | `output_dimensionality` | `parameters.outputDimensionality` | Provider-specific alias. Reject if it conflicts with `dimensions`. |
 | `outputDimensionality` | `parameters.outputDimensionality` | Provider-native alias. Accept only if consistent with other aliases. |
 | `encoding_format` absent or `float` | n/a | Accept. |

--- a/docs/plans/2026-07-05-vertex-gemini-embeddings.md
+++ b/docs/plans/2026-07-05-vertex-gemini-embeddings.md
@@ -1,0 +1,756 @@
+# Vertex Gemini Embeddings Implementation Plan
+
+`See also`: [Google Vertex AI](../providers/gcp-vertex.md), [Provider API Compatibility](../reference/provider-api-compatibility.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Budgets](../access/budgets.md), [Budgets and Spending](../contributing/operations/budgets-and-spending.md), [Pricing Catalog and Accounting](../configuration/pricing-catalog-and-accounting.md)
+
+- Date: 2026-07-05
+- Status: Draft plan
+- GitHub issues: [#218](https://github.com/ahstn/oceans-llm/issues/218), [#103](https://github.com/ahstn/oceans-llm/issues/103)
+- Primary target: native Vertex AI text embeddings through Oceans' existing OpenAI-compatible `POST /v1/embeddings` endpoint
+
+## Summary
+
+Implement native `gcp_vertex` embeddings for Google publisher text-embedding models, starting with `google/gemini-embedding-001` and including `google/text-embedding-005` and `google/text-multilingual-embedding-002` when they use the same verified Vertex `:predict` text-embedding contract.
+
+The public Oceans contract remains OpenAI-compatible:
+
+- request: `model`, `input`, optional `dimensions`, optional `encoding_format`, plus documented provider-specific extras
+- input support: `string` and `string[]`
+- response: `object: "list"`, ordered `data[]`, `data[].object: "embedding"`, `data[].index`, float vectors, `model`, and normalized `usage` when real token counts are available
+- accounting: existing request logging, usage ledger, pricing catalog, and budget enforcement paths stay shared with chat and responses
+
+The implementation should be conservative. Do not infer token usage from character counts, do not silently ignore unsupported OpenAI fields, and do not mark broad Vertex chat routes as embedding-capable just because the provider type can support a different embedding route.
+
+## Decisions Already Made
+
+1. First supported scope is broader than Gemini-only: support `gemini-embedding-001` plus verified legacy Vertex text embedding models (`text-embedding-005`, `text-multilingual-embedding-002`) when covered by the same `:predict` request/response shape.
+2. Keep the synchronous OpenAI-compatible endpoint. Async batch embeddings, vector database storage, and multimodal Gemini embeddings remain out of scope.
+3. Reject unsupported OpenAI features locally for this provider path instead of forwarding malformed requests to Vertex.
+4. Preserve the existing generic handler/accounting flow. Vertex-specific work belongs in provider mapping, response normalization, and capability derivation.
+5. Keep user-facing budget setup in `docs/access/budgets.md`; keep ledger/pricing/budget internals in `docs/contributing/operations/budgets-and-spending.md` and `docs/configuration/pricing-catalog-and-accounting.md`.
+
+## Goals
+
+- A configured `gcp_vertex` route for a supported Google text embedding model can set `capabilities.embeddings: true` and successfully execute `POST /v1/embeddings`.
+- `input: "text"` returns one embedding with `index: 0`.
+- `input: ["a", "b"]` returns two embeddings in original order with indexes `0` and `1`.
+- `dimensions` maps to Vertex `outputDimensionality` where the selected model supports it.
+- `task_type`, `input_type`, `title`, and `auto_truncate` handling is explicit, documented, and tested.
+- `encoding_format: "float"` is accepted; `encoding_format: "base64"` is rejected locally unless a later implementation adds tested float32/base64 encoding.
+- OpenAI token-array inputs, nested arrays, non-string values, empty strings, and multimodal/base64 payloads fail locally with clear `invalid_request` errors for native Vertex text embeddings.
+- Usage normalization uses real provider token counts only. Character or byte counts must not be relabeled as tokens.
+- Successful priced usage charges the existing usage ledger and budgets. `usage_missing` and `unpriced` remain visible but do not consume budgets.
+- Admin/model capability views match executable runtime support.
+- Existing OpenAI-compatible embedding routes keep working unchanged.
+
+## Non-Goals
+
+- Multimodal embeddings for image/audio/video/PDF inputs.
+- `gemini-embedding-2` multimodal support.
+- Gemini Developer API key provider support.
+- Async batch embedding jobs.
+- Vector storage, retrieval APIs, or RAG-specific persistence.
+- New native providers such as Cohere, Mistral, Hugging Face, NVIDIA NIM, or Bedrock embeddings.
+- Pre-provider cost estimation for the current request.
+- Replacing the existing ledger, pricing catalog, budget scopes, or request-log lifecycle.
+
+## Current Local State
+
+Observed from the codebase:
+
+- `crates/gateway/src/http/mod.rs` registers `POST /v1/embeddings`.
+- `crates/gateway/src/http/handlers.rs::v1_embeddings` already performs auth, model resolution, capability filtering, request logging, pre-provider budget guard, provider execution, usage accounting, and non-stream request logging.
+- `crates/gateway-core/src/protocol/openai.rs`, `crates/gateway-core/src/protocol/core.rs`, and `crates/gateway-core/src/protocol/translate.rs` preserve embeddings requests as `model`, raw JSON `input`, and flattened `extra` fields.
+- `crates/gateway-providers/src/openai_compat.rs` already forwards embeddings to OpenAI-compatible `/embeddings` upstreams.
+- `crates/gateway-providers/src/vertex.rs::embeddings` currently returns `ProviderError::InvalidRequest("vertex embeddings are not supported in this v1 runtime")`.
+- `crates/gateway-providers/src/vertex.rs::capabilities` currently advertises `embeddings: false` for the Vertex provider.
+- `crates/gateway-service/src/admin_models.rs::provider_capabilities` currently treats non-Anthropic `gcp_vertex` as `chat_only_streaming()`, so admin/model views will not show Vertex embedding support until updated.
+- `crates/gateway-service/src/pricing_catalog.rs` already maps `gcp_vertex` `google/<model_id>` routes to pricing provider `google-vertex` and model id `<model_id>`.
+- `crates/gateway-service/data/pricing_catalog_fallback.json` contains `google-vertex/gemini-embedding-001` with input pricing in the observed provider investigation.
+- `docs/providers/gcp-vertex.md`, `docs/reference/provider-api-compatibility.md`, and `docs/configuration/model-routing-and-api-behavior.md` currently say Vertex embeddings are not implemented and should be capability-gated off.
+
+## External API Facts Used For Planning
+
+Source-backed facts from external documentation and implementation references:
+
+- OpenAI embeddings create reference: `POST /v1/embeddings`; accepts `input`, `model`, optional `dimensions`, optional `encoding_format`; response shape is `object: "list"`, `data[]`, `model`, `usage.prompt_tokens`, `usage.total_tokens`.
+- Vertex text embeddings `:predict` endpoint: `POST https://{host}/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:predict`.
+- Vertex `:predict` request body for text embeddings uses `instances: [{ content, task_type?, title? }]` and optional `parameters: { autoTruncate?, outputDimensionality? }`.
+- Vertex `:predict` response shape includes `predictions[].embeddings.values` and `predictions[].embeddings.statistics.token_count`/`truncated` in the documented text-embedding response.
+- `gemini-embedding-001` defaults to 3072 dimensions, has a 2048-token max sequence length in public docs, and supports lower output dimensions.
+- `text-embedding-005` and `text-multilingual-embedding-002` are older Vertex text embedding models with up to 768 dimensions.
+- Google task types include `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`, `SEMANTIC_SIMILARITY`, `CLASSIFICATION`, `CLUSTERING`, `QUESTION_ANSWERING`, `FACT_VERIFICATION`, and `CODE_RETRIEVAL_QUERY`.
+- `title` is documented as useful/valid for retrieval-document embeddings.
+- `autoTruncate` defaults to provider truncation behavior when omitted; `auto_truncate: false` should make overlong inputs fail upstream instead of truncating when supported.
+- Google docs are inconsistent on batching for `gemini-embedding-001`: generic text embedding docs mention multiple inputs, but model-specific REST notes say `gemini-embedding-001` supports only one input text per request on `:predict`. Plan for safe fan-out unless fixtures prove multi-instance support.
+- LiteLLM design context maps OpenAI `dimensions` to Vertex `outputDimensionality`, maps `input_type` to Vertex `task_type`, transforms `instances`/`parameters`, and sums `statistics.token_count` into OpenAI-compatible usage.
+
+Reference URLs:
+
+- OpenAI embeddings API: https://developers.openai.com/api/reference/resources/embeddings/methods/create/
+- Vertex text embeddings API: https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/text-embeddings-api
+- Vertex get text embeddings guide: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/embeddings/get-text-embeddings
+- Vertex `models.embedContent` reference: https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/embedContent
+- Gemini embeddings API: https://ai.google.dev/api/embeddings
+- Gemini embeddings guide: https://ai.google.dev/gemini-api/docs/embeddings
+- Gemini embedding pricing reference: https://ai.google.dev/gemini-api/docs/pricing#gemini-embedding
+- Gemini embedding GA note: https://developers.googleblog.com/gemini-embedding-available-gemini-api/
+- LiteLLM Vertex embeddings transform: https://github.com/BerriAI/litellm/blob/main/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
+- LiteLLM Gemini batch embedding transform: https://github.com/BerriAI/litellm/blob/main/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+
+## Architecture
+
+```mermaid
+flowchart TD
+    Client[OpenAI-compatible client] --> Handler[POST /v1/embeddings handler]
+    Handler --> Auth[API key auth and model access]
+    Auth --> Resolve[Model alias and route resolution]
+    Resolve --> Capabilities[Route/provider capability filter]
+    Capabilities --> BudgetPre[Pre-provider budget guard]
+    BudgetPre --> Vertex[VertexProvider::embeddings]
+    Vertex --> Validate[Provider-local input and parameter validation]
+    Validate --> Fanout[Per-input Vertex predict calls when needed]
+    Fanout --> Normalize[OpenAI-compatible list response]
+    Normalize --> Ledger[Existing usage ledger and pricing]
+    Ledger --> BudgetPost[Post-provider budget enforcement and alerts]
+    Normalize --> Logs[Existing request-log success/failure path]
+    Normalize --> Client
+```
+
+### Boundary Placement
+
+- Keep OpenAI/core DTOs loose. Do not add provider-specific fields to `gateway-core` unless every provider needs typed access.
+- Add native Vertex embedding mapping helpers in `crates/gateway-providers/src/vertex.rs` near existing Google request/response mapping helpers.
+- Keep generic handler behavior in `crates/gateway/src/http/handlers.rs` unchanged unless route-aware capability derivation requires a small helper update.
+- Keep ledger and budget code generic. Do not add an embeddings-specific usage table or budget path.
+- Update admin capability derivation in `crates/gateway-service/src/admin_models.rs` using the same support predicate as runtime route filtering.
+
+## Route Capability Strategy
+
+This is the highest-risk design point because route capability defaults are permissive.
+
+Current route selection computes:
+
+```text
+provider.capabilities() ∩ route.capabilities
+```
+
+If `VertexProvider::capabilities()` simply flips `embeddings` to `true`, then existing `google/*` chat routes with default or loose route capabilities may become embedding-eligible and fail only after provider validation. That would be confusing and would violate the capability model's goal of edge failure.
+
+Plan:
+
+1. Introduce one shared support predicate for Vertex embedding routes, for example:
+   - provider type is `gcp_vertex`
+   - `upstream_model` publisher is `google`
+   - model id is in the supported text-embedding set:
+     - `gemini-embedding-001`
+     - `text-embedding-005`
+     - `text-multilingual-embedding-002`
+   - route capability explicitly enables `embeddings`
+2. Use that predicate in runtime effective capabilities so supported embedding routes can pass the `embeddings` gate.
+3. Use the same predicate in admin model capability derivation so the UI/API reports executable support accurately.
+4. Keep existing Google chat route examples with `embeddings: false`.
+5. Prefer explicit embedding-only routes in examples:
+
+```yaml
+models:
+  - id: gemini-embedding
+    description: Gemini embeddings on Vertex AI
+    routes:
+      - provider: vertex-global
+        upstream_model: google/gemini-embedding-001
+        capabilities:
+          chat_completions: false
+          responses: false
+          embeddings: true
+          stream: false
+          tools: false
+          vision: false
+          json_schema: false
+```
+
+If route compatibility metadata is needed to support multiple Vertex embedding endpoint styles, add an explicit `gcp_vertex` compatibility profile instead of encoding behavior only by model name. A new ADR is warranted only if that metadata becomes a durable config contract.
+
+## Provider Implementation Plan
+
+### 1. Add Vertex Embedding Model Classification
+
+Add helpers in `crates/gateway-providers/src/vertex.rs`:
+
+- parse and require `PublisherFamily::Google`
+- classify supported text embedding models:
+  - `gemini-embedding-001`
+  - `text-embedding-005`
+  - `text-multilingual-embedding-002`
+- return `ProviderError::InvalidRequest` for:
+  - malformed upstream model
+  - unsupported publisher such as `anthropic/*`
+  - unsupported Google model id when a route tries embeddings
+
+Keep classification small and explicit. This avoids accidentally accepting Gemini chat or multimodal models under an embeddings route.
+
+### 2. Parse OpenAI-Compatible Inputs
+
+Add a helper such as `vertex_embedding_inputs(&CoreEmbeddingsRequest) -> Result<Vec<String>, ProviderError>`.
+
+Accept:
+
+- `input: "hello"`
+- `input: ["hello", "world"]`
+
+Reject locally:
+
+- `input: []`
+- empty string values
+- `input: [1, 2, 3]`
+- `input: [[1, 2], [3, 4]]`
+- arrays containing non-string elements
+- objects, null, booleans, or nested arrays
+- anything that implies multimodal payloads for this text-only route
+
+Reason: OpenAI token arrays depend on OpenAI tokenization. Vertex text embeddings expect text content. There is no provider-safe translation from OpenAI token IDs to Vertex text.
+
+### 3. Parse and Validate Parameters
+
+Consume request `extra` deliberately. Do not pass arbitrary OpenAI embedding extras to Vertex.
+
+Supported public fields:
+
+| Public field | Vertex field | Plan |
+| --- | --- | --- |
+| `dimensions` | `parameters.outputDimensionality` | Primary OpenAI-compatible field. Require positive integer. Validate known max per model where practical: 3072 for `gemini-embedding-001`, 768 for `text-embedding-005` and `text-multilingual-embedding-002`. |
+| `output_dimensionality` | `parameters.outputDimensionality` | Provider-specific alias. Reject if it conflicts with `dimensions`. |
+| `outputDimensionality` | `parameters.outputDimensionality` | Provider-native alias. Accept only if consistent with other aliases. |
+| `encoding_format` absent or `float` | n/a | Accept. |
+| `encoding_format: "base64"` | n/a | Reject locally for the first implementation. |
+| `task_type` | `instances[].task_type` | Accept only known Google task enum values. |
+| `input_type` | `instances[].task_type` | OpenAI-compat-friendly alias. Normalize common values to Google task types when documented; reject conflicts with `task_type`. |
+| `title` | `instances[].title` | Accept only for `RETRIEVAL_DOCUMENT` behavior, or reject with a clear local error. Preferred: reject unless task type resolves to `RETRIEVAL_DOCUMENT`. |
+| `auto_truncate` | `parameters.autoTruncate` | Accept bool. |
+| `autoTruncate` | `parameters.autoTruncate` | Provider-native alias. Reject conflict with `auto_truncate`. |
+| `user` | n/a | Do not forward to Vertex. It is OpenAI metadata; preserve request logging behavior only if already captured elsewhere. |
+
+Task type enum to allow:
+
+- `RETRIEVAL_QUERY`
+- `RETRIEVAL_DOCUMENT`
+- `SEMANTIC_SIMILARITY`
+- `CLASSIFICATION`
+- `CLUSTERING`
+- `QUESTION_ANSWERING`
+- `FACT_VERIFICATION`
+- `CODE_RETRIEVAL_QUERY`
+
+If the selected legacy model rejects one of these values in empirical fixtures, narrow the model-specific set and document it.
+
+### 4. Build Vertex `:predict` Requests
+
+For each input text, build:
+
+```json
+{
+  "instances": [
+    {
+      "content": "text to embed",
+      "task_type": "SEMANTIC_SIMILARITY"
+    }
+  ],
+  "parameters": {
+    "outputDimensionality": 768,
+    "autoTruncate": true
+  }
+}
+```
+
+Omit optional fields when absent.
+
+Endpoint:
+
+```text
+{base}/v1/projects/{project_id}/locations/{location}/publishers/google/models/{model_id}:predict
+```
+
+Reuse existing `VertexProvider::model_endpoint("google", model_id, "predict")` and `build_request` so auth, default headers, route extra headers, timeout, and `x-request-id` stay consistent with chat paths.
+
+Route `extra_body` policy:
+
+- Prefer not to rely on `extra_body` for ordinary embedding parameters; request fields should be documented and validated.
+- If `extra_body` is applied, merge it after generated body only for admin-controlled experiments, then re-run validation so route config cannot bypass local safeguards.
+- Document any final override behavior in `docs/providers/gcp-vertex.md` and `docs/reference/provider-api-compatibility.md`.
+
+### 5. Preserve OpenAI Array Semantics
+
+OpenAI array input means independent embeddings, not one fused prompt.
+
+For `input: ["a", "b"]`:
+
+- produce two upstream embedding operations if the chosen Vertex API style only supports one input per request
+- keep result index `0` for `"a"` and `1` for `"b"`
+- aggregate usage across all upstream calls
+- fail the whole request if any upstream call fails
+- do not collapse all strings into one newline-joined content
+
+Concurrency:
+
+- Add a small bounded fan-out inside `VertexProvider`, not in the generic handler.
+- Use a boring constant initially, for example `VERTEX_EMBEDDING_FANOUT_LIMIT: usize = 4`, unless the repo has an existing config pattern for provider concurrency.
+- Preserve output ordering by storing each result with its original input index.
+- Keep single-input requests as one upstream call.
+
+Future optimization:
+
+- If empirical tests prove multi-instance `:predict` works for a model, add model/API-style capability and tests before switching from fan-out.
+- Keep Gemini `batchEmbedContents` and async batch as separate future API styles; do not mix them into this first synchronous `gcp_vertex` provider path.
+
+### 6. Normalize Vertex Responses
+
+Support the documented `:predict` response shape:
+
+```json
+{
+  "predictions": [
+    {
+      "embeddings": {
+        "values": [0.1, 0.2],
+        "statistics": {
+          "token_count": 5,
+          "truncated": false
+        }
+      }
+    }
+  ]
+}
+```
+
+Normalize to:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [0.1, 0.2]
+    }
+  ],
+  "model": "gemini-embedding",
+  "usage": {
+    "prompt_tokens": 5,
+    "total_tokens": 5
+  }
+}
+```
+
+Rules:
+
+- `model` should use `context.model_key`; the handler also normalizes top-level `model` to the requested gateway model key.
+- Validate that vectors are numeric arrays.
+- Treat missing/invalid vectors as provider response errors (`ProviderError::Transport` with a specific message), not as local request errors.
+- Sum per-input `statistics.token_count` when present.
+- Include `usage.prompt_tokens` and `usage.total_tokens` only when token counts are real.
+- Do not convert `billable_character_count` to token usage.
+- Consider preserving `truncated` and raw provider statistics in `usage.provider_usage` only if existing logging/accounting parsers tolerate extra fields and user-facing response compatibility remains acceptable. Otherwise keep public response minimal and rely on request-log payloads for raw response capture.
+
+### 7. Error Handling
+
+Follow existing Vertex conventions:
+
+- local validation: `ProviderError::InvalidRequest(message)`
+- upstream non-2xx: `ProviderError::UpstreamHttp { status, body }`
+- invalid provider JSON or invalid provider response shape: `ProviderError::Transport(message)`
+- reqwest timeout/transport: existing `map_reqwest_error`
+
+Error messages should name the unsupported field and the supported contract. Examples:
+
+- `vertex embeddings input must be a string or array of strings; token arrays are not supported`
+- `vertex embeddings encoding_format "base64" is not supported; use "float"`
+- `vertex embeddings title is only supported with task_type RETRIEVAL_DOCUMENT`
+- `vertex embeddings route google/gemini-2.0-flash is not a supported embedding model`
+
+## Accounting, Pricing, And Budgets
+
+### Preserve Existing Flow
+
+`v1_embeddings` already calls:
+
+- `enforce_pre_provider_budget` before provider execution
+- `provider.embeddings`
+- `finalize_successful_usage_accounting` after provider success
+- `usage_value_from_response(&value)` to read top-level `usage`
+- `best_effort_log_non_stream_success` / failure helpers
+
+Do not fork this flow. Provider normalization should feed it.
+
+### Usage Normalization
+
+For Vertex text embeddings:
+
+- `usage.prompt_tokens`: sum `statistics.token_count` across inputs when present
+- `usage.total_tokens`: same as prompt tokens for text embeddings
+- `usage.completion_tokens`: omit, or set `0` only if tests confirm downstream summaries/pricing remain correct
+- no token counts: omit `usage` or omit token fields so the ledger records `usage_missing`
+
+Current `GatewayService::record_chat_usage` accepts `prompt_tokens`/`input_tokens`, `completion_tokens`/`output_tokens`, and `total_tokens`.
+
+### Pricing
+
+`gcp_vertex` pricing target logic already maps:
+
+- `google/gemini-embedding-001` -> `google-vertex/gemini-embedding-001`
+- `google/text-embedding-005` -> `google-vertex/text-embedding-005`
+- `google/text-multilingual-embedding-002` -> `google-vertex/text-multilingual-embedding-002`
+
+Add tests for exact target behavior and missing-row behavior.
+
+Budget correctness depends on pricing rows and normalized token counts:
+
+- real token usage + exact pricing row -> `priced`, counts toward spend and hard-limit windows
+- real token usage + no exact pricing row -> `unpriced`, visible but does not count toward spend
+- no token usage -> `usage_missing`, visible but does not count toward spend
+
+Do not estimate request spend from input character length or output dimensions.
+
+### Budget Documentation Split
+
+User-facing `docs/access/budgets.md` should explain:
+
+- budget taxonomy: user budgets, service-account budgets, user model budgets
+- embedding requests are chargeable gateway traffic when usage/pricing are available
+- user model budgets can target an embedding gateway model such as `gemini-embedding`
+- service-account budgets apply to automation embedding calls exactly like chat calls
+- `unpriced` and `usage_missing` rows are visible accounting-quality signals but do not consume budgets
+- Vertex provider service-account credentials are not gateway service accounts and are not budget principals
+
+Developer docs should explain:
+
+- one ledger row per `(request_id, ownership_scope_key)`
+- input-token-only accounting for embeddings
+- how `usage_missing` and `unpriced` are produced
+- post-provider budget behavior and alert implications
+- pricing source and model id resolution for `google-vertex/*`
+
+## Admin And Capability Updates
+
+Update runtime and admin surfaces together.
+
+Runtime targets:
+
+- `crates/gateway-providers/src/vertex.rs`
+  - implement `ProviderClient::embeddings`
+  - expose provider capability in a way that does not make unsupported chat routes embedding-eligible
+- `crates/gateway/src/http/handlers.rs`
+  - if needed, make `route_effective_provider_capabilities` route-aware for Vertex embeddings using the shared predicate
+  - keep generic handler flow unchanged
+
+Admin targets:
+
+- `crates/gateway-service/src/admin_models.rs`
+  - update `provider_capabilities` or route capability computation to identify supported Vertex embedding routes
+  - add tests showing:
+    - `google/gemini-embedding-001` can display `embeddings: true`
+    - `google/gemini-2.0-flash` chat route remains `embeddings: false` unless explicitly supported by a tested embedding API style
+    - `anthropic/*` remains embeddings not applicable
+
+Config/admin docs should recommend explicit route capabilities. Do not rely on permissive defaults for partial providers.
+
+## Documentation Plan
+
+### User-Facing Docs
+
+Update these pages after implementation:
+
+1. `docs/providers/gcp-vertex.md`
+   - Replace blanket unsupported statement for `/v1/embeddings`.
+   - Add Vertex embeddings route example.
+   - Add curl and OpenAI SDK examples.
+   - Document supported models, request parameters, limits, fan-out behavior, usage/pricing/budget notes, and troubleshooting.
+   - Keep chat Gemini examples with `embeddings: false`.
+
+2. `docs/reference/provider-api-compatibility.md`
+   - Update provider endpoint matrix for `gcp_vertex` `google/*` embeddings.
+   - Keep `anthropic/*` embeddings as not applicable.
+   - Add Vertex embeddings compatibility section for input support, local rejections, parameter mapping, response normalization, usage/pricing caveats.
+   - Remove or reclassify #103 as completed after implementation lands.
+
+3. `docs/configuration/model-routing-and-api-behavior.md`
+   - Replace current limitation saying Vertex embeddings are out of scope.
+   - Explain embedding route capability filtering and embedding-only Vertex routes.
+   - Add failure examples for capability mismatch and unsupported input.
+
+4. `docs/configuration/configuration-reference.md`
+   - Add a Vertex embedding-only route example.
+   - Add `gcp_vertex` caveat that pricing is inferred from `google/*` and embedding routes should declare explicit capabilities.
+
+5. `docs/access/budgets.md`
+   - Add user-facing section for embedding spend and budgets per model.
+   - Include steps for a user model budget targeting an embedding gateway model.
+   - Keep taxonomy, setup, and principal model here.
+
+6. `docs/access/admin-control-plane.md`
+   - Broaden current capability visibility wording from Responses-only to Responses and embeddings.
+
+### Developer/Maintainer Docs
+
+Update these pages after implementation:
+
+1. `docs/contributing/operations/budgets-and-spending.md`
+   - Add embeddings-specific ledger lifecycle details.
+   - Keep setup/taxonomy out of this page; link to `docs/access/budgets.md`.
+
+2. `docs/configuration/pricing-catalog-and-accounting.md`
+   - Document Vertex embedding pricing behavior, `usage_missing`, `unpriced`, and input-token-only charging.
+   - State whether dimensions/task/truncation affects pricing status.
+
+3. `docs/reference/request-lifecycle-and-failure-modes.md`
+   - Add Vertex embeddings lifecycle/failure examples.
+
+4. `docs/operations/observability-and-request-logs.md`
+   - Add a note that native Vertex embeddings log `operation: embeddings`, provider attempts, and sanitized payloads through existing policy.
+
+5. Historical ADRs
+   - Do not rewrite accepted ADRs.
+   - Optionally append status notes to ADRs that currently say Vertex embeddings are deferred if the capability model or provider support changes materially.
+
+## Test Plan
+
+Delegate test authoring to the Tester agent during implementation. Tests should assert behavior, not implementation plumbing.
+
+### Provider Tests: `crates/gateway-providers/src/vertex.rs`
+
+Add focused unit/integration-style tests for:
+
+- supported upstream model classification
+- unsupported upstream model rejection:
+  - `google/gemini-2.0-flash`
+  - `anthropic/claude-sonnet-4-6`
+  - malformed model id
+- input parsing:
+  - string input
+  - string array input
+  - empty string rejection
+  - empty array rejection
+  - token-array rejection
+  - nested-array rejection
+  - non-string element rejection
+- parameter mapping:
+  - `dimensions` -> `outputDimensionality`
+  - `output_dimensionality` alias
+  - alias conflict rejection
+  - `encoding_format: float` accepted
+  - `encoding_format: base64` rejected
+  - `task_type` allowed enum
+  - `input_type` alias mapping
+  - `task_type`/`input_type` conflict rejection
+  - `title` accepted only for `RETRIEVAL_DOCUMENT`
+  - `auto_truncate`/`autoTruncate` mapping and conflict rejection
+- request body construction for `:predict`
+- response normalization from `predictions[].embeddings.values`
+- token usage aggregation from `statistics.token_count`
+- usage-missing behavior when token stats are absent
+- fan-out ordering for array inputs
+- upstream non-2xx propagation
+- invalid provider JSON/shape errors
+- local HTTP test verifying:
+  - endpoint path ends in `publishers/google/models/gemini-embedding-001:predict`
+  - bearer auth is present
+  - `x-request-id` is present
+  - fan-out sends one request per input if using per-input calls
+
+### Core Tests
+
+Existing core DTOs can remain loose. Add or preserve tests for:
+
+- embeddings requirements require only `embeddings`
+- OpenAI/core embeddings round-trip preserves `input` and `extra`
+- no narrowing that breaks OpenAI-compatible providers
+
+### Handler/Capability Tests
+
+Add focused tests around route selection/capability behavior:
+
+- supported Vertex embedding route is eligible for `/v1/embeddings`
+- Vertex chat route with `google/gemini-2.0-flash` is not embedding-eligible
+- `anthropic/*` Vertex route is not embedding-eligible
+- OpenAI-compatible embedding route remains eligible
+- no-compatible-route error remains deterministic when only chat routes exist
+
+### Accounting/Budget Tests
+
+Add tests for:
+
+- normalized embedding `usage.prompt_tokens` creates a priced ledger row when pricing exists
+- priced embedding row counts toward user budget and user-model budget windows
+- service-account embedding spend uses service-account budget
+- `usage_missing` embedding row is visible but does not count toward budget
+- `unpriced:model_not_found` embedding row is visible but does not count toward budget
+- duplicate request id still fails before another ledger write
+
+### Admin Model Tests
+
+Add tests in `crates/gateway-service/src/admin_models.rs` for:
+
+- supported Vertex embedding route displays `embeddings: true`
+- unsupported Vertex Google chat route displays `embeddings: false`
+- Anthropic-on-Vertex route keeps tool behavior unchanged and embeddings false
+- generated client config/model data aligns with effective runtime support
+
+### Docs Tests
+
+After docs updates:
+
+- run docs link/ownership checks via repo tooling
+- verify new user-facing budget text does not duplicate maintainer ledger internals
+- verify plan remains in `docs/plans/` and is either intentionally excluded from public docs or intentionally linked in contributor navigation
+
+## Verification Commands For Implementation
+
+Use `mise` per repo convention. Focused commands first:
+
+```bash
+/Users/ahstn/.local/bin/mise exec -- cargo test -p gateway-providers vertex
+/Users/ahstn/.local/bin/mise exec -- cargo test -p gateway-core embeddings
+/Users/ahstn/.local/bin/mise exec -- cargo test -p gateway-service pricing_catalog admin_models request_logging budget_guard
+/Users/ahstn/.local/bin/mise exec -- cargo test -p gateway -- embeddings
+/Users/ahstn/.local/bin/mise run docs-check
+```
+
+Before handoff after implementation:
+
+```bash
+/Users/ahstn/.local/bin/mise exec -- cargo clippy --workspace --all-targets -- -D warnings
+```
+
+If UI/admin contract types change:
+
+```bash
+/Users/ahstn/.local/bin/mise run admin-contract-generate
+/Users/ahstn/.local/bin/mise run admin-contract-check
+```
+
+## Implementation Phases
+
+### Phase 1: Provider Mapping And Normalization
+
+- Add supported Vertex embedding model classifier.
+- Add input parser and parameter parser.
+- Implement single-input `:predict` request mapping.
+- Implement response vector extraction and OpenAI-compatible response normalization.
+- Add provider unit tests for parsing, mapping, normalization, and local errors.
+
+Exit criteria:
+
+- Provider tests show string input works for `gemini-embedding-001`.
+- Unsupported input forms fail locally.
+- Existing OpenAI-compatible provider embedding tests remain unchanged.
+
+### Phase 2: Batch Fan-Out And Usage Aggregation
+
+- Add bounded fan-out for `input: string[]`.
+- Preserve input order and indexes.
+- Aggregate token counts across upstream calls.
+- Add local HTTP tests for multiple inputs.
+
+Exit criteria:
+
+- Array input returns one embedding per input in order.
+- Any upstream failure fails the whole request deterministically.
+- Usage totals sum real token counts only.
+
+### Phase 3: Runtime/Admin Capability Truthfulness
+
+- Add shared route support predicate or compatibility metadata.
+- Update runtime effective capability derivation.
+- Update admin model capability derivation.
+- Add tests for supported embedding route and unsupported chat routes.
+
+Exit criteria:
+
+- `google/gemini-embedding-001` embedding route can pass `/v1/embeddings` capability filtering.
+- `google/gemini-2.0-flash` chat route does not become embedding-capable by accident.
+- Admin/model views align with runtime behavior.
+
+### Phase 4: Accounting And Budget Coverage
+
+- Add pricing target test for `google/gemini-embedding-001` and legacy text embedding models when present.
+- Add usage ledger tests for prompt-token-only embedding usage.
+- Add budget tests for user, service-account, and user-model embedding spend.
+- Add `usage_missing` and `unpriced` coverage.
+
+Exit criteria:
+
+- Priced embedding usage counts toward budgets.
+- `usage_missing`/`unpriced` rows are visible and do not consume budget.
+- Duplicate request id behavior is unchanged.
+
+### Phase 5: Documentation Updates
+
+- Update provider, compatibility, routing, config, budget, pricing/accounting, lifecycle, and observability docs listed above.
+- Keep user-facing and developer-facing docs split.
+- Add examples for route config, curl/OpenAI SDK request, budget per model, and troubleshooting.
+
+Exit criteria:
+
+- No docs still claim Vertex embeddings are unsupported for the implemented model family.
+- User docs explain budget taxonomy and setup without leaking implementation internals.
+- Developer docs explain ledger/pricing behavior without duplicating user setup guidance.
+
+### Phase 6: Final Verification And Cleanup
+
+- Run focused tests.
+- Run docs check.
+- Run lint/clippy per changed scope.
+- Remove stale comments, unused imports, dead helpers, and obsolete unsupported-doc text.
+
+Exit criteria:
+
+- Acceptance criteria from issues #218 and #103 are satisfied.
+- Existing OpenAI-compatible embeddings behavior is protected by regression coverage.
+- Plan/docs/tests all describe the same capability boundary.
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Provider-wide `embeddings: true` makes chat routes eligible | Confusing runtime failures and stale admin capability display | Use shared route/model support predicate or explicit compatibility metadata; keep examples explicit. |
+| Vertex docs conflict on multi-input support | Broken array semantics or upstream 400s | Implement safe per-input fan-out for `gemini-embedding-001`; add fixture tests before optimizing. |
+| Character counts mistaken for token counts | Incorrect budgets and spend reports | Only use provider token counts for `usage`; otherwise record `usage_missing`. |
+| `encoding_format: base64` silently ignored | Client receives wrong response format | Reject locally until implemented and tested. |
+| `task_type`, `input_type`, and `title` drift across docs/models | Opaque upstream errors | Validate local enum/constraints and document supported subset. |
+| Legacy text models differ from `gemini-embedding-001` | Incorrect dimensions/task behavior | Gate support by model classification and tests; narrow docs to verified behavior. |
+| Docs overpromise budget enforcement when pricing/usage is absent | Operator confusion | User docs must state only priced rows count; `unpriced` and `usage_missing` are visible but not budget-consuming. |
+| Admin UI says supported while runtime rejects, or vice versa | Loss of operator trust | Share support predicate between runtime and admin capability derivation. |
+| Fan-out multiplies latency and partial failure surface | Slower large array requests | Bound concurrency, preserve order, fail whole request on any upstream error, document behavior. |
+| Route `extra_body` bypasses validation | Hard-to-debug provider 400s or unsupported behavior | Re-validate after merge or do not allow route overrides for protected fields. |
+
+## Open Questions For Implementation
+
+These should be answered with fixture tests or explicit product decisions before coding beyond the initial narrow path:
+
+1. Does Vertex `:predict` for `gemini-embedding-001` accept multiple `instances` in one request in the target environment, or only one?
+2. Does the raw REST `:predict` response always include `statistics.token_count` for all supported models?
+3. Should the public native Vertex route accept both `auto_truncate` and `autoTruncate`, or only the snake_case alias documented by Oceans?
+4. Should `outputDimensionality` be accepted as a provider-native request field, or should Oceans document only `dimensions` and `output_dimensionality`?
+5. Should `title` without `RETRIEVAL_DOCUMENT` be rejected locally or passed through to Vertex for provider validation?
+6. Should `completion_tokens: 0` be included in the OpenAI-compatible `usage`, or omitted for embeddings?
+7. Does the admin/client model response need a new explicit embedding dimension/capability metadata field, or are existing boolean capabilities enough for this issue?
+
+## Acceptance Checklist
+
+- [ ] `gcp_vertex` route for `google/gemini-embedding-001` executes `POST /v1/embeddings` successfully.
+- [ ] Verified same-contract support for `google/text-embedding-005` and `google/text-multilingual-embedding-002`, or docs explicitly narrow support if fixtures differ.
+- [ ] OpenAI-compatible string input tested.
+- [ ] OpenAI-compatible array-of-strings input tested with order/index preservation.
+- [ ] `dimensions`/`outputDimensionality` behavior tested.
+- [ ] `task_type`/`input_type`, `title`, and `auto_truncate` accepted/rejected as documented.
+- [ ] `encoding_format: base64` rejected locally unless fully implemented.
+- [ ] Token arrays and nested arrays rejected locally.
+- [ ] Vertex response normalized to OpenAI-compatible list shape.
+- [ ] Usage normalization uses real token counts; missing token counts become `usage_missing`.
+- [ ] Pricing target and ledger behavior verified for `google-vertex/gemini-embedding-001`.
+- [ ] Budget behavior verified for user, service-account, and user-model budgets.
+- [ ] Request logging success and provider-error paths covered.
+- [ ] Admin/model capabilities align with runtime support.
+- [ ] Existing OpenAI-compatible embedding routes remain unchanged.
+- [ ] User-facing docs explain Vertex embedding setup, request examples, supported parameters, limitations, troubleshooting, and budgets per model.
+- [ ] Developer docs explain ledger/pricing/budget internals for embeddings.
+- [ ] Stale docs saying Vertex embeddings are unsupported are removed or scoped to unsupported model families.

--- a/docs/providers/gcp-vertex.md
+++ b/docs/providers/gcp-vertex.md
@@ -8,9 +8,10 @@ This page owns provider-specific configuration examples for Google Vertex AI rou
 
 The gateway uses one `gcp_vertex` provider type for multiple Vertex publisher families:
 
-- `google/*` upstream models use Vertex `generateContent` and `streamGenerateContent`
+- `google/*` chat upstream models use Vertex `generateContent` and `streamGenerateContent`
+- supported `google/*` text-embedding upstream models use Vertex `:predict` through the public `/v1/embeddings` path
 - `anthropic/*` upstream models use Anthropic-on-Vertex `rawPredict` and `streamRawPredict`
-- `/v1/responses` and `/v1/embeddings` are not implemented for `gcp_vertex` routes in this slice
+- `/v1/responses` is not implemented for `gcp_vertex` routes in this slice
 
 Vertex routes require Google Cloud authentication with the `https://www.googleapis.com/auth/cloud-platform` scope. The provider supports Application Default Credentials, service-account JSON from a mounted path, and static bearer tokens for constrained environments.
 
@@ -82,6 +83,9 @@ Examples verified against Anthropic and Google Cloud docs on 2026-05-01:
 | Claude coding and agent workloads | `claude-sonnet-vertex` | `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 supports adaptive thinking with effort. |
 | Older pinned Claude | `claude-sonnet-45-vertex` | `anthropic/claude-sonnet-4-5@20250929` | Versioned Anthropic model IDs use the `@YYYYMMDD` suffix on Vertex. |
 | Gemini chat | `gemini-flash-vertex` | `google/gemini-2.0-flash` | Uses the Vertex Google publisher request shape. |
+| Gemini embeddings | `gemini-embedding-vertex` | `google/gemini-embedding-001` | Uses Vertex text embeddings `:predict` through `/v1/embeddings`. |
+| Vertex text embeddings | `text-embedding-vertex` | `google/text-embedding-005` | Older text embedding model using the same Vertex text-embedding contract. |
+| Vertex multilingual embeddings | `text-multilingual-embedding-vertex` | `google/text-multilingual-embedding-002` | Multilingual text embedding model using the same Vertex text-embedding contract. |
 
 Google documents that Claude model availability varies by endpoint and region. Prefer `global` when your residency policy allows it; use `us`, `eu`, or a regional location when you need a geography-specific processing boundary.
 
@@ -216,9 +220,110 @@ models:
 
 Vertex Google multimodal inputs currently accept `gs://` image and file URIs through OpenAI-compatible typed content. Inline/base64 data and remote HTTP URLs are not supported in this gateway slice.
 
+## Text Embeddings Example
+
+Native Vertex text embeddings are exposed through the OpenAI-compatible gateway endpoint:
+
+```text
+POST /v1/embeddings
+```
+
+Use an embedding-only route. Do not make a Gemini chat route embedding-capable just because it also uses the `google/*` publisher prefix.
+
+```yaml
+models:
+  - id: gemini-embedding
+    description: Gemini embeddings on Vertex AI
+    tags: [vertex, embeddings]
+    routes:
+      - provider: vertex-global
+        upstream_model: google/gemini-embedding-001
+        capabilities:
+          chat_completions: false
+          responses: false
+          embeddings: true
+          stream: false
+          tools: false
+          vision: false
+          json_schema: false
+```
+
+Supported native Vertex text-embedding upstream models:
+
+| Upstream model | Default/maximum output dimensions | Notes |
+| --- | ---: | --- |
+| `google/gemini-embedding-001` | 3072 | Supports lower `dimensions` values through Vertex `outputDimensionality`. The gateway fans out array input as independent embedding operations when needed to preserve OpenAI array semantics. |
+| `google/text-embedding-005` | 768 | Uses the same Vertex `:predict` text-embedding contract. |
+| `google/text-multilingual-embedding-002` | 768 | Uses the same Vertex `:predict` text-embedding contract. |
+
+Request example:
+
+```bash
+curl "$OCEANS_BASE_URL/v1/embeddings" \
+  -H "Authorization: Bearer $OCEANS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-embedding",
+    "input": ["search query", "document text"],
+    "dimensions": 768,
+    "task_type": "SEMANTIC_SIMILARITY",
+    "encoding_format": "float"
+  }'
+```
+
+OpenAI SDK example:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://gateway.example.com/v1", api_key="...")
+
+response = client.embeddings.create(
+    model="gemini-embedding",
+    input=["search query", "document text"],
+    dimensions=768,
+    extra_body={
+        "task_type": "SEMANTIC_SIMILARITY",
+        "auto_truncate": False,
+    },
+)
+```
+
+Parameter mapping:
+
+| Public request field | Vertex field | Gateway behavior |
+| --- | --- | --- |
+| `input: "text"` | `instances[].content` | Returns one embedding with `index: 0`. Empty strings are rejected locally. |
+| `input: ["a", "b"]` | independent `instances[].content` values | Returns one embedding per input in original order. Empty arrays, nested arrays, token arrays, non-string values, and multimodal payloads are rejected locally. |
+| `dimensions` | `parameters.outputDimensionality` | Must be a positive integer within the supported model maximum. |
+| `output_dimensionality` / `outputDimensionality` | `parameters.outputDimensionality` | Provider-specific aliases; conflicting aliases are rejected locally. |
+| `encoding_format: "float"` or omitted | n/a | Accepted. `base64` is rejected locally. |
+| `task_type` | `instances[].task_type` | Must be one of Google's supported task enum values. |
+| `input_type` | `instances[].task_type` | Compatibility alias for `task_type`; conflicts are rejected. |
+| `title` | `instances[].title` | Accepted only for retrieval-document embeddings. |
+| `auto_truncate` / `autoTruncate` | `parameters.autoTruncate` | Boolean. When `false`, overlong input is left for Vertex to reject instead of truncating. |
+
+Allowed task types are `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`, `SEMANTIC_SIMILARITY`, `CLASSIFICATION`, `CLUSTERING`, `QUESTION_ANSWERING`, `FACT_VERIFICATION`, and `CODE_RETRIEVAL_QUERY`.
+
+Usage, pricing, and budgets:
+
+- The gateway uses real Vertex `statistics.token_count` values only. It does not convert character counts or byte counts into tokens.
+- When token counts and exact pricing are available, embedding spend is charged through the same user, service-account, and user-model budgets as other gateway traffic.
+- If Vertex omits token counts, the ledger row is `usage_missing`; if exact catalog pricing is unavailable, the row is `unpriced`. Both remain visible in reporting but do not consume budgets.
+
+Troubleshooting:
+
+| Symptom | Check |
+| --- | --- |
+| `/v1/embeddings` returns a capability or invalid-request error | Confirm the selected route has `embeddings: true` and uses one of the supported embedding upstream models, not a Gemini chat model. |
+| `encoding_format` fails | Use `float`; native Vertex `base64` encoding is not implemented. |
+| Token-array or nested-array input fails | Send text strings. OpenAI token arrays cannot be translated safely to Vertex text content. |
+| Spend row is `usage_missing` | Vertex did not return usable token counts, so the request is visible but not budget-consuming. |
+| Spend row is `unpriced` | The pricing catalog did not have an exact supported price for the selected Vertex model/location. |
+
 ## Operational Notes
 
-- Set `responses: false` and `embeddings: false` on Vertex routes until those API families exist in the provider adapter.
+- Keep `responses: false` on all Vertex routes. Keep `embeddings: false` on Vertex chat routes and enable `embeddings: true` only on explicit `google/gemini-embedding-001`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002` routes.
 - Use `upstream_model: anthropic/<model-id>` for Claude and `upstream_model: google/<model-id>` for Gemini; unqualified model IDs fail at the gateway edge.
 - Vertex AI limits Anthropic request payloads to 30 MB. Large documents and many images can hit that byte limit before the model token limit.
 - Keep `json_schema: false` unless a route has explicit provider-specific overrides and tests.

--- a/docs/providers/gcp-vertex.md
+++ b/docs/providers/gcp-vertex.md
@@ -84,8 +84,9 @@ Examples verified against Anthropic and Google Cloud docs on 2026-05-01:
 | Older pinned Claude | `claude-sonnet-45-vertex` | `anthropic/claude-sonnet-4-5@20250929` | Versioned Anthropic model IDs use the `@YYYYMMDD` suffix on Vertex. |
 | Gemini chat | `gemini-flash-vertex` | `google/gemini-2.0-flash` | Uses the Vertex Google publisher request shape. |
 | Gemini embeddings | `gemini-embedding-vertex` | `google/gemini-embedding-001` | Uses Vertex text embeddings `:predict` through `/v1/embeddings`. |
-| Vertex text embeddings | `text-embedding-vertex` | `google/text-embedding-005` | Older text embedding model using the same Vertex text-embedding contract. |
-| Vertex multilingual embeddings | `text-multilingual-embedding-vertex` | `google/text-multilingual-embedding-002` | Multilingual text embedding model using the same Vertex text-embedding contract. |
+| Gemini Embedding 2 | `gemini-embedding-2-vertex` | `google/gemini-embedding-2` | Uses Vertex `:embedContent` for text-only OpenAI-compatible embeddings. |
+| Vertex text embeddings | `text-embedding-vertex` | `google/text-embedding-005` | Older text embedding model using the Vertex text-embedding `:predict` contract. |
+| Vertex multilingual embeddings | `text-multilingual-embedding-vertex` | `google/text-multilingual-embedding-002` | Multilingual text embedding model using the Vertex text-embedding `:predict` contract. |
 
 Google documents that Claude model availability varies by endpoint and region. Prefer `global` when your residency policy allows it; use `us`, `eu`, or a regional location when you need a geography-specific processing boundary.
 
@@ -253,6 +254,7 @@ Supported native Vertex text-embedding upstream models:
 | Upstream model | Default/maximum output dimensions | Notes |
 | --- | ---: | --- |
 | `google/gemini-embedding-001` | 3072 | Supports lower `dimensions` values through Vertex `outputDimensionality`. The gateway fans out array input as independent embedding operations when needed to preserve OpenAI array semantics. |
+| `google/gemini-embedding-2` | 3072 | Uses Vertex `:embedContent`. The gateway supports text-only OpenAI-compatible embeddings; image, audio, video, and PDF multimodal inputs remain unsupported on `/v1/embeddings`. `task_type`, `input_type`, `title`, and `auto_truncate` are not accepted for this model; put task instructions in the input text. |
 | `google/text-embedding-005` | 768 | Uses the same Vertex `:predict` text-embedding contract. |
 | `google/text-multilingual-embedding-002` | 768 | Uses the same Vertex `:predict` text-embedding contract. |
 
@@ -293,21 +295,21 @@ Parameter mapping:
 
 | Public request field | Vertex field | Gateway behavior |
 | --- | --- | --- |
-| `input: "text"` | `instances[].content` | Returns one embedding with `index: 0`. Empty strings are rejected locally. |
-| `input: ["a", "b"]` | independent `instances[].content` values | Returns one embedding per input in original order. Empty arrays, nested arrays, token arrays, non-string values, and multimodal payloads are rejected locally. |
-| `dimensions` | `parameters.outputDimensionality` | Must be a positive integer within the supported model maximum. |
-| `output_dimensionality` / `outputDimensionality` | `parameters.outputDimensionality` | Provider-specific aliases; conflicting aliases are rejected locally. |
+| `input: "text"` | `instances[].content` for `:predict`; `content.parts[].text` for `google/gemini-embedding-2` `:embedContent` | Returns one embedding with `index: 0`. Empty strings are rejected locally. |
+| `input: ["a", "b"]` | independent Vertex requests | Returns one embedding per input in original order. Empty arrays, nested arrays, token arrays, non-string values, and multimodal payloads are rejected locally. |
+| `dimensions` | `parameters.outputDimensionality` for `:predict`; `embedContentConfig.outputDimensionality` for `google/gemini-embedding-2` | Must be a positive integer within the supported model maximum. |
+| `output_dimensionality` / `outputDimensionality` | Same as `dimensions` | Provider-specific aliases; conflicting aliases are rejected locally. |
 | `encoding_format: "float"` or omitted | n/a | Accepted. `base64` is rejected locally. |
-| `task_type` | `instances[].task_type` | Must be one of Google's supported task enum values. |
-| `input_type` | `instances[].task_type` | Compatibility alias for `task_type`; conflicts are rejected. |
-| `title` | `instances[].title` | Accepted only for retrieval-document embeddings. |
-| `auto_truncate` / `autoTruncate` | `parameters.autoTruncate` | Boolean. When `false`, overlong input is left for Vertex to reject instead of truncating. |
+| `task_type` | `instances[].task_type` for `:predict` models only | Must be one of Google's supported task enum values. Rejected for `google/gemini-embedding-2`; put task instructions in the input text. |
+| `input_type` | Alias for `task_type` for `:predict` models only | Conflicts are rejected. Rejected for `google/gemini-embedding-2`. |
+| `title` | `instances[].title` for `:predict` models only | Accepted only for retrieval-document embeddings. Rejected for `google/gemini-embedding-2`. |
+| `auto_truncate` / `autoTruncate` | `parameters.autoTruncate` for `:predict` models only | Boolean. When `false`, overlong input is left for Vertex to reject instead of truncating. Rejected for `google/gemini-embedding-2`. |
 
 Allowed task types are `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`, `SEMANTIC_SIMILARITY`, `CLASSIFICATION`, `CLUSTERING`, `QUESTION_ANSWERING`, `FACT_VERIFICATION`, and `CODE_RETRIEVAL_QUERY`.
 
 Usage, pricing, and budgets:
 
-- The gateway uses real Vertex `statistics.token_count` values only. It does not convert character counts or byte counts into tokens.
+- The gateway uses real Vertex token counts only: `predictions[].embeddings.statistics.token_count` for `:predict` models and `usageMetadata.promptTokenCount` for `google/gemini-embedding-2`. It does not convert character counts or byte counts into tokens.
 - When token counts and exact pricing are available, embedding spend is charged through the same user, service-account, and user-model budgets as other gateway traffic.
 - If Vertex omits token counts, the ledger row is `usage_missing`; if exact catalog pricing is unavailable, the row is `unpriced`. Both remain visible in reporting but do not consume budgets.
 
@@ -323,7 +325,7 @@ Troubleshooting:
 
 ## Operational Notes
 
-- Keep `responses: false` on all Vertex routes. Keep `embeddings: false` on Vertex chat routes and enable `embeddings: true` only on explicit `google/gemini-embedding-001`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002` routes.
+- Keep `responses: false` on all Vertex routes. Keep `embeddings: false` on Vertex chat routes and enable `embeddings: true` only on explicit `google/gemini-embedding-001`, `google/gemini-embedding-2`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002` routes.
 - Use `upstream_model: anthropic/<model-id>` for Claude and `upstream_model: google/<model-id>` for Gemini; unqualified model IDs fail at the gateway edge.
 - Vertex AI limits Anthropic request payloads to 30 MB. Large documents and many images can hit that byte limit before the model token limit.
 - Keep `json_schema: false` unless a route has explicit provider-specific overrides and tests.

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -36,7 +36,7 @@ This matrix is about current execution support, not provider marketing claims.
 | --- | --- | --- | --- |
 | `openai_compat` | Supported. Chat Completions route profiles can rewrite known request-shape quirks. | Supported through the distinct Responses request/provider path. Chat Completions profile transforms do not apply. | Supported. No route compatibility transforms apply in this slice. |
 | `gcp_cloud_run_openai_compat` | Supported through the OpenAI-compatible adapter with Cloud Run ID-token auth. | Supported when the deployed service exposes an OpenAI-compatible Responses endpoint. Chat Completions profile transforms do not apply. | Supported when the deployed service exposes an OpenAI-compatible embeddings endpoint. |
-| `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Supported only for explicit text-embedding routes using `google/gemini-embedding-001`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002` with `embeddings: true`. Google chat and multimodal models should keep `embeddings: false`. |
+| `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Supported only for explicit text-embedding routes using `google/gemini-embedding-001`, `google/gemini-embedding-2`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002` with `embeddings: true`. Google chat and multimodal routes should keep `embeddings: false`. |
 | `gcp_vertex` with `anthropic/*` upstream models | Supported for Chat Completions and Anthropic Messages when route capabilities allow it. Tool use is supported for text/tool workflows. | Not implemented; keep route `responses: false`. | Not applicable. |
 | `aws_bedrock` | Supported through explicit `compatibility.aws_bedrock.api_style`: Runtime Converse, Runtime Anthropic InvokeModel, Runtime OpenAI Chat, Mantle OpenAI Chat, or Mantle Anthropic Messages. Streaming uses the configured style's stream contract. | Supported for `api_style: mantle_openai_responses` with an OpenAI base path such as `/openai/v1`. This is the Bedrock-supported Responses subset, not full direct-OpenAI hosted-tool parity. | Not implemented; keep route `embeddings: false`. |
 
@@ -163,6 +163,7 @@ Vertex Google publisher routes remain separate from Anthropic-on-Vertex. `google
 Native Vertex text embeddings are available through the public OpenAI-compatible `POST /v1/embeddings` endpoint for these Google publisher models:
 
 - `google/gemini-embedding-001`
+- `google/gemini-embedding-2`
 - `google/text-embedding-005`
 - `google/text-multilingual-embedding-002`
 
@@ -183,17 +184,17 @@ Compatibility contract:
 
 | Public field or behavior | Vertex mapping or outcome |
 | --- | --- |
-| `input: "text"` | One Vertex text embedding request and one OpenAI-compatible `data[0]` embedding. |
+| `input: "text"` | One Vertex text embedding request and one OpenAI-compatible `data[0]` embedding. `google/gemini-embedding-2` uses Vertex `:embedContent`; the other supported models use Vertex `:predict`. |
 | `input: ["a", "b"]` | Independent embedding operations with OpenAI-compatible indexes preserved in request order. |
 | Token arrays, nested arrays, non-string values, empty arrays, empty strings, multimodal/base64 payloads | Rejected locally with `invalid_request`. |
-| `dimensions` | `parameters.outputDimensionality`; must be positive and within the model's supported maximum. |
+| `dimensions` | `parameters.outputDimensionality` for `:predict` models; `embedContentConfig.outputDimensionality` for `google/gemini-embedding-2`; must be positive and within the model's supported maximum. |
 | `output_dimensionality` / `outputDimensionality` | Aliases for `dimensions`; conflicts are rejected. |
 | `encoding_format` omitted or `float` | Accepted; response embeddings are float vectors. |
 | `encoding_format: "base64"` | Rejected locally. |
-| `task_type` | `instances[].task_type`; must use a supported Google task enum. |
-| `input_type` | Alias for `task_type`; conflicts are rejected. |
-| `title` | Accepted only for retrieval-document embeddings. |
-| `auto_truncate` / `autoTruncate` | `parameters.autoTruncate`; conflicts are rejected. |
+| `task_type` | `instances[].task_type` for `:predict` models; rejected for `google/gemini-embedding-2`, which expects task instructions in the input text. |
+| `input_type` | Alias for `task_type` on `:predict` models; conflicts are rejected. Rejected for `google/gemini-embedding-2`. |
+| `title` | Accepted only for retrieval-document embeddings on `:predict` models. Rejected for `google/gemini-embedding-2`. |
+| `auto_truncate` / `autoTruncate` | `parameters.autoTruncate` for `:predict` models; conflicts are rejected. Rejected for `google/gemini-embedding-2`. |
 
 Responses are normalized to the OpenAI embeddings list shape: `object: "list"`, ordered `data[]`, `data[].object: "embedding"`, `data[].index`, float vectors, `model`, and `usage` when Vertex returns real token counts. Missing token counts become `usage_missing`; exact catalog misses become `unpriced`. Neither state consumes budget.
 
@@ -343,7 +344,7 @@ Current durable accounting only relies on:
 
 Responses usage is normalized from `usage.input_tokens`, `usage.output_tokens`, and `usage.total_tokens` into the gateway's prompt/completion/total accounting columns. Streaming Responses usage is read from completed response events with `response.usage`.
 
-Vertex text embeddings normalize Vertex `statistics.token_count` into prompt/input token usage when the provider returns it. The gateway does not infer tokens from character or byte counts. Provider-specific cache, reasoning, image, audio, and modality counters remain follow-up work. Until those semantics are explicit, successful requests may still become `usage_missing` or `unpriced`.
+Vertex text embeddings normalize real provider token counts into prompt/input token usage: `predictions[].embeddings.statistics.token_count` for Vertex `:predict` text-embedding models and `usageMetadata.promptTokenCount` for `google/gemini-embedding-2`. The gateway does not infer tokens from character or byte counts. Provider-specific cache, reasoning, image, audio, and modality counters remain follow-up work. Until those semantics are explicit, successful requests may still become `usage_missing` or `unpriced`.
 
 ## Research References
 

--- a/docs/reference/provider-api-compatibility.md
+++ b/docs/reference/provider-api-compatibility.md
@@ -23,7 +23,7 @@ The Responses API is a first-class API family. It is not translated through Chat
 | --- | --- | --- | --- |
 | OpenAI Chat Completions | Supported for `openai_compat` providers | `crates/gateway-providers/src/openai_compat.rs` | Route-level `openai_compat` profile can declare request-shape quirks and streaming usage support. |
 | OpenAI Responses API | Supported for `openai_compat` providers | `crates/gateway-providers/src/openai_compat.rs` | Uses a distinct typed request/core/provider boundary and preserves Responses event-stream semantics. |
-| OpenAI Embeddings | Supported for `openai_compat` providers | `crates/gateway-providers/src/openai_compat.rs` | Uses the same route/provider resolution path; no compatibility transforms are applied in this slice. |
+| OpenAI Embeddings | Supported for `openai_compat` providers and native Vertex text-embedding routes | `crates/gateway-providers/src/openai_compat.rs`, `crates/gateway-providers/src/vertex.rs` | OpenAI-compatible providers receive the OpenAI-shaped request. Vertex text embeddings use a provider-specific `:predict` mapper with explicit local validation. |
 | Anthropic Messages | Supported for `/v1/messages` and `/messages` through the chat execution boundary | `crates/gateway/src/http/handlers.rs`, `crates/gateway-providers/src/vertex.rs` | Accepts Anthropic Messages request shape and returns Anthropic Messages response/SSE for chat-capable routes such as Anthropic-on-Vertex. |
 | Google Generative AI | Not implemented as a direct API-key provider path | Follow-up issue | Vertex Google transport exists; direct Google native API needs separate auth, request, and stream mapping. |
 | Cross-provider multimodal files/images | Partial, provider-dependent | Follow-up issue | Needs explicit request body and accounting semantics across OpenAI-compatible, Vertex Google, Anthropic, and Google native APIs. |
@@ -36,7 +36,7 @@ This matrix is about current execution support, not provider marketing claims.
 | --- | --- | --- | --- |
 | `openai_compat` | Supported. Chat Completions route profiles can rewrite known request-shape quirks. | Supported through the distinct Responses request/provider path. Chat Completions profile transforms do not apply. | Supported. No route compatibility transforms apply in this slice. |
 | `gcp_cloud_run_openai_compat` | Supported through the OpenAI-compatible adapter with Cloud Run ID-token auth. | Supported when the deployed service exposes an OpenAI-compatible Responses endpoint. Chat Completions profile transforms do not apply. | Supported when the deployed service exposes an OpenAI-compatible embeddings endpoint. |
-| `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Not implemented in this slice; keep route `embeddings: false`. |
+| `gcp_vertex` with `google/*` upstream models | Supported for the current Vertex chat path when route capabilities allow it. | Not implemented; keep route `responses: false`. | Supported only for explicit text-embedding routes using `google/gemini-embedding-001`, `google/text-embedding-005`, or `google/text-multilingual-embedding-002` with `embeddings: true`. Google chat and multimodal models should keep `embeddings: false`. |
 | `gcp_vertex` with `anthropic/*` upstream models | Supported for Chat Completions and Anthropic Messages when route capabilities allow it. Tool use is supported for text/tool workflows. | Not implemented; keep route `responses: false`. | Not applicable. |
 | `aws_bedrock` | Supported through explicit `compatibility.aws_bedrock.api_style`: Runtime Converse, Runtime Anthropic InvokeModel, Runtime OpenAI Chat, Mantle OpenAI Chat, or Mantle Anthropic Messages. Streaming uses the configured style's stream contract. | Supported for `api_style: mantle_openai_responses` with an OpenAI base path such as `/openai/v1`. This is the Bedrock-supported Responses subset, not full direct-OpenAI hosted-tool parity. | Not implemented; keep route `embeddings: false`. |
 
@@ -101,7 +101,7 @@ Effective capability is the intersection of configured route metadata and provid
 - Provider implementations still enforce what they can actually execute.
 - Capability defaults are permissive, so routes for partial providers should set unsupported API families to `false`.
 
-For example, a Vertex Google chat route should normally set `responses: false` and `embeddings: false` until those provider paths are implemented. Otherwise the route may look viable from config alone and still fail when the provider adapter rejects the unsupported API family.
+For example, a Vertex Google chat route should normally set `responses: false` and `embeddings: false`. A separate Vertex text-embedding route can set `embeddings: true` only when its `upstream_model` is one of the supported Google embedding models. Otherwise the route may look viable from config alone and still fail when provider capability checks reject the unsupported API family or model.
 
 For Cloud Run OpenAI-compatible routes, set capabilities to the endpoints exposed by the deployed service. The gateway adapter can construct Chat Completions, Responses, embeddings, and streams through the OpenAI-compatible path, but a vLLM deployment might only enable some of those endpoints.
 
@@ -157,6 +157,48 @@ Provider metadata preservation is not yet request-side replay. The current Verte
 Vertex Claude route capabilities should stay aligned with tested gateway behavior, not only upstream model capability. Function tools, tool-result continuations, and streaming tool-use deltas are supported for Anthropic-on-Vertex text/tool workflows. Image/document content blocks remain unsupported in the current mapper and should keep `vision: false`; broader multimodal matrices remain tracked by [issue #91](https://github.com/ahstn/oceans-llm/issues/91) and [issue #93](https://github.com/ahstn/oceans-llm/issues/93).
 
 Vertex Google publisher routes remain separate from Anthropic-on-Vertex. `google/*` upstream models use Vertex `generateContent` and `streamGenerateContent`; Anthropic Messages fields such as `thinking`, `output_config`, and `anthropic_version` do not apply to those routes.
+
+## Google Vertex Text Embeddings
+
+Native Vertex text embeddings are available through the public OpenAI-compatible `POST /v1/embeddings` endpoint for these Google publisher models:
+
+- `google/gemini-embedding-001`
+- `google/text-embedding-005`
+- `google/text-multilingual-embedding-002`
+
+The route should be embedding-only unless you have separately tested another API family for the same upstream model:
+
+```yaml
+capabilities:
+  chat_completions: false
+  responses: false
+  embeddings: true
+  stream: false
+  tools: false
+  vision: false
+  json_schema: false
+```
+
+Compatibility contract:
+
+| Public field or behavior | Vertex mapping or outcome |
+| --- | --- |
+| `input: "text"` | One Vertex text embedding request and one OpenAI-compatible `data[0]` embedding. |
+| `input: ["a", "b"]` | Independent embedding operations with OpenAI-compatible indexes preserved in request order. |
+| Token arrays, nested arrays, non-string values, empty arrays, empty strings, multimodal/base64 payloads | Rejected locally with `invalid_request`. |
+| `dimensions` | `parameters.outputDimensionality`; must be positive and within the model's supported maximum. |
+| `output_dimensionality` / `outputDimensionality` | Aliases for `dimensions`; conflicts are rejected. |
+| `encoding_format` omitted or `float` | Accepted; response embeddings are float vectors. |
+| `encoding_format: "base64"` | Rejected locally. |
+| `task_type` | `instances[].task_type`; must use a supported Google task enum. |
+| `input_type` | Alias for `task_type`; conflicts are rejected. |
+| `title` | Accepted only for retrieval-document embeddings. |
+| `auto_truncate` / `autoTruncate` | `parameters.autoTruncate`; conflicts are rejected. |
+
+Responses are normalized to the OpenAI embeddings list shape: `object: "list"`, ordered `data[]`, `data[].object: "embedding"`, `data[].index`, float vectors, `model`, and `usage` when Vertex returns real token counts. Missing token counts become `usage_missing`; exact catalog misses become `unpriced`. Neither state consumes budget.
+
+Anthropic-on-Vertex routes and Google chat/multimodal models do not implement embeddings.
+
 
 ## AWS Bedrock Runtime Anthropic Claude
 
@@ -301,7 +343,7 @@ Current durable accounting only relies on:
 
 Responses usage is normalized from `usage.input_tokens`, `usage.output_tokens`, and `usage.total_tokens` into the gateway's prompt/completion/total accounting columns. Streaming Responses usage is read from completed response events with `response.usage`.
 
-Provider-specific cache, reasoning, image, audio, and modality counters remain follow-up work. Until those semantics are explicit, successful requests may still become `usage_missing` or `unpriced`.
+Vertex text embeddings normalize Vertex `statistics.token_count` into prompt/input token usage when the provider returns it. The gateway does not infer tokens from character or byte counts. Provider-specific cache, reasoning, image, audio, and modality counters remain follow-up work. Until those semantics are explicit, successful requests may still become `usage_missing` or `unpriced`.
 
 ## Research References
 
@@ -321,7 +363,6 @@ These items are intentionally outside this first slice:
 - cross-provider tool-call streaming normalization fixtures: [issue #91](https://github.com/ahstn/oceans-llm/issues/91)
 - cache, reasoning, and modality token accounting: [issue #92](https://github.com/ahstn/oceans-llm/issues/92)
 - multimodal image/file compatibility across provider families: [issue #93](https://github.com/ahstn/oceans-llm/issues/93)
-- Vertex embeddings provider support: [issue #103](https://github.com/ahstn/oceans-llm/issues/103)
 - Bedrock Runtime Anthropic streaming over `InvokeModelWithResponseStream`: [issue #139](https://github.com/ahstn/oceans-llm/issues/139)
 - Anthropic thinking block replay for tool-use continuations: [issue #140](https://github.com/ahstn/oceans-llm/issues/140)
 - Vertex Claude multimodal parity: [issue #141](https://github.com/ahstn/oceans-llm/issues/141)

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -80,6 +80,42 @@ One common request path looks like this:
   - `usage_cost_events.pricing_status` becomes `priced`
   - the service-account budget window includes the charge
 
+## Vertex Embeddings Example
+
+Native Vertex text embeddings follow the same cross-cutting lifecycle as other `/v1/*` requests:
+
+- Request:
+  - `POST /v1/embeddings`
+  - model is `gemini-embedding`
+  - input is `["query text", "document text"]`
+- Resolution:
+  - `gemini-embedding` resolves to a route with `provider: vertex-global`
+  - `upstream_model` is `google/gemini-embedding-001`
+- Capability filter:
+  - the route has `embeddings: true`
+  - unrelated families such as `chat_completions` and `responses` are disabled on that route
+- Provider execution:
+  - the Vertex adapter validates text-only input and supported parameters
+  - the adapter calls Vertex `:predict`, fanning out array input when needed while preserving output indexes
+- Logging:
+  - request logs record `operation: embeddings`
+  - request-log attempts record the Vertex provider execution attempt when a summary row is written
+- Accounting:
+  - Vertex `statistics.token_count` values are aggregated into prompt/input token usage
+  - exact Google Vertex pricing produces a `priced` ledger row
+  - user, service-account, and matching user-model budget windows include the charge
+
+Important failure examples:
+
+| Failure | Lifecycle point | Outcome |
+| --- | --- | --- |
+| Gemini chat route has `embeddings: false` | capability filtering | The route is removed before Vertex execution. |
+| Route uses unsupported `google/gemini-2.0-flash` for embeddings | provider support validation | The request fails with a deterministic invalid-request error instead of treating all `google/*` models as embedding-capable. |
+| `input` is a token array, nested array, non-string, empty array, or empty string | provider-local request validation | The request fails locally before the upstream call. |
+| `encoding_format: "base64"` | provider-local request validation | The request fails locally because native Vertex embeddings return float vectors only in this slice. |
+| Vertex omits token counts | accounting | The request can still succeed, but the ledger status is `usage_missing` and budgets are not consumed. |
+| Pricing catalog lacks an exact embedding model/rate | accounting | The request can still succeed, but the ledger status is `unpriced` and budgets are not consumed. |
+
 ## Model Visibility Versus Execution
 
 A model can be visible and still fail at runtime.

--- a/docs/reference/request-lifecycle-and-failure-modes.md
+++ b/docs/reference/request-lifecycle-and-failure-modes.md
@@ -96,12 +96,12 @@ Native Vertex text embeddings follow the same cross-cutting lifecycle as other `
   - unrelated families such as `chat_completions` and `responses` are disabled on that route
 - Provider execution:
   - the Vertex adapter validates text-only input and supported parameters
-  - the adapter calls Vertex `:predict`, fanning out array input when needed while preserving output indexes
+  - the adapter calls Vertex `:predict` for legacy text-embedding models or `:embedContent` for `google/gemini-embedding-2`, fanning out array input when needed while preserving output indexes
 - Logging:
   - request logs record `operation: embeddings`
   - request-log attempts record the Vertex provider execution attempt when a summary row is written
 - Accounting:
-  - Vertex `statistics.token_count` values are aggregated into prompt/input token usage
+  - Vertex provider token counts are aggregated into prompt/input token usage (`statistics.token_count` for `:predict`, `usageMetadata.promptTokenCount` for `:embedContent`)
   - exact Google Vertex pricing produces a `priced` ledger row
   - user, service-account, and matching user-model budget windows include the charge
 


### PR DESCRIPTION
## Description

Adds native `gcp_vertex` text embedding support for `/v1/embeddings`, including provider request/response mapping, route-aware capability surfaces, accounting/logging verification, and user/developer documentation.

- Summary of changes
  - Supports `google/gemini-embedding-001`, `google/text-embedding-005`, and `google/text-multilingual-embedding-002` through Vertex `:predict`.
  - Preserves OpenAI-compatible `input: string | string[]` and normalized `object: "list"` embedding responses.
  - Rejects unsupported Vertex embedding forms locally, including token arrays, nested arrays, non-string input, `encoding_format: "base64"`, invalid aliases, and `title` outside `RETRIEVAL_DOCUMENT`.
  - Centralizes supported Vertex text-embedding metadata in `gateway-core` for provider validation, runtime routing, and admin capability derivation.
  - Adds focused tests for provider mapping, route/admin capabilities, exact `gemini-embedding-001` pricing resolution, `usage_missing`, and embeddings request-log success/provider-error attempts.
  - Updates Vertex, compatibility, routing, pricing/accounting, budget, observability, and request-lifecycle docs.
- Why this approach was chosen
  - Keeps `/v1/embeddings` on the existing gateway auth, routing, request logging, budget guard, usage ledger, and pricing paths instead of adding a second embeddings execution lane.
  - Uses real Vertex token metadata only; no character-count-to-token inference.
  - Keeps Vertex embedding routes explicit and embedding-only so chat/multimodal routes do not inherit unsupported capabilities.
- How it works
  - The Vertex provider maps OpenAI-compatible embedding requests to one Vertex `:predict` request per text input when needed, preserving response order and aggregating real `statistics.token_count` values.
  - Runtime and admin capability derivation use shared `gateway-core` Vertex text-embedding metadata.
  - Existing accounting consumes the normalized OpenAI-style `usage` object; missing usage remains `usage_missing`, and missing exact pricing remains `unpriced`.
- Risks, tradeoffs, and alternatives considered
  - Array input currently fans out sequentially, which is safe and bounded but not optimized for latency.
  - `encoding_format: "base64"` and OpenAI token-array inputs are rejected until there is a deliberate compatible representation.
  - Only text embedding models verified against the Vertex text-embedding `:predict` contract are enabled.
- Additional context for reviewers
  - Implements GitHub issues #218 and #103.
  - Plan artifact: `docs/plans/2026-07-05-vertex-gemini-embeddings.md`.

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Focused verification run in this session:

- `cargo test -p gateway-providers vertex`
- `cargo test -p gateway-service embedding --lib`
- `cargo test -p gateway vertex_`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `mise run docs:check`
