### PR TITLE
feat(gateway): add declarative user budget defaults

### DIFF
--- a/crates/admin-ui/web/src/generated/admin-api.ts
+++ b/crates/admin-ui/web/src/generated/admin-api.ts
@@ -1483,6 +1483,10 @@ export interface components {
             hard_limit: boolean;
             timezone: string;
         };
+        BudgetSourceView: {
+            key?: string | null;
+            kind: string;
+        };
         BudgetUserModelByModelScopeRequest: {
             kind: components["schemas"]["BudgetUserModelScopeKind"];
             model_id: string;
@@ -2038,6 +2042,7 @@ export interface components {
             data: {
                 budget: components["schemas"]["BudgetSettingsView"];
                 budget_id: string;
+                budget_source: components["schemas"]["BudgetSourceView"];
                 /** Format: int64 */
                 current_window_spend_usd_10000: number;
                 scope: components["schemas"]["BudgetScopeView"];
@@ -2616,6 +2621,7 @@ export interface components {
             alert_email_ready: boolean;
             alert_recipient_summary: string;
             budget?: null | components["schemas"]["BudgetSettingsView"];
+            budget_source?: null | components["schemas"]["BudgetSourceView"];
             /** Format: int64 */
             current_window_spend_usd_10000: number;
             service_account_id: string;
@@ -2630,6 +2636,7 @@ export interface components {
             alert_recipient_summary: string;
             budget: components["schemas"]["BudgetSettingsView"];
             budget_id: string;
+            budget_source: components["schemas"]["BudgetSourceView"];
             /** Format: int64 */
             current_window_spend_usd_10000: number;
             model_id?: string | null;
@@ -2641,6 +2648,7 @@ export interface components {
             alert_email_ready: boolean;
             alert_recipient_summary: string;
             budget?: null | components["schemas"]["BudgetSettingsView"];
+            budget_source?: null | components["schemas"]["BudgetSourceView"];
             /** Format: int64 */
             current_window_spend_usd_10000: number;
             email: string;
@@ -2773,6 +2781,7 @@ export interface components {
         UpsertBudgetResultView: {
             budget: components["schemas"]["BudgetSettingsView"];
             budget_id: string;
+            budget_source: components["schemas"]["BudgetSourceView"];
             /** Format: int64 */
             current_window_spend_usd_10000: number;
             scope: components["schemas"]["BudgetScopeView"];

--- a/crates/admin-ui/web/src/routes/api-keys.tsx
+++ b/crates/admin-ui/web/src/routes/api-keys.tsx
@@ -70,12 +70,15 @@ export function ApiKeysPage() {
         isPending={state.isPending}
         modelOptions={models}
         open={state.manageDialog.mode === 'open'}
+        revealedKey={state.revealedManageKey}
         submitDisabled={state.isManageDisabled}
         target={state.manageTarget}
         onModelGrantModeChange={state.actions.updateManageModelGrantMode}
         onModelToggle={state.actions.toggleManageModelKey}
         onOpenChange={(open) => (!open ? state.actions.closeManageDialog() : undefined)}
+        onReveal={state.actions.handleRevealManageApiKey}
         onRevoke={state.actions.handleRevokeApiKey}
+        onCopy={state.actions.handleCopy}
         onSubmit={state.actions.handleUpdateApiKey}
       />
     </div>

--- a/crates/admin-ui/web/src/routes/api-keys/-components.tsx
+++ b/crates/admin-ui/web/src/routes/api-keys/-components.tsx
@@ -416,24 +416,30 @@ export function ManageApiKeyDialog({
   isPending,
   modelOptions,
   open,
+  revealedKey,
   submitDisabled,
   target,
   onModelGrantModeChange,
   onModelToggle,
   onOpenChange,
+  onReveal,
   onRevoke,
+  onCopy,
   onSubmit,
 }: {
   form: UpdateApiKeyInput
   isPending: boolean
   modelOptions: ApiKeyModelOptionView[]
   open: boolean
+  revealedKey: string | null
   submitDisabled: boolean
   target: ApiKeyView | null
   onModelGrantModeChange: (mode: UpdateApiKeyInput['model_grant_mode']) => void
   onModelToggle: (modelKey: string, checked: boolean) => void
   onOpenChange: (open: boolean) => void
+  onReveal: () => void | Promise<void>
   onRevoke: () => void | Promise<void>
+  onCopy: (value: string, successMessage: string) => void | Promise<void>
   onSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>
 }) {
   return (
@@ -488,6 +494,55 @@ export function ManageApiKeyDialog({
                   </div>
                 </dl>
               </section>
+
+              {target.owner_kind === 'service_account' && target.status === 'active' ? (
+                <section
+                  data-testid="manage-api-key-secret"
+                  className="flex flex-col gap-3 border-b border-[color:var(--color-border)] pb-4"
+                >
+                  <div className="flex flex-col gap-1">
+                    <h3 className="text-sm font-semibold text-[var(--color-text)]">
+                      Credential secret
+                    </h3>
+                    <p className="text-sm text-[var(--color-text-muted)]">
+                      Service-account-owned keys can be revealed for this owner scope.
+                    </p>
+                  </div>
+
+                  {revealedKey ? (
+                    <div className="flex flex-col gap-3">
+                      <div className="rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-3">
+                        <p
+                          data-testid="manage-api-key-raw-key"
+                          className="font-mono text-xs break-all text-[var(--color-text)]"
+                        >
+                          {revealedKey}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          onClick={() => onCopy(revealedKey, 'API key copied')}
+                        >
+                          Copy API key
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={onReveal}
+                        disabled={isPending}
+                      >
+                        {isPending ? 'Revealing...' : 'Reveal API key'}
+                      </Button>
+                    </div>
+                  )}
+                </section>
+              ) : null}
 
               {target.status === 'revoked' ? (
                 <Alert>

--- a/crates/admin-ui/web/src/routes/api-keys/-components.tsx
+++ b/crates/admin-ui/web/src/routes/api-keys/-components.tsx
@@ -450,7 +450,10 @@ export function ManageApiKeyDialog({
         {target ? (
           <form className="flex min-h-0 flex-1 flex-col gap-6" onSubmit={onSubmit}>
             <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pr-1">
-              <section className="flex flex-col gap-3 rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface-muted)] p-4">
+              <section
+                data-testid="manage-api-key-summary"
+                className="flex flex-col gap-3 border-y border-[color:var(--color-border)] py-4"
+              >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex min-w-0 flex-col gap-1">
                     <p className="font-semibold text-[var(--color-text)]">{target.name}</p>
@@ -463,20 +466,23 @@ export function ManageApiKeyDialog({
                   </Badge>
                 </div>
 
-                <dl className="grid gap-3 text-sm sm:grid-cols-3">
-                  <div className="flex flex-col gap-1">
+                <dl
+                  data-testid="manage-api-key-metadata"
+                  className="flex flex-col divide-y divide-[color:var(--color-border)] text-sm"
+                >
+                  <div className="grid gap-1 py-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:items-start">
                     <dt className="text-[var(--color-text-soft)]">Owner</dt>
-                    <dd className="text-[var(--color-text)]">{formatOwner(target)}</dd>
+                    <dd className="min-w-0 text-[var(--color-text)]">{formatOwner(target)}</dd>
                   </div>
-                  <div className="flex flex-col gap-1">
+                  <div className="grid gap-1 py-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:items-start">
                     <dt className="text-[var(--color-text-soft)]">Created</dt>
-                    <dd className="text-[var(--color-text)]">
+                    <dd className="min-w-0 text-[var(--color-text)]">
                       {formatCreatedAt(target.created_at)}
                     </dd>
                   </div>
-                  <div className="flex flex-col gap-1">
+                  <div className="grid gap-1 py-2 sm:grid-cols-[7rem_minmax(0,1fr)] sm:items-start">
                     <dt className="text-[var(--color-text-soft)]">Last used</dt>
-                    <dd className="text-[var(--color-text)]">
+                    <dd className="min-w-0 text-[var(--color-text)]">
                       {formatLastUsedAt(target.last_used_at)}
                     </dd>
                   </div>

--- a/crates/admin-ui/web/src/routes/api-keys/-use-api-keys-page.ts
+++ b/crates/admin-ui/web/src/routes/api-keys/-use-api-keys-page.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 
 import {
   createGatewayApiKey,
+  revealGatewayApiKeySecret,
   revokeGatewayApiKey,
   updateGatewayApiKey,
 } from '@/server/admin-data.functions'
@@ -45,6 +46,7 @@ export function useApiKeysPageState({
   const [manageForm, setManageForm] = useState<UpdateApiKeyInput>(initialManageForm)
   const [createdResult, setCreatedResult] = useState<CreateApiKeyResult | null>(null)
   const [manageDialog, setManageDialog] = useState<ManageDialogState>({ mode: 'closed' })
+  const [revealedManageKey, setRevealedManageKey] = useState<string | null>(null)
   const [isMutating, setIsMutating] = useState(false)
   const handledFocusedApiKeyId = useRef<string | null>(null)
 
@@ -93,11 +95,13 @@ export function useApiKeysPageState({
       model_grant_mode: target?.model_grant_mode ?? 'explicit',
       model_keys: target?.model_keys ?? [],
     })
+    setRevealedManageKey(null)
     setManageDialog({ mode: 'open', apiKeyId })
   }
 
   function closeManageDialog() {
     setManageForm(initialManageForm)
+    setRevealedManageKey(null)
     setManageDialog({ mode: 'closed' })
   }
 
@@ -260,6 +264,25 @@ export function useApiKeysPageState({
     }
   }
 
+  async function handleRevealManageApiKey() {
+    if (manageDialog.mode !== 'open' || !manageTarget || manageTarget.status !== 'active') {
+      return
+    }
+
+    setIsMutating(true)
+    try {
+      const response = await revealGatewayApiKeySecret({
+        data: { apiKeyId: manageDialog.apiKeyId },
+      })
+      setRevealedManageKey(response.data.raw_key)
+      toast.success('API key revealed')
+    } catch (error) {
+      toast.error(getErrorMessage(error))
+    } finally {
+      setIsMutating(false)
+    }
+  }
+
   async function handleCopy(value: string, successMessage: string) {
     try {
       await navigator.clipboard.writeText(value)
@@ -279,6 +302,7 @@ export function useApiKeysPageState({
     manageDialog,
     manageForm,
     manageTarget,
+    revealedManageKey,
     selectedOwnerLabel,
     actions: {
       closeCreateDialog,
@@ -286,6 +310,7 @@ export function useApiKeysPageState({
       handleCopy,
       handleCreateApiKey,
       handleRevokeApiKey,
+      handleRevealManageApiKey,
       handleUpdateApiKey,
       openCreateDialog,
       openManageDialog,

--- a/crates/admin-ui/web/src/server/admin-data.functions.ts
+++ b/crates/admin-ui/web/src/server/admin-data.functions.ts
@@ -47,6 +47,7 @@ import {
   listOidcProviders,
   loginWithPassword,
   logoutCurrentSession,
+  revealApiKeySecret,
   removeTeamMember,
   revokeApiKey,
   refreshMcpServerDiscovery,
@@ -82,6 +83,12 @@ export const createGatewayApiKey = createServerFn({ method: 'POST' }).handler(
 export const revokeGatewayApiKey = createServerFn({ method: 'POST' }).handler(
   async ({ data }: { data: { apiKeyId: string } }) => {
     return revokeApiKey(data.apiKeyId)
+  },
+)
+
+export const revealGatewayApiKeySecret = createServerFn({ method: 'POST' }).handler(
+  async ({ data }: { data: { apiKeyId: string } }) => {
+    return revealApiKeySecret(data.apiKeyId)
   },
 )
 

--- a/crates/admin-ui/web/src/server/admin-data.server.ts
+++ b/crates/admin-ui/web/src/server/admin-data.server.ts
@@ -62,6 +62,7 @@ import type {
   CreateReviewAgentRepositoryInput,
   UpdateReviewAgentRepositoryInput,
   RevokeApiKeyResult,
+  RevealApiKeySecretResponse,
   ServiceAccountsPayload,
   SpendBudgetsView,
   SpendOwnerKind,
@@ -117,6 +118,17 @@ export async function revokeApiKey(apiKeyId: string): Promise<ApiEnvelope<Revoke
     {
       method: 'POST',
     },
+  )
+}
+
+export async function revealApiKeySecret(
+  apiKeyId: string,
+): Promise<ApiEnvelope<RevealApiKeySecretResponse>> {
+  const client = createGatewayApiClient()
+  return unwrapGatewayResponse(
+    await client.POST('/api/v1/admin/api-keys/{api_key_id}/secret/reveal', {
+      params: { path: { api_key_id: apiKeyId } },
+    }),
   )
 }
 

--- a/crates/admin-ui/web/src/styles/globals.css
+++ b/crates/admin-ui/web/src/styles/globals.css
@@ -74,6 +74,7 @@
   --sidebar-accent-foreground: oklch(0.205 0.018 238);
   --sidebar-border: oklch(0.91 0.01 226);
   --sidebar-ring: oklch(0.572 0.112 230.199);
+  --surface-muted: oklch(0.97 0.006 226);
 }
 
 .dark {
@@ -109,6 +110,7 @@
   --sidebar-accent-foreground: oklch(0.985 0.004 226);
   --sidebar-border: oklch(0.985 0.004 226 / 10%);
   --sidebar-ring: oklch(0.572 0.112 230.199);
+  --surface-muted: oklch(0.245 0.018 238);
 }
 
 :root,
@@ -118,7 +120,7 @@
   --color-bg: var(--background);
   --color-bg-accent: color-mix(in oklch, var(--background) 74%, var(--primary) 26%);
   --color-surface: color-mix(in oklch, var(--card) 90%, var(--background) 10%);
-  --color-surface-muted: color-mix(in oklch, var(--muted) 86%, var(--background) 14%);
+  --color-surface-muted: var(--surface-muted);
   --color-surface-strong: color-mix(in oklch, var(--card) 76%, var(--foreground) 24%);
   --color-surface-contrast: color-mix(in oklch, var(--secondary) 82%, var(--primary) 18%);
   --color-card: var(--card);

--- a/crates/admin-ui/web/src/test/routes/api-keys-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/api-keys-route.test.tsx
@@ -383,6 +383,19 @@ describe('ApiKeysPage', () => {
     expect(within(dialog).getByText('2026-03-14')).toBeInTheDocument()
     expect(within(dialog).getByText('2026-03-18 09:15')).toBeInTheDocument()
 
+    const summary = within(dialog).getByTestId('manage-api-key-summary')
+    expect(summary).toHaveClass('border-y')
+    expect(summary).not.toHaveClass('rounded-lg')
+    expect(summary).not.toHaveClass('bg-[color:var(--color-surface-muted)]')
+
+    const metadata = within(dialog).getByTestId('manage-api-key-metadata')
+    expect(metadata).toHaveClass('divide-y')
+    expect(within(metadata).getByText('Owner').closest('div')).toHaveTextContent('Jane Admin')
+    expect(within(metadata).getByText('Created').closest('div')).toHaveTextContent('2026-03-14')
+    expect(within(metadata).getByText('Last used').closest('div')).toHaveTextContent(
+      '2026-03-18 09:15',
+    )
+
     const saveButton = within(dialog).getByRole('button', { name: 'Save access' })
     expect(saveButton).toBeDisabled()
 

--- a/crates/admin-ui/web/src/test/routes/api-keys-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/api-keys-route.test.tsx
@@ -19,6 +19,7 @@ const routerMock = {
 }
 
 const createGatewayApiKeyMock = vi.fn()
+const revealGatewayApiKeySecretMock = vi.fn()
 const revokeGatewayApiKeyMock = vi.fn()
 const updateGatewayApiKeyMock = vi.fn()
 
@@ -37,6 +38,7 @@ vi.mock('sonner', () => ({
 vi.mock('@/server/admin-data.functions', () => ({
   createGatewayApiKey: (...args: unknown[]) => createGatewayApiKeyMock(...args),
   getApiKeys: vi.fn(),
+  revealGatewayApiKeySecret: (...args: unknown[]) => revealGatewayApiKeySecretMock(...args),
   revokeGatewayApiKey: (...args: unknown[]) => revokeGatewayApiKeyMock(...args),
   updateGatewayApiKey: (...args: unknown[]) => updateGatewayApiKeyMock(...args),
 }))
@@ -113,6 +115,7 @@ describe('ApiKeysPage', () => {
     routeMock.useSearch.mockReturnValue({ api_key_id: undefined })
     routerMock.invalidate.mockClear()
     createGatewayApiKeyMock.mockReset()
+    revealGatewayApiKeySecretMock.mockReset()
     revokeGatewayApiKeyMock.mockReset()
     updateGatewayApiKeyMock.mockReset()
     Object.assign(navigator, {
@@ -414,6 +417,57 @@ describe('ApiKeysPage', () => {
       },
     })
     expect(routerMock.invalidate).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveals and copies retrievable service-account-owned API keys from the manage dialog', async () => {
+    revealGatewayApiKeySecretMock.mockResolvedValue({
+      data: { raw_key: 'gwk_service_account.secret-value' },
+    })
+    routeMock.useLoaderData.mockReturnValue({
+      data: {
+        ...basePayload,
+        items: [
+          {
+            ...basePayload.items[0],
+            owner_kind: 'service_account',
+            owner_id: 'service_account_1',
+            owner_name: 'Deploy Bot',
+            owner_email: null,
+            owner_team_key: 'core-platform',
+            owner_service_account_key: 'deploy-bot',
+            owner_service_account_team_id: 'team_1',
+            owner_service_account_team_key: 'core-platform',
+          },
+        ],
+      },
+    })
+
+    const { ApiKeysPage } = await import('@/routes/api-keys')
+
+    render(<ApiKeysPage />)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Manage' })[0])
+
+    const dialog = screen.getByRole('dialog', { name: 'Manage API key' })
+    expect(within(dialog).getByText('Credential secret')).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Reveal API key' }))
+
+    await waitFor(() => expect(revealGatewayApiKeySecretMock).toHaveBeenCalledTimes(1))
+    expect(revealGatewayApiKeySecretMock).toHaveBeenCalledWith({
+      data: { apiKeyId: 'api_key_1' },
+    })
+    expect(await within(dialog).findByTestId('manage-api-key-raw-key')).toHaveTextContent(
+      'gwk_service_account.secret-value',
+    )
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Copy API key' }))
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'gwk_service_account.secret-value',
+      ),
+    )
   })
 
   it('revokes from the manage dialog lifecycle section', async () => {

--- a/crates/gateway-core/src/budgets.rs
+++ b/crates/gateway-core/src/budgets.rs
@@ -33,6 +33,97 @@ impl BudgetScopeKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetSourceKind {
+    Manual,
+    ConfigUserOverride,
+    ConfigUserDefault,
+    ConfigUserModelDefault,
+}
+
+impl BudgetSourceKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::ConfigUserOverride => "config_user_override",
+            Self::ConfigUserDefault => "config_user_default",
+            Self::ConfigUserModelDefault => "config_user_model_default",
+        }
+    }
+
+    #[must_use]
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "manual" => Some(Self::Manual),
+            "config_user_override" => Some(Self::ConfigUserOverride),
+            "config_user_default" => Some(Self::ConfigUserDefault),
+            "config_user_model_default" => Some(Self::ConfigUserModelDefault),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BudgetSource {
+    pub kind: BudgetSourceKind,
+    #[serde(default)]
+    pub key: Option<String>,
+}
+
+impl BudgetSource {
+    #[must_use]
+    pub fn manual() -> Self {
+        Self {
+            kind: BudgetSourceKind::Manual,
+            key: None,
+        }
+    }
+
+    #[must_use]
+    pub fn manual_deactivated() -> Self {
+        Self {
+            kind: BudgetSourceKind::Manual,
+            key: Some("deactivated".to_string()),
+        }
+    }
+
+    #[must_use]
+    pub fn is_manual_deactivation(&self) -> bool {
+        self.kind == BudgetSourceKind::Manual && self.key.as_deref() == Some("deactivated")
+    }
+
+    #[must_use]
+    pub fn config_user_override(email_normalized: impl Into<String>) -> Self {
+        Self {
+            kind: BudgetSourceKind::ConfigUserOverride,
+            key: Some(email_normalized.into()),
+        }
+    }
+
+    #[must_use]
+    pub fn config_user_default() -> Self {
+        Self {
+            kind: BudgetSourceKind::ConfigUserDefault,
+            key: Some("budgets.users.default".to_string()),
+        }
+    }
+
+    #[must_use]
+    pub fn config_user_model_default(model_key: impl Into<String>) -> Self {
+        Self {
+            kind: BudgetSourceKind::ConfigUserModelDefault,
+            key: Some(format!("budgets.users.model_defaults:{}", model_key.into())),
+        }
+    }
+
+    #[must_use]
+    pub fn matches(&self, other: &Self) -> bool {
+        self.kind == other.kind && self.key.as_deref() == other.key.as_deref()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum BudgetModelSelector {
     Model { model_id: Uuid },
@@ -229,6 +320,7 @@ pub struct BudgetRecord {
     pub scope: BudgetScope,
     pub scope_key: String,
     pub settings: BudgetSettings,
+    pub source: BudgetSource,
     pub is_active: bool,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,

--- a/crates/gateway-core/src/domain.rs
+++ b/crates/gateway-core/src/domain.rs
@@ -2620,6 +2620,21 @@ pub struct SeedBudget {
     pub timezone: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SeedHumanBudgetDefaults {
+    #[serde(default)]
+    pub default_user_budget: Option<SeedBudget>,
+    #[serde(default)]
+    pub model_defaults: Vec<SeedUserModelBudgetDefault>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeedUserModelBudgetDefault {
+    pub model_key: String,
+    pub model_id: Uuid,
+    pub budget: SeedBudget,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SeedTeam {
     pub team_key: String,

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -11,7 +11,8 @@ pub use auth::{
     AuthenticatedApiKey, ParsedGatewayApiKey, extract_bearer_token, parse_gateway_api_key,
 };
 pub use budgets::{
-    BudgetModelSelector, BudgetRecord, BudgetScope, BudgetScopeKind, BudgetSettings,
+    BudgetModelSelector, BudgetRecord, BudgetScope, BudgetScopeKind, BudgetSettings, BudgetSource,
+    BudgetSourceKind,
 };
 pub use domain::{
     ApiKeyModelGrantMode, ApiKeyOwnerKind, ApiKeyRecord, ApiKeySecretMaterialRecord,
@@ -50,16 +51,17 @@ pub use domain::{
     ReviewAgentRepositoryRecord, ReviewAgentRepositoryStatus, ReviewAgentRunRecord,
     ReviewAgentRunStatus, ReviewAgentSettings, RouteCompatibility, SYSTEM_BOOTSTRAP_ADMIN_EMAIL,
     SYSTEM_BOOTSTRAP_ADMIN_USER_ID, SeedApiKey, SeedApiKeySecretMaterial, SeedBudget,
-    SeedManagedServiceAccountApiKey, SeedModel, SeedModelRoute, SeedOauthProvider,
-    SeedOidcProvider, SeedProvider, SeedServiceAccount, SeedTeam, SeedUser, SeedUserMembership,
-    ServiceAccountRecord, ServiceAccountStatus, SpendDailyAggregateRecord,
-    SpendModelAggregateRecord, SpendOwnerAggregateRecord, TeamMembershipRecord, TeamRecord,
-    UpdateExternalMcpServerRecord, UpdateMcpToolsetRecord, UpdateReviewAgentRepositoryRecord,
-    UpdateReviewAgentRunRecord, UpsertExternalMcpToolRecord, UpsertMcpToolGrantRecord,
-    UpsertMcpUpstreamCredentialBindingRecord, UpsertReviewAgentPullRequestRecord,
-    UsageLeaderboardBucketRecord, UsageLeaderboardUserRecord, UsageLedgerRecord,
-    UsagePricingStatus, UserOauthAuthRecord, UserOidcAuthRecord, UserPasswordAuthRecord,
-    UserRecord, UserSessionRecord, UserStatus, VERTEX_TEXT_EMBEDDING_MODEL_IDS, budget_window_utc,
+    SeedHumanBudgetDefaults, SeedManagedServiceAccountApiKey, SeedModel, SeedModelRoute,
+    SeedOauthProvider, SeedOidcProvider, SeedProvider, SeedServiceAccount, SeedTeam, SeedUser,
+    SeedUserMembership, SeedUserModelBudgetDefault, ServiceAccountRecord, ServiceAccountStatus,
+    SpendDailyAggregateRecord, SpendModelAggregateRecord, SpendOwnerAggregateRecord,
+    TeamMembershipRecord, TeamRecord, UpdateExternalMcpServerRecord, UpdateMcpToolsetRecord,
+    UpdateReviewAgentRepositoryRecord, UpdateReviewAgentRunRecord, UpsertExternalMcpToolRecord,
+    UpsertMcpToolGrantRecord, UpsertMcpUpstreamCredentialBindingRecord,
+    UpsertReviewAgentPullRequestRecord, UsageLeaderboardBucketRecord, UsageLeaderboardUserRecord,
+    UsageLedgerRecord, UsagePricingStatus, UserOauthAuthRecord, UserOidcAuthRecord,
+    UserPasswordAuthRecord, UserRecord, UserSessionRecord, UserStatus,
+    VERTEX_TEXT_EMBEDDING_MODEL_IDS, budget_window_utc,
     is_supported_vertex_text_embedding_model_id, is_supported_vertex_text_embedding_upstream_model,
     vertex_route_capabilities_for_upstream_model, vertex_text_embedding_capabilities,
 };

--- a/crates/gateway-core/src/traits.rs
+++ b/crates/gateway-core/src/traits.rs
@@ -8,7 +8,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::{
-    budgets::{BudgetRecord, BudgetScope, BudgetScopeKind, BudgetSettings},
+    budgets::{BudgetRecord, BudgetScope, BudgetScopeKind, BudgetSettings, BudgetSource},
     domain::{
         ApiKeyModelGrantMode, ApiKeyRecord, BudgetAlertDeliveryRecord, BudgetAlertDispatchTask,
         BudgetAlertHistoryPage, BudgetAlertHistoryQuery, BudgetAlertRecord,
@@ -327,6 +327,10 @@ pub trait BudgetRepository: Send + Sync {
         &self,
         scope: &BudgetScope,
     ) -> Result<Option<BudgetRecord>, StoreError>;
+    async fn get_latest_budget_by_scope(
+        &self,
+        scope: &BudgetScope,
+    ) -> Result<Option<BudgetRecord>, StoreError>;
     async fn list_active_budgets(
         &self,
         scope_kind: Option<BudgetScopeKind>,
@@ -340,6 +344,13 @@ pub trait BudgetRepository: Send + Sync {
         &self,
         scope: &BudgetScope,
         settings: &BudgetSettings,
+        updated_at: OffsetDateTime,
+    ) -> Result<BudgetRecord, StoreError>;
+    async fn upsert_active_budget_with_source(
+        &self,
+        scope: &BudgetScope,
+        settings: &BudgetSettings,
+        source: &BudgetSource,
         updated_at: OffsetDateTime,
     ) -> Result<BudgetRecord, StoreError>;
     async fn deactivate_active_budget(

--- a/crates/gateway-core/src/traits.rs
+++ b/crates/gateway-core/src/traits.rs
@@ -353,9 +353,23 @@ pub trait BudgetRepository: Send + Sync {
         source: &BudgetSource,
         updated_at: OffsetDateTime,
     ) -> Result<BudgetRecord, StoreError>;
+    async fn upsert_active_budget_with_source_guard(
+        &self,
+        scope: &BudgetScope,
+        settings: &BudgetSettings,
+        source: &BudgetSource,
+        expected_current_source: Option<&BudgetSource>,
+        updated_at: OffsetDateTime,
+    ) -> Result<Option<BudgetRecord>, StoreError>;
     async fn deactivate_active_budget(
         &self,
         scope: &BudgetScope,
+        updated_at: OffsetDateTime,
+    ) -> Result<bool, StoreError>;
+    async fn deactivate_active_budget_by_source(
+        &self,
+        scope: &BudgetScope,
+        source: &BudgetSource,
         updated_at: OffsetDateTime,
     ) -> Result<bool, StoreError>;
     async fn get_usage_ledger_by_request_and_scope(

--- a/crates/gateway-service/src/budget_guard.rs
+++ b/crates/gateway-service/src/budget_guard.rs
@@ -171,8 +171,8 @@ mod tests {
     use async_trait::async_trait;
     use gateway_core::{
         ApiKeyModelGrantMode, ApiKeyOwnerKind, AuthenticatedApiKey, BudgetCadence, BudgetRecord,
-        BudgetRepository, BudgetScope, BudgetSettings, Money4, StoreError, UsageLedgerRecord,
-        UsagePricingStatus,
+        BudgetRepository, BudgetScope, BudgetSettings, BudgetSource, Money4, StoreError,
+        UsageLedgerRecord, UsagePricingStatus,
     };
     use serde_json::json;
     use time::OffsetDateTime;
@@ -218,7 +218,7 @@ mod tests {
             &self,
             _scope: &BudgetScope,
             _settings: &BudgetSettings,
-            _source: &gateway_core::BudgetSource,
+            _source: &BudgetSource,
             _updated_at: OffsetDateTime,
         ) -> Result<BudgetRecord, StoreError> {
             self.active_budget
@@ -226,9 +226,29 @@ mod tests {
                 .ok_or_else(|| StoreError::NotFound("budget missing".to_string()))
         }
 
+        async fn upsert_active_budget_with_source_guard(
+            &self,
+            _scope: &BudgetScope,
+            _settings: &BudgetSettings,
+            _source: &BudgetSource,
+            _expected_current_source: Option<&BudgetSource>,
+            _updated_at: OffsetDateTime,
+        ) -> Result<Option<BudgetRecord>, StoreError> {
+            Ok(self.active_budget.clone())
+        }
+
         async fn deactivate_active_budget(
             &self,
             _scope: &BudgetScope,
+            _updated_at: OffsetDateTime,
+        ) -> Result<bool, StoreError> {
+            Ok(false)
+        }
+
+        async fn deactivate_active_budget_by_source(
+            &self,
+            _scope: &BudgetScope,
+            _source: &BudgetSource,
             _updated_at: OffsetDateTime,
         ) -> Result<bool, StoreError> {
             Ok(false)

--- a/crates/gateway-service/src/budget_guard.rs
+++ b/crates/gateway-service/src/budget_guard.rs
@@ -196,10 +196,29 @@ mod tests {
             Ok(self.active_budget.clone())
         }
 
+        async fn get_latest_budget_by_scope(
+            &self,
+            _scope: &BudgetScope,
+        ) -> Result<Option<BudgetRecord>, StoreError> {
+            Ok(self.active_budget.clone())
+        }
+
         async fn upsert_active_budget(
             &self,
             _scope: &BudgetScope,
             _settings: &BudgetSettings,
+            _updated_at: OffsetDateTime,
+        ) -> Result<BudgetRecord, StoreError> {
+            self.active_budget
+                .clone()
+                .ok_or_else(|| StoreError::NotFound("budget missing".to_string()))
+        }
+
+        async fn upsert_active_budget_with_source(
+            &self,
+            _scope: &BudgetScope,
+            _settings: &BudgetSettings,
+            _source: &gateway_core::BudgetSource,
             _updated_at: OffsetDateTime,
         ) -> Result<BudgetRecord, StoreError> {
             self.active_budget
@@ -282,6 +301,7 @@ mod tests {
                 hard_limit,
                 timezone: "UTC".to_string(),
             },
+            source: gateway_core::BudgetSource::manual(),
             is_active: true,
             created_at: now,
             updated_at: now,

--- a/crates/gateway-service/src/service.rs
+++ b/crates/gateway-service/src/service.rs
@@ -701,10 +701,10 @@ mod tests {
     use async_trait::async_trait;
     use gateway_core::{
         ApiKeyModelGrantMode, ApiKeyOwnerKind, ApiKeyRecord, ApiKeyRepository, AuthenticatedApiKey,
-        BudgetAlertRepository, BudgetRecord, BudgetRepository, BudgetScope, GatewayModel,
-        IdentityRepository, McpToolInvocationDetail, McpToolInvocationPage,
-        McpToolInvocationPayloadRecord, McpToolInvocationQuery, McpToolInvocationRecord,
-        McpToolInvocationRepository, ModelRepository, ModelRoute, Money4,
+        BudgetAlertRepository, BudgetRecord, BudgetRepository, BudgetScope, BudgetSettings,
+        BudgetSource, GatewayModel, IdentityRepository, McpToolInvocationDetail,
+        McpToolInvocationPage, McpToolInvocationPayloadRecord, McpToolInvocationQuery,
+        McpToolInvocationRecord, McpToolInvocationRepository, ModelRepository, ModelRoute, Money4,
         PricingCatalogCacheRecord, PricingCatalogRepository, ProviderCapabilities,
         ProviderConnection, ProviderRepository, RequestLogDetail, RequestLogPage,
         RequestLogPayloadRecord, RequestLogPurgeResult, RequestLogQuery, RequestLogRecord,
@@ -756,14 +756,34 @@ mod tests {
             Ok(None)
         }
 
+        async fn get_latest_budget_by_scope(
+            &self,
+            _scope: &BudgetScope,
+        ) -> Result<Option<BudgetRecord>, StoreError> {
+            Ok(None)
+        }
+
         async fn upsert_active_budget(
             &self,
             _scope: &BudgetScope,
-            _settings: &gateway_core::BudgetSettings,
+            _settings: &BudgetSettings,
             _updated_at: OffsetDateTime,
         ) -> Result<BudgetRecord, StoreError> {
             Err(StoreError::Unexpected(
                 "upsert_active_budget is not used by usage accounting tests".to_string(),
+            ))
+        }
+
+        async fn upsert_active_budget_with_source(
+            &self,
+            _scope: &BudgetScope,
+            _settings: &BudgetSettings,
+            _source: &BudgetSource,
+            _updated_at: OffsetDateTime,
+        ) -> Result<BudgetRecord, StoreError> {
+            Err(StoreError::Unexpected(
+                "upsert_active_budget_with_source is not used by usage accounting tests"
+                    .to_string(),
             ))
         }
 

--- a/crates/gateway-service/src/service.rs
+++ b/crates/gateway-service/src/service.rs
@@ -787,9 +787,29 @@ mod tests {
             ))
         }
 
+        async fn upsert_active_budget_with_source_guard(
+            &self,
+            _scope: &BudgetScope,
+            _settings: &BudgetSettings,
+            _source: &BudgetSource,
+            _expected_current_source: Option<&BudgetSource>,
+            _updated_at: OffsetDateTime,
+        ) -> Result<Option<BudgetRecord>, StoreError> {
+            Ok(None)
+        }
+
         async fn deactivate_active_budget(
             &self,
             _scope: &BudgetScope,
+            _updated_at: OffsetDateTime,
+        ) -> Result<bool, StoreError> {
+            Ok(false)
+        }
+
+        async fn deactivate_active_budget_by_source(
+            &self,
+            _scope: &BudgetScope,
+            _source: &BudgetSource,
             _updated_at: OffsetDateTime,
         ) -> Result<bool, StoreError> {
             Ok(false)

--- a/crates/gateway-store/migrations/V38__budget_sources.sql
+++ b/crates/gateway-store/migrations/V38__budget_sources.sql
@@ -1,0 +1,9 @@
+ALTER TABLE budgets
+  ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'manual'
+  CHECK (source_kind IN ('manual', 'config_user_override', 'config_user_default', 'config_user_model_default'));
+
+ALTER TABLE budgets
+  ADD COLUMN source_key TEXT;
+
+CREATE INDEX IF NOT EXISTS budgets_source_idx
+  ON budgets (source_kind, source_key, is_active);

--- a/crates/gateway-store/migrations/V38__budget_sources.sql
+++ b/crates/gateway-store/migrations/V38__budget_sources.sql
@@ -5,5 +5,11 @@ ALTER TABLE budgets
 ALTER TABLE budgets
   ADD COLUMN source_key TEXT;
 
+UPDATE budgets
+SET source_key = 'deactivated'
+WHERE is_active = 0
+  AND source_kind = 'manual'
+  AND source_key IS NULL;
+
 CREATE INDEX IF NOT EXISTS budgets_source_idx
   ON budgets (source_kind, source_key, is_active);

--- a/crates/gateway-store/migrations/postgres/V38__budget_sources.sql
+++ b/crates/gateway-store/migrations/postgres/V38__budget_sources.sql
@@ -4,6 +4,12 @@ ALTER TABLE budgets
 ALTER TABLE budgets
   ADD COLUMN source_key TEXT;
 
+UPDATE budgets
+SET source_key = 'deactivated'
+WHERE is_active = 0
+  AND source_kind = 'manual'
+  AND source_key IS NULL;
+
 ALTER TABLE budgets
   ADD CONSTRAINT budgets_source_kind_check
   CHECK (source_kind IN ('manual', 'config_user_override', 'config_user_default', 'config_user_model_default'));

--- a/crates/gateway-store/migrations/postgres/V38__budget_sources.sql
+++ b/crates/gateway-store/migrations/postgres/V38__budget_sources.sql
@@ -1,0 +1,12 @@
+ALTER TABLE budgets
+  ADD COLUMN source_kind TEXT NOT NULL DEFAULT 'manual';
+
+ALTER TABLE budgets
+  ADD COLUMN source_key TEXT;
+
+ALTER TABLE budgets
+  ADD CONSTRAINT budgets_source_kind_check
+  CHECK (source_kind IN ('manual', 'config_user_override', 'config_user_default', 'config_user_model_default'));
+
+CREATE INDEX IF NOT EXISTS budgets_source_idx
+  ON budgets (source_kind, source_key, is_active);

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -37,12 +37,12 @@ mod tests {
         ApiKeyOwnerKind, ApiKeyRepository, ApiKeySecretStorageKind, ApiKeyStatus, AuthMode,
         BudgetAlertChannel, BudgetAlertDeliveryRecord, BudgetAlertDeliveryStatus,
         BudgetAlertHistoryQuery, BudgetAlertRecord, BudgetAlertRepository, BudgetCadence,
-        BudgetRepository, BudgetScope, BudgetSettings, ExternalMcpAuthMode,
-        ExternalMcpDiscoveryRunRecord, ExternalMcpDiscoveryStatus, ExternalMcpServerStatus,
-        ExternalMcpTransport, GlobalRole, IdentityRepository, ManagedApiKeySource,
-        McpRegistryRepository, McpToolInvocationPayloadRecord, McpToolInvocationQuery,
-        McpToolInvocationRecord, McpToolInvocationRepository, McpToolInvocationStatus,
-        McpToolPolicyResult, McpUpstreamCredentialMaterialKind,
+        BudgetModelSelector, BudgetRepository, BudgetScope, BudgetSettings, BudgetSourceKind,
+        ExternalMcpAuthMode, ExternalMcpDiscoveryRunRecord, ExternalMcpDiscoveryStatus,
+        ExternalMcpServerStatus, ExternalMcpTransport, GlobalRole, IdentityRepository,
+        ManagedApiKeySource, McpRegistryRepository, McpToolInvocationPayloadRecord,
+        McpToolInvocationQuery, McpToolInvocationRecord, McpToolInvocationRepository,
+        McpToolInvocationStatus, McpToolPolicyResult, McpUpstreamCredentialMaterialKind,
         McpUpstreamCredentialOwnerScopeKind, McpUpstreamCredentialRepository,
         McpUpstreamSecretStorageKind, MembershipRole, ModelPricingRecord, ModelRepository, Money4,
         NewExternalMcpServerRecord, NewReviewAgentRepositoryRecord, NewReviewAgentRunRecord,
@@ -54,9 +54,10 @@ mod tests {
         RequestTag, RequestTags, RequestToolCardinality, ReviewAgentProvider,
         ReviewAgentPullRequestState, ReviewAgentRepository, ReviewAgentRepositoryStatus,
         ReviewAgentRunStatus, ReviewAgentSettings, RouteCompatibility, SeedApiKey,
-        SeedApiKeySecretMaterial, SeedBudget, SeedManagedServiceAccountApiKey, SeedModel,
-        SeedModelRoute, SeedOauthProvider, SeedProvider, SeedServiceAccount, SeedTeam, SeedUser,
-        SeedUserMembership, ServiceAccountStatus, StoreError, StoreHealth,
+        SeedApiKeySecretMaterial, SeedBudget, SeedHumanBudgetDefaults,
+        SeedManagedServiceAccountApiKey, SeedModel, SeedModelRoute, SeedOauthProvider,
+        SeedProvider, SeedServiceAccount, SeedTeam, SeedUser, SeedUserMembership,
+        SeedUserModelBudgetDefault, ServiceAccountStatus, StoreError, StoreHealth,
         UpdateExternalMcpServerRecord, UpdateReviewAgentRunRecord, UpsertExternalMcpToolRecord,
         UpsertMcpUpstreamCredentialBindingRecord, UpsertReviewAgentPullRequestRecord,
         UsageLedgerRecord, UsagePricingStatus, UserStatus,
@@ -5558,13 +5559,159 @@ mod tests {
             .expect("ops team exists");
         assert_eq!(refreshed_platform.team_name, "Platform Engineering");
         let _ops_team_id = ops_team.team_id;
-        assert!(
+        assert_eq!(
             store
                 .get_active_budget_by_scope(&BudgetScope::User {
                     user_id: user.user_id,
                 })
                 .await
                 .expect("user budget after reseed")
+                .expect("user budget remains")
+                .settings
+                .amount_usd,
+            Money4::from_scaled(750_000)
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn libsql_human_budget_defaults_inherit_until_manual_override_or_deactivation() {
+        let tmp = tempdir().expect("tempdir");
+        let db_path = tmp.path().join("gateway.db");
+        run_migrations(&db_path).await.expect("migrations");
+
+        let store = LibsqlStore::new_local(db_path.to_str().expect("db path"))
+            .await
+            .expect("store");
+        let users = vec![SeedUser {
+            name: "Member".to_string(),
+            email: "member@example.com".to_string(),
+            email_normalized: "member@example.com".to_string(),
+            global_role: GlobalRole::User,
+            auth_mode: AuthMode::Password,
+            request_logging_enabled: true,
+            oidc_provider_key: None,
+            oauth_provider_key: None,
+            membership: None,
+            budget: None,
+        }];
+        let models = vec![SeedModel {
+            model_key: "fable-5".to_string(),
+            alias_target_model_key: None,
+            description: None,
+            tags: Vec::new(),
+            rank: 10,
+            routes: Vec::new(),
+            allowlist: None,
+        }];
+
+        store
+            .seed_from_inputs(&[], &models, &[], &[], &[], &[], &[], &users)
+            .await
+            .expect("seed user");
+        let user = store
+            .get_user_by_email_normalized("member@example.com")
+            .await
+            .expect("load user")
+            .expect("user exists");
+        let model_id = crate::seed::model_uuid("fable-5");
+        let defaults = SeedHumanBudgetDefaults {
+            default_user_budget: Some(SeedBudget {
+                cadence: BudgetCadence::Daily,
+                amount_usd: Money4::from_scaled(700_000),
+                hard_limit: true,
+                timezone: "UTC".to_string(),
+            }),
+            model_defaults: vec![SeedUserModelBudgetDefault {
+                model_key: "fable-5".to_string(),
+                model_id,
+                budget: SeedBudget {
+                    cadence: BudgetCadence::Daily,
+                    amount_usd: Money4::from_scaled(400_000),
+                    hard_limit: true,
+                    timezone: "UTC".to_string(),
+                },
+            }],
+        };
+        let now = OffsetDateTime::now_utc();
+
+        store
+            .reconcile_human_budget_defaults(&defaults, now)
+            .await
+            .expect("apply defaults");
+
+        let user_scope = BudgetScope::User {
+            user_id: user.user_id,
+        };
+        let inherited_user_budget = store
+            .get_active_budget_by_scope(&user_scope)
+            .await
+            .expect("load inherited user budget")
+            .expect("inherited user budget exists");
+        assert_eq!(
+            inherited_user_budget.source.kind,
+            BudgetSourceKind::ConfigUserDefault
+        );
+        assert_eq!(
+            inherited_user_budget.settings.amount_usd,
+            Money4::from_scaled(700_000)
+        );
+
+        let model_scope = BudgetScope::UserModel {
+            user_id: user.user_id,
+            selector: BudgetModelSelector::Model { model_id },
+        };
+        let inherited_model_budget = store
+            .get_active_budget_by_scope(&model_scope)
+            .await
+            .expect("load inherited model budget")
+            .expect("inherited model budget exists");
+        assert_eq!(
+            inherited_model_budget.source.kind,
+            BudgetSourceKind::ConfigUserModelDefault
+        );
+        assert_eq!(
+            inherited_model_budget.settings.amount_usd,
+            Money4::from_scaled(400_000)
+        );
+
+        store
+            .upsert_active_budget(
+                &user_scope,
+                &BudgetSettings {
+                    cadence: BudgetCadence::Daily,
+                    amount_usd: Money4::from_scaled(250_000),
+                    hard_limit: true,
+                    timezone: "UTC".to_string(),
+                },
+                now + Duration::seconds(1),
+            )
+            .await
+            .expect("manual user override");
+        store
+            .deactivate_active_budget(&model_scope, now + Duration::seconds(1))
+            .await
+            .expect("manual model deactivation");
+        store
+            .reconcile_human_budget_defaults(&defaults, now + Duration::seconds(2))
+            .await
+            .expect("reapply defaults");
+
+        let manual_user_budget = store
+            .get_active_budget_by_scope(&user_scope)
+            .await
+            .expect("load manual user budget")
+            .expect("manual user budget remains");
+        assert_eq!(manual_user_budget.source.kind, BudgetSourceKind::Manual);
+        assert_eq!(
+            manual_user_budget.settings.amount_usd,
+            Money4::from_scaled(250_000)
+        );
+        assert!(
+            store
+                .get_active_budget_by_scope(&model_scope)
+                .await
+                .expect("load model budget after deactivation")
                 .is_none()
         );
     }
@@ -6016,14 +6163,17 @@ mod tests {
             .expect("ops team exists");
         assert_eq!(refreshed_platform.team_name, "Platform Engineering");
         let _ops_team_id = ops_team.team_id;
-        assert!(
+        assert_eq!(
             store
                 .get_active_budget_by_scope(&BudgetScope::User {
                     user_id: user.user_id,
                 })
                 .await
                 .expect("user budget after reseed")
-                .is_none()
+                .expect("user budget remains")
+                .settings
+                .amount_usd,
+            Money4::from_scaled(750_000)
         );
 
         store.pool().close().await;

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -37,30 +37,30 @@ mod tests {
         ApiKeyOwnerKind, ApiKeyRepository, ApiKeySecretStorageKind, ApiKeyStatus, AuthMode,
         BudgetAlertChannel, BudgetAlertDeliveryRecord, BudgetAlertDeliveryStatus,
         BudgetAlertHistoryQuery, BudgetAlertRecord, BudgetAlertRepository, BudgetCadence,
-        BudgetModelSelector, BudgetRepository, BudgetScope, BudgetSettings, BudgetSourceKind,
-        ExternalMcpAuthMode, ExternalMcpDiscoveryRunRecord, ExternalMcpDiscoveryStatus,
-        ExternalMcpServerStatus, ExternalMcpTransport, GlobalRole, IdentityRepository,
-        ManagedApiKeySource, McpRegistryRepository, McpToolInvocationPayloadRecord,
-        McpToolInvocationQuery, McpToolInvocationRecord, McpToolInvocationRepository,
-        McpToolInvocationStatus, McpToolPolicyResult, McpUpstreamCredentialMaterialKind,
-        McpUpstreamCredentialOwnerScopeKind, McpUpstreamCredentialRepository,
-        McpUpstreamSecretStorageKind, MembershipRole, ModelPricingRecord, ModelRepository, Money4,
-        NewExternalMcpServerRecord, NewReviewAgentRepositoryRecord, NewReviewAgentRunRecord,
-        OauthJitPolicy, OidcLoginStateRecord, OpenAiCompatDeveloperRole,
-        OpenAiCompatMaxTokensField, OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility,
-        PricingCatalogCacheRecord, PricingCatalogRepository, PricingLimits, PricingModalities,
-        PricingProvenance, ProviderCapabilities, RequestAttemptRecord, RequestAttemptStatus,
-        RequestLogPayloadRecord, RequestLogQuery, RequestLogRecord, RequestLogRepository,
-        RequestTag, RequestTags, RequestToolCardinality, ReviewAgentProvider,
-        ReviewAgentPullRequestState, ReviewAgentRepository, ReviewAgentRepositoryStatus,
-        ReviewAgentRunStatus, ReviewAgentSettings, RouteCompatibility, SeedApiKey,
-        SeedApiKeySecretMaterial, SeedBudget, SeedHumanBudgetDefaults,
-        SeedManagedServiceAccountApiKey, SeedModel, SeedModelRoute, SeedOauthProvider,
-        SeedProvider, SeedServiceAccount, SeedTeam, SeedUser, SeedUserMembership,
-        SeedUserModelBudgetDefault, ServiceAccountStatus, StoreError, StoreHealth,
-        UpdateExternalMcpServerRecord, UpdateReviewAgentRunRecord, UpsertExternalMcpToolRecord,
-        UpsertMcpUpstreamCredentialBindingRecord, UpsertReviewAgentPullRequestRecord,
-        UsageLedgerRecord, UsagePricingStatus, UserStatus,
+        BudgetModelSelector, BudgetRepository, BudgetScope, BudgetSettings, BudgetSource,
+        BudgetSourceKind, ExternalMcpAuthMode, ExternalMcpDiscoveryRunRecord,
+        ExternalMcpDiscoveryStatus, ExternalMcpServerStatus, ExternalMcpTransport, GlobalRole,
+        IdentityRepository, ManagedApiKeySource, McpRegistryRepository,
+        McpToolInvocationPayloadRecord, McpToolInvocationQuery, McpToolInvocationRecord,
+        McpToolInvocationRepository, McpToolInvocationStatus, McpToolPolicyResult,
+        McpUpstreamCredentialMaterialKind, McpUpstreamCredentialOwnerScopeKind,
+        McpUpstreamCredentialRepository, McpUpstreamSecretStorageKind, MembershipRole,
+        ModelPricingRecord, ModelRepository, Money4, NewExternalMcpServerRecord,
+        NewReviewAgentRepositoryRecord, NewReviewAgentRunRecord, OauthJitPolicy,
+        OidcLoginStateRecord, OpenAiCompatDeveloperRole, OpenAiCompatMaxTokensField,
+        OpenAiCompatReasoningEffort, OpenAiCompatRouteCompatibility, PricingCatalogCacheRecord,
+        PricingCatalogRepository, PricingLimits, PricingModalities, PricingProvenance,
+        ProviderCapabilities, RequestAttemptRecord, RequestAttemptStatus, RequestLogPayloadRecord,
+        RequestLogQuery, RequestLogRecord, RequestLogRepository, RequestTag, RequestTags,
+        RequestToolCardinality, ReviewAgentProvider, ReviewAgentPullRequestState,
+        ReviewAgentRepository, ReviewAgentRepositoryStatus, ReviewAgentRunStatus,
+        ReviewAgentSettings, RouteCompatibility, SeedApiKey, SeedApiKeySecretMaterial, SeedBudget,
+        SeedHumanBudgetDefaults, SeedManagedServiceAccountApiKey, SeedModel, SeedModelRoute,
+        SeedOauthProvider, SeedProvider, SeedServiceAccount, SeedTeam, SeedUser,
+        SeedUserMembership, SeedUserModelBudgetDefault, ServiceAccountStatus, StoreError,
+        StoreHealth, UpdateExternalMcpServerRecord, UpdateReviewAgentRunRecord,
+        UpsertExternalMcpToolRecord, UpsertMcpUpstreamCredentialBindingRecord,
+        UpsertReviewAgentPullRequestRecord, UsageLedgerRecord, UsagePricingStatus, UserStatus,
     };
     use serde_json::{Map, json};
     use serial_test::serial;
@@ -2429,6 +2429,99 @@ mod tests {
                 .await
                 .expect_err("check should fail");
         assert!(error.to_string().contains("pending migrations"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn libsql_budget_source_migration_marks_legacy_inactive_budgets_as_deactivated() {
+        let tmp = tempdir().expect("tempdir");
+        let db_path = tmp.path().join("gateway.db");
+        let db = libsql::Builder::new_local(db_path.to_str().expect("db path"))
+            .build()
+            .await
+            .expect("db");
+        let conn = db.connect().expect("connection");
+
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS refinery_schema_history (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_on INTEGER NOT NULL,
+                checksum TEXT NOT NULL
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("schema history");
+
+        for migration in MIGRATION_REGISTRY
+            .iter()
+            .filter(|migration| migration.version < 38)
+        {
+            conn.execute_batch(migration.sql_for(MigrationBackend::Libsql))
+                .await
+                .unwrap_or_else(|error| panic!("apply migration {}: {error}", migration.version));
+            conn.execute(
+                r#"
+                INSERT INTO refinery_schema_history (version, name, applied_on, checksum)
+                VALUES (?1, ?2, unixepoch(), ?3)
+                "#,
+                libsql::params![migration.version as i64, migration.name, migration.checksum],
+            )
+            .await
+            .unwrap_or_else(|error| panic!("record migration {}: {error}", migration.version));
+        }
+
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        let user_id = Uuid::new_v4();
+        conn.execute(
+            r#"
+            INSERT INTO users (
+              user_id, name, email, email_normalized, global_role, auth_mode, status,
+              request_logging_enabled, model_access_mode, created_at, updated_at
+            ) VALUES (?1, 'User One', 'user@example.com', 'user@example.com', 'user', 'password', 'active', 1, 'all', ?2, ?2)
+            "#,
+            libsql::params![user_id.to_string(), now],
+        )
+        .await
+        .expect("user");
+        conn.execute(
+            r#"
+            INSERT INTO budgets (
+                budget_id, scope_kind, scope_key, user_id, cadence, amount_10000,
+                hard_limit, timezone, is_active, created_at, updated_at
+            ) VALUES (?1, 'user', ?2, ?3, 'daily', 100000, 1, 'UTC', 0, ?4, ?4)
+            "#,
+            libsql::params![
+                Uuid::new_v4().to_string(),
+                format!("budget:v1:user:{user_id}"),
+                user_id.to_string(),
+                now
+            ],
+        )
+        .await
+        .expect("legacy inactive budget");
+
+        run_migrations(&db_path).await.expect("apply v38");
+
+        let mut rows = conn
+            .query(
+                "SELECT source_kind, source_key FROM budgets WHERE user_id = ?1",
+                [user_id.to_string()],
+            )
+            .await
+            .expect("source query");
+        let row = rows
+            .next()
+            .await
+            .expect("source row fetch")
+            .expect("source row");
+        let source_kind: String = row.get(0).expect("source kind");
+        let source_key: String = row.get(1).expect("source key");
+        assert_eq!(source_kind, "manual");
+        assert_eq!(source_key, "deactivated");
     }
 
     #[tokio::test]
@@ -5846,6 +5939,77 @@ mod tests {
                 .await
                 .expect("load model budget after deactivation")
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn libsql_guarded_config_budget_upsert_does_not_recreate_after_deactivation() {
+        let tmp = tempdir().expect("tempdir");
+        let db_path = tmp.path().join("gateway.db");
+        run_migrations(&db_path).await.expect("migrations");
+
+        let store = LibsqlStore::new_local(db_path.to_str().expect("db path"))
+            .await
+            .expect("store");
+        let user = store
+            .create_identity_user(
+                "User",
+                "user@example.com",
+                "user@example.com",
+                GlobalRole::User,
+                AuthMode::Password,
+                UserStatus::Active,
+            )
+            .await
+            .expect("user");
+        let scope = BudgetScope::User {
+            user_id: user.user_id,
+        };
+        let settings = BudgetSettings {
+            cadence: BudgetCadence::Daily,
+            amount_usd: Money4::from_scaled(700_000),
+            hard_limit: true,
+            timezone: "UTC".to_string(),
+        };
+        let source = BudgetSource::config_user_default();
+        let now = OffsetDateTime::now_utc();
+
+        store
+            .upsert_active_budget_with_source(&scope, &settings, &source, now)
+            .await
+            .expect("config default budget");
+        store
+            .deactivate_active_budget(&scope, now + Duration::seconds(1))
+            .await
+            .expect("manual deactivation");
+
+        let guarded = store
+            .upsert_active_budget_with_source_guard(
+                &scope,
+                &settings,
+                &source,
+                Some(&source),
+                now + Duration::seconds(2),
+            )
+            .await
+            .expect("guarded upsert");
+        assert!(guarded.is_none());
+        assert!(
+            store
+                .get_active_budget_by_scope(&scope)
+                .await
+                .expect("active budget")
+                .is_none()
+        );
+        assert!(
+            store
+                .get_latest_budget_by_scope(&scope)
+                .await
+                .expect("latest budget")
+                .expect("latest budget exists")
+                .source
+                .is_manual_deactivation()
         );
     }
 

--- a/crates/gateway-store/src/lib.rs
+++ b/crates/gateway-store/src/lib.rs
@@ -5559,17 +5559,14 @@ mod tests {
             .expect("ops team exists");
         assert_eq!(refreshed_platform.team_name, "Platform Engineering");
         let _ops_team_id = ops_team.team_id;
-        assert_eq!(
+        assert!(
             store
                 .get_active_budget_by_scope(&BudgetScope::User {
                     user_id: user.user_id,
                 })
                 .await
                 .expect("user budget after reseed")
-                .expect("user budget remains")
-                .settings
-                .amount_usd,
-            Money4::from_scaled(750_000)
+                .is_none()
         );
     }
 
@@ -5609,6 +5606,10 @@ mod tests {
             .seed_from_inputs(&[], &models, &[], &[], &[], &[], &[], &users)
             .await
             .expect("seed user");
+        let bootstrap_user = store
+            .upsert_bootstrap_admin_user("Admin", "admin@local", true)
+            .await
+            .expect("bootstrap admin");
         let user = store
             .get_user_by_email_normalized("member@example.com")
             .await
@@ -5656,6 +5657,22 @@ mod tests {
             inherited_user_budget.settings.amount_usd,
             Money4::from_scaled(700_000)
         );
+        let bootstrap_scope = BudgetScope::User {
+            user_id: bootstrap_user.user_id,
+        };
+        let bootstrap_budget = store
+            .get_active_budget_by_scope(&bootstrap_scope)
+            .await
+            .expect("load bootstrap budget")
+            .expect("bootstrap budget exists");
+        assert_eq!(
+            bootstrap_budget.source.kind,
+            BudgetSourceKind::ConfigUserDefault
+        );
+        assert_eq!(
+            bootstrap_budget.settings.amount_usd,
+            Money4::from_scaled(700_000)
+        );
 
         let model_scope = BudgetScope::UserModel {
             user_id: user.user_id,
@@ -5675,6 +5692,122 @@ mod tests {
             Money4::from_scaled(400_000)
         );
 
+        let defaults_without_model = SeedHumanBudgetDefaults {
+            default_user_budget: defaults.default_user_budget.clone(),
+            model_defaults: Vec::new(),
+        };
+        store
+            .reconcile_human_budget_defaults(&defaults_without_model, now + Duration::seconds(1))
+            .await
+            .expect("remove model default");
+        assert!(
+            store
+                .get_active_budget_by_scope(&model_scope)
+                .await
+                .expect("load model budget after default removal")
+                .is_none()
+        );
+        assert_eq!(
+            store
+                .get_latest_budget_by_scope(&model_scope)
+                .await
+                .expect("latest model budget")
+                .expect("inactive model budget remains")
+                .source
+                .kind,
+            BudgetSourceKind::ConfigUserModelDefault
+        );
+        store
+            .reconcile_human_budget_defaults(&defaults, now + Duration::seconds(2))
+            .await
+            .expect("restore model default");
+        let restored_model_budget = store
+            .get_active_budget_by_scope(&model_scope)
+            .await
+            .expect("load restored model budget")
+            .expect("restored model budget exists");
+        assert_eq!(
+            restored_model_budget.source.kind,
+            BudgetSourceKind::ConfigUserModelDefault
+        );
+        assert_eq!(
+            restored_model_budget.settings.amount_usd,
+            Money4::from_scaled(400_000)
+        );
+
+        let override_users = vec![SeedUser {
+            name: "Override".to_string(),
+            email: "override@example.com".to_string(),
+            email_normalized: "override@example.com".to_string(),
+            global_role: GlobalRole::User,
+            auth_mode: AuthMode::Password,
+            request_logging_enabled: true,
+            oidc_provider_key: None,
+            oauth_provider_key: None,
+            membership: None,
+            budget: Some(SeedBudget {
+                cadence: BudgetCadence::Daily,
+                amount_usd: Money4::from_scaled(250_000),
+                hard_limit: true,
+                timezone: "UTC".to_string(),
+            }),
+        }];
+        store
+            .seed_from_inputs(&[], &[], &[], &[], &[], &[], &[], &override_users)
+            .await
+            .expect("seed explicit user override");
+        store
+            .reconcile_human_budget_defaults(&defaults, now + Duration::seconds(3))
+            .await
+            .expect("reconcile defaults with explicit override");
+        let override_user = store
+            .get_user_by_email_normalized("override@example.com")
+            .await
+            .expect("load override user")
+            .expect("override user exists");
+        let override_scope = BudgetScope::User {
+            user_id: override_user.user_id,
+        };
+        let config_override_budget = store
+            .get_active_budget_by_scope(&override_scope)
+            .await
+            .expect("load config override budget")
+            .expect("config override budget exists");
+        assert_eq!(
+            config_override_budget.source.kind,
+            BudgetSourceKind::ConfigUserOverride
+        );
+        assert_eq!(
+            config_override_budget.settings.amount_usd,
+            Money4::from_scaled(250_000)
+        );
+
+        let inherited_users = vec![SeedUser {
+            budget: None,
+            ..override_users[0].clone()
+        }];
+        store
+            .seed_from_inputs(&[], &[], &[], &[], &[], &[], &[], &inherited_users)
+            .await
+            .expect("remove explicit user override");
+        store
+            .reconcile_human_budget_defaults(&defaults, now + Duration::seconds(4))
+            .await
+            .expect("reconcile defaults after override removal");
+        let inherited_override_budget = store
+            .get_active_budget_by_scope(&override_scope)
+            .await
+            .expect("load inherited budget after override removal")
+            .expect("inherited budget exists");
+        assert_eq!(
+            inherited_override_budget.source.kind,
+            BudgetSourceKind::ConfigUserDefault
+        );
+        assert_eq!(
+            inherited_override_budget.settings.amount_usd,
+            Money4::from_scaled(700_000)
+        );
+
         store
             .upsert_active_budget(
                 &user_scope,
@@ -5684,16 +5817,16 @@ mod tests {
                     hard_limit: true,
                     timezone: "UTC".to_string(),
                 },
-                now + Duration::seconds(1),
+                now + Duration::seconds(5),
             )
             .await
             .expect("manual user override");
         store
-            .deactivate_active_budget(&model_scope, now + Duration::seconds(1))
+            .deactivate_active_budget(&model_scope, now + Duration::seconds(5))
             .await
             .expect("manual model deactivation");
         store
-            .reconcile_human_budget_defaults(&defaults, now + Duration::seconds(2))
+            .reconcile_human_budget_defaults(&defaults, now + Duration::seconds(6))
             .await
             .expect("reapply defaults");
 
@@ -6163,17 +6296,14 @@ mod tests {
             .expect("ops team exists");
         assert_eq!(refreshed_platform.team_name, "Platform Engineering");
         let _ops_team_id = ops_team.team_id;
-        assert_eq!(
+        assert!(
             store
                 .get_active_budget_by_scope(&BudgetScope::User {
                     user_id: user.user_id,
                 })
                 .await
                 .expect("user budget after reseed")
-                .expect("user budget remains")
-                .settings
-                .amount_usd,
-            Money4::from_scaled(750_000)
+                .is_none()
         );
 
         store.pool().close().await;

--- a/crates/gateway-store/src/libsql_store/budgets.rs
+++ b/crates/gateway-store/src/libsql_store/budgets.rs
@@ -182,39 +182,28 @@ impl BudgetRepository for LibsqlStore {
             self.connection
                 .execute(
                     r#"
-                    INSERT INTO budgets (
-                        budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
-                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                        created_at, updated_at, source_kind, source_key
-                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?13, ?14, ?15)
-                    ON CONFLICT(scope_key) WHERE is_active = 1
-                    DO UPDATE SET
-                        cadence = excluded.cadence,
-                        amount_10000 = excluded.amount_10000,
-                        hard_limit = excluded.hard_limit,
-                        timezone = excluded.timezone,
-                        source_kind = excluded.source_kind,
-                        source_key = excluded.source_key,
-                        updated_at = excluded.updated_at
-                    WHERE budgets.source_kind = ?16
-                      AND budgets.source_key IS ?17
+                    UPDATE budgets
+                    SET cadence = ?1,
+                        amount_10000 = ?2,
+                        hard_limit = ?3,
+                        timezone = ?4,
+                        source_kind = ?5,
+                        source_key = ?6,
+                        updated_at = ?7
+                    WHERE scope_key = ?8
+                      AND is_active = 1
+                      AND source_kind = ?9
+                      AND source_key IS ?10
                     "#,
                     libsql::params![
-                        Uuid::new_v4().to_string(),
-                        scope.kind().as_str(),
-                        scope.scope_key(),
-                        scope.user_id().map(|id| id.to_string()),
-                        scope.service_account_id().map(|id| id.to_string()),
-                        scope.model_id().map(|id| id.to_string()),
-                        scope.upstream_model().map(ToOwned::to_owned),
                         settings.cadence.as_str(),
                         settings.amount_usd.as_scaled_i64(),
                         if settings.hard_limit { 1 } else { 0 },
                         settings.timezone.clone(),
-                        updated_at.unix_timestamp(),
-                        updated_at.unix_timestamp(),
                         source.kind.as_str(),
                         source.key.clone(),
+                        updated_at.unix_timestamp(),
+                        scope.scope_key(),
                         expected_source.kind.as_str(),
                         expected_source.key.clone(),
                     ],

--- a/crates/gateway-store/src/libsql_store/budgets.rs
+++ b/crates/gateway-store/src/libsql_store/budgets.rs
@@ -13,7 +13,7 @@ impl BudgetRepository for LibsqlStore {
                 r#"
                 SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                       created_at, updated_at
+                       created_at, updated_at, source_kind, source_key
                 FROM budgets
                 WHERE scope_key = ?1
                   AND is_active = 1
@@ -35,6 +35,34 @@ impl BudgetRepository for LibsqlStore {
         decode_budget_record(&row).map(Some)
     }
 
+    async fn get_latest_budget_by_scope(
+        &self,
+        scope: &BudgetScope,
+    ) -> Result<Option<BudgetRecord>, StoreError> {
+        let mut rows = self
+            .connection
+            .query(
+                r#"
+                SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
+                       upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
+                       created_at, updated_at, source_kind, source_key
+                FROM budgets
+                WHERE scope_key = ?1
+                ORDER BY updated_at DESC, created_at DESC
+                LIMIT 1
+                "#,
+                [scope.scope_key()],
+            )
+            .await
+            .map_err(to_query_error)?;
+
+        let Some(row) = rows.next().await.map_err(to_query_error)? else {
+            return Ok(None);
+        };
+
+        decode_budget_record(&row).map(Some)
+    }
+
     async fn list_active_budgets(
         &self,
         scope_kind: Option<BudgetScopeKind>,
@@ -45,7 +73,7 @@ impl BudgetRepository for LibsqlStore {
                     r#"
                 SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                       created_at, updated_at
+                       created_at, updated_at, source_kind, source_key
                 FROM budgets
                 WHERE scope_kind = ?1
                   AND is_active = 1
@@ -61,7 +89,7 @@ impl BudgetRepository for LibsqlStore {
                     r#"
                 SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                       created_at, updated_at
+                       created_at, updated_at, source_kind, source_key
                 FROM budgets
                 WHERE is_active = 1
                 ORDER BY updated_at DESC, scope_key ASC
@@ -85,20 +113,33 @@ impl BudgetRepository for LibsqlStore {
         settings: &BudgetSettings,
         updated_at: OffsetDateTime,
     ) -> Result<BudgetRecord, StoreError> {
+        self.upsert_active_budget_with_source(scope, settings, &BudgetSource::manual(), updated_at)
+            .await
+    }
+
+    async fn upsert_active_budget_with_source(
+        &self,
+        scope: &BudgetScope,
+        settings: &BudgetSettings,
+        source: &BudgetSource,
+        updated_at: OffsetDateTime,
+    ) -> Result<BudgetRecord, StoreError> {
         self.connection
             .execute(
                 r#"
                 INSERT INTO budgets (
                     budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                     upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                    created_at, updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?13)
+                    created_at, updated_at, source_kind, source_key
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?13, ?14, ?15)
                 ON CONFLICT(scope_key) WHERE is_active = 1
                 DO UPDATE SET
                     cadence = excluded.cadence,
                     amount_10000 = excluded.amount_10000,
                     hard_limit = excluded.hard_limit,
                     timezone = excluded.timezone,
+                    source_kind = excluded.source_kind,
+                    source_key = excluded.source_key,
                     updated_at = excluded.updated_at
                 "#,
                 libsql::params![
@@ -115,6 +156,8 @@ impl BudgetRepository for LibsqlStore {
                     settings.timezone.clone(),
                     updated_at.unix_timestamp(),
                     updated_at.unix_timestamp(),
+                    source.kind.as_str(),
+                    source.key.clone(),
                 ],
             )
             .await
@@ -132,17 +175,25 @@ impl BudgetRepository for LibsqlStore {
         scope: &BudgetScope,
         updated_at: OffsetDateTime,
     ) -> Result<bool, StoreError> {
+        let source = BudgetSource::manual_deactivated();
         let updated = self
             .connection
             .execute(
                 r#"
                 UPDATE budgets
                 SET is_active = 0,
-                    updated_at = ?1
+                    updated_at = ?1,
+                    source_kind = ?3,
+                    source_key = ?4
                 WHERE scope_key = ?2
                   AND is_active = 1
                 "#,
-                libsql::params![updated_at.unix_timestamp(), scope.scope_key()],
+                libsql::params![
+                    updated_at.unix_timestamp(),
+                    scope.scope_key(),
+                    source.kind.as_str(),
+                    source.key,
+                ],
             )
             .await
             .map_err(to_query_error)?;

--- a/crates/gateway-store/src/libsql_store/budgets.rs
+++ b/crates/gateway-store/src/libsql_store/budgets.rs
@@ -170,6 +170,97 @@ impl BudgetRepository for LibsqlStore {
             })
     }
 
+    async fn upsert_active_budget_with_source_guard(
+        &self,
+        scope: &BudgetScope,
+        settings: &BudgetSettings,
+        source: &BudgetSource,
+        expected_current_source: Option<&BudgetSource>,
+        updated_at: OffsetDateTime,
+    ) -> Result<Option<BudgetRecord>, StoreError> {
+        if let Some(expected_source) = expected_current_source {
+            self.connection
+                .execute(
+                    r#"
+                    INSERT INTO budgets (
+                        budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
+                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
+                        created_at, updated_at, source_kind, source_key
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?13, ?14, ?15)
+                    ON CONFLICT(scope_key) WHERE is_active = 1
+                    DO UPDATE SET
+                        cadence = excluded.cadence,
+                        amount_10000 = excluded.amount_10000,
+                        hard_limit = excluded.hard_limit,
+                        timezone = excluded.timezone,
+                        source_kind = excluded.source_kind,
+                        source_key = excluded.source_key,
+                        updated_at = excluded.updated_at
+                    WHERE budgets.source_kind = ?16
+                      AND budgets.source_key IS ?17
+                    "#,
+                    libsql::params![
+                        Uuid::new_v4().to_string(),
+                        scope.kind().as_str(),
+                        scope.scope_key(),
+                        scope.user_id().map(|id| id.to_string()),
+                        scope.service_account_id().map(|id| id.to_string()),
+                        scope.model_id().map(|id| id.to_string()),
+                        scope.upstream_model().map(ToOwned::to_owned),
+                        settings.cadence.as_str(),
+                        settings.amount_usd.as_scaled_i64(),
+                        if settings.hard_limit { 1 } else { 0 },
+                        settings.timezone.clone(),
+                        updated_at.unix_timestamp(),
+                        updated_at.unix_timestamp(),
+                        source.kind.as_str(),
+                        source.key.clone(),
+                        expected_source.kind.as_str(),
+                        expected_source.key.clone(),
+                    ],
+                )
+                .await
+                .map_err(to_query_error)?;
+        } else {
+            self.connection
+                .execute(
+                    r#"
+                    INSERT INTO budgets (
+                        budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
+                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
+                        created_at, updated_at, source_kind, source_key
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?13, ?14, ?15)
+                    ON CONFLICT(scope_key) WHERE is_active = 1
+                    DO NOTHING
+                    "#,
+                    libsql::params![
+                        Uuid::new_v4().to_string(),
+                        scope.kind().as_str(),
+                        scope.scope_key(),
+                        scope.user_id().map(|id| id.to_string()),
+                        scope.service_account_id().map(|id| id.to_string()),
+                        scope.model_id().map(|id| id.to_string()),
+                        scope.upstream_model().map(ToOwned::to_owned),
+                        settings.cadence.as_str(),
+                        settings.amount_usd.as_scaled_i64(),
+                        if settings.hard_limit { 1 } else { 0 },
+                        settings.timezone.clone(),
+                        updated_at.unix_timestamp(),
+                        updated_at.unix_timestamp(),
+                        source.kind.as_str(),
+                        source.key.clone(),
+                    ],
+                )
+                .await
+                .map_err(to_query_error)?;
+        }
+
+        match self.get_active_budget_by_scope(scope).await? {
+            Some(budget) if budget.source.matches(source) => Ok(Some(budget)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
     async fn deactivate_active_budget(
         &self,
         scope: &BudgetScope,
@@ -193,6 +284,36 @@ impl BudgetRepository for LibsqlStore {
                     scope.scope_key(),
                     source.kind.as_str(),
                     source.key,
+                ],
+            )
+            .await
+            .map_err(to_query_error)?;
+        Ok(updated > 0)
+    }
+
+    async fn deactivate_active_budget_by_source(
+        &self,
+        scope: &BudgetScope,
+        source: &BudgetSource,
+        updated_at: OffsetDateTime,
+    ) -> Result<bool, StoreError> {
+        let updated = self
+            .connection
+            .execute(
+                r#"
+                UPDATE budgets
+                SET is_active = 0,
+                    updated_at = ?1
+                WHERE scope_key = ?2
+                  AND is_active = 1
+                  AND source_kind = ?3
+                  AND source_key IS ?4
+                "#,
+                libsql::params![
+                    updated_at.unix_timestamp(),
+                    scope.scope_key(),
+                    source.kind.as_str(),
+                    source.key.clone(),
                 ],
             )
             .await

--- a/crates/gateway-store/src/libsql_store/mod.rs
+++ b/crates/gateway-store/src/libsql_store/mod.rs
@@ -28,15 +28,15 @@ use gateway_core::{
     BudgetAlertDeliveryStatus, BudgetAlertDispatchTask, BudgetAlertHistoryPage,
     BudgetAlertHistoryQuery, BudgetAlertHistoryRecord, BudgetAlertRecord, BudgetAlertRepository,
     BudgetCadence, BudgetModelSelector, BudgetRecord, BudgetRepository, BudgetScope,
-    BudgetScopeKind, BudgetSettings, ExternalMcpAuthMode, ExternalMcpDiscoveryRunRecord,
-    ExternalMcpDiscoveryStatus, ExternalMcpServerRecord, ExternalMcpServerStatus,
-    ExternalMcpToolRecord, ExternalMcpTransport, FocusExportAggregateRecord,
-    FocusExportDiagnosticsRecord, GatewayModel, GlobalRole, IdentityRepository, IdentityUserRecord,
-    MAX_MCP_TOOL_INVOCATION_PAGE_SIZE, McpAccessRepository, McpAccessResolution,
-    McpAggregateSessionRecord, McpAggregateSessionRepository, McpCatalogAccessResolution,
-    McpCatalogToolRecord, McpGrantSubject, McpRegistryRepository, McpTokenEstimateConfidence,
-    McpTokenEstimateSource, McpTokenOverheadRepository, McpToolGrantRecord,
-    McpToolGrantSubjectKind, McpToolGrantTargetKind, McpToolInvocationDetail,
+    BudgetScopeKind, BudgetSettings, BudgetSource, BudgetSourceKind, ExternalMcpAuthMode,
+    ExternalMcpDiscoveryRunRecord, ExternalMcpDiscoveryStatus, ExternalMcpServerRecord,
+    ExternalMcpServerStatus, ExternalMcpToolRecord, ExternalMcpTransport,
+    FocusExportAggregateRecord, FocusExportDiagnosticsRecord, GatewayModel, GlobalRole,
+    IdentityRepository, IdentityUserRecord, MAX_MCP_TOOL_INVOCATION_PAGE_SIZE, McpAccessRepository,
+    McpAccessResolution, McpAggregateSessionRecord, McpAggregateSessionRepository,
+    McpCatalogAccessResolution, McpCatalogToolRecord, McpGrantSubject, McpRegistryRepository,
+    McpTokenEstimateConfidence, McpTokenEstimateSource, McpTokenOverheadRepository,
+    McpToolGrantRecord, McpToolGrantSubjectKind, McpToolGrantTargetKind, McpToolInvocationDetail,
     McpToolInvocationPage, McpToolInvocationPayloadRecord, McpToolInvocationQuery,
     McpToolInvocationRecord, McpToolInvocationRepository, McpToolInvocationStatus,
     McpToolPolicyResult, McpToolTokenEstimateRecord, McpToolsetRecord, McpToolsetStatus,
@@ -681,6 +681,23 @@ impl GatewayStore for LibsqlStore {
             users,
         )
         .await
+    }
+
+    async fn reconcile_human_budget_defaults(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        Self::reconcile_human_budget_defaults(self, defaults, updated_at).await
+    }
+
+    async fn apply_human_budget_defaults_for_user(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        user_id: Uuid,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        Self::apply_human_budget_defaults_for_user(self, defaults, user_id, updated_at).await
     }
 }
 

--- a/crates/gateway-store/src/libsql_store/seed.rs
+++ b/crates/gateway-store/src/libsql_store/seed.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::seed::{
-    generate_seed_api_key_material, managed_api_key_uuid, prevalidate_seed_users,
-    provided_seed_api_key_material, reconcile_seed_teams, reconcile_seed_users,
-    service_account_uuid, validate_seed_service_account_team_references,
+    apply_human_budget_defaults_for_user, generate_seed_api_key_material, managed_api_key_uuid,
+    prevalidate_seed_users, provided_seed_api_key_material, reconcile_human_budget_defaults,
+    reconcile_seed_teams, reconcile_seed_users, service_account_uuid,
+    validate_seed_service_account_team_references,
 };
 use crate::shared::{parse_uuid, serialize_json, serialize_optional_json};
 
@@ -800,5 +801,22 @@ impl LibsqlStore {
         reconcile_seed_users(self, &seeded_teams, users, now).await?;
 
         Ok(())
+    }
+
+    pub async fn reconcile_human_budget_defaults(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        reconcile_human_budget_defaults(self, defaults, updated_at).await
+    }
+
+    pub async fn apply_human_budget_defaults_for_user(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        user_id: Uuid,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        apply_human_budget_defaults_for_user(self, defaults, user_id, updated_at).await
     }
 }

--- a/crates/gateway-store/src/libsql_store/support.rs
+++ b/crates/gateway-store/src/libsql_store/support.rs
@@ -540,6 +540,8 @@ pub(super) fn decode_budget_record(row: &libsql::Row) -> Result<BudgetRecord, St
     let is_active: i64 = row.get(11).map_err(to_query_error)?;
     let created_at: i64 = row.get(12).map_err(to_query_error)?;
     let updated_at: i64 = row.get(13).map_err(to_query_error)?;
+    let source_kind: String = row.get(14).map_err(to_query_error)?;
+    let source_key: Option<String> = row.get(15).map_err(to_query_error)?;
 
     let scope = match BudgetScopeKind::from_db(&scope_kind).ok_or_else(|| {
         StoreError::Serialization(format!("unknown budget scope kind `{scope_kind}`"))
@@ -582,6 +584,12 @@ pub(super) fn decode_budget_record(row: &libsql::Row) -> Result<BudgetRecord, St
             amount_usd: Money4::from_scaled(amount_10000),
             hard_limit: hard_limit == 1,
             timezone,
+        },
+        source: BudgetSource {
+            kind: BudgetSourceKind::from_db(&source_kind).ok_or_else(|| {
+                StoreError::Serialization(format!("unknown budget source kind `{source_kind}`"))
+            })?,
+            key: source_key,
         },
         is_active: is_active == 1,
         created_at: unix_to_datetime(created_at)?,

--- a/crates/gateway-store/src/migration_registry.rs
+++ b/crates/gateway-store/src/migration_registry.rs
@@ -180,6 +180,13 @@ pub(crate) const MIGRATION_REGISTRY: &[MigrationManifest] = &[
         libsql_sql: include_str!("../migrations/V37__model_allowlists.sql"),
         postgres_sql: include_str!("../migrations/postgres/V37__model_allowlists.sql"),
     },
+    MigrationManifest {
+        version: 38,
+        name: "budget_sources",
+        checksum: "V38__budget_sources.sql",
+        libsql_sql: include_str!("../migrations/V38__budget_sources.sql"),
+        postgres_sql: include_str!("../migrations/postgres/V38__budget_sources.sql"),
+    },
 ];
 
 #[cfg(test)]

--- a/crates/gateway-store/src/postgres_store/budgets.rs
+++ b/crates/gateway-store/src/postgres_store/budgets.rs
@@ -159,39 +159,28 @@ impl BudgetRepository for PostgresStore {
         if let Some(expected_source) = expected_current_source {
             sqlx::query(
                 r#"
-                INSERT INTO budgets (
-                    budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
-                    upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                    created_at, updated_at, source_kind, source_key
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 1, $12, $13, $14, $15)
-                ON CONFLICT (scope_key) WHERE is_active = 1
-                DO UPDATE SET
-                    cadence = excluded.cadence,
-                    amount_10000 = excluded.amount_10000,
-                    hard_limit = excluded.hard_limit,
-                    timezone = excluded.timezone,
-                    source_kind = excluded.source_kind,
-                    source_key = excluded.source_key,
-                    updated_at = excluded.updated_at
-                WHERE budgets.source_kind = $16
-                  AND budgets.source_key IS NOT DISTINCT FROM $17
+                UPDATE budgets
+                SET cadence = $1,
+                    amount_10000 = $2,
+                    hard_limit = $3,
+                    timezone = $4,
+                    source_kind = $5,
+                    source_key = $6,
+                    updated_at = $7
+                WHERE scope_key = $8
+                  AND is_active = 1
+                  AND source_kind = $9
+                  AND source_key IS NOT DISTINCT FROM $10
                 "#,
             )
-            .bind(Uuid::new_v4().to_string())
-            .bind(scope.kind().as_str())
-            .bind(scope.scope_key())
-            .bind(scope.user_id().map(|id| id.to_string()))
-            .bind(scope.service_account_id().map(|id| id.to_string()))
-            .bind(scope.model_id().map(|id| id.to_string()))
-            .bind(scope.upstream_model().map(ToOwned::to_owned))
             .bind(settings.cadence.as_str())
             .bind(settings.amount_usd.as_scaled_i64())
             .bind(if settings.hard_limit { 1_i64 } else { 0_i64 })
             .bind(&settings.timezone)
-            .bind(updated_at.unix_timestamp())
-            .bind(updated_at.unix_timestamp())
             .bind(source.kind.as_str())
             .bind(source.key.as_deref())
+            .bind(updated_at.unix_timestamp())
+            .bind(scope.scope_key())
             .bind(expected_source.kind.as_str())
             .bind(expected_source.key.as_deref())
             .execute(&self.pool)

--- a/crates/gateway-store/src/postgres_store/budgets.rs
+++ b/crates/gateway-store/src/postgres_store/budgets.rs
@@ -11,10 +11,33 @@ impl BudgetRepository for PostgresStore {
             r#"
             SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                    upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                   created_at, updated_at
+                   created_at, updated_at, source_kind, source_key
             FROM budgets
             WHERE scope_key = $1
               AND is_active = 1
+            LIMIT 1
+            "#,
+        )
+        .bind(scope.scope_key())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(to_query_error)?;
+
+        row.as_ref().map(decode_budget_record).transpose()
+    }
+
+    async fn get_latest_budget_by_scope(
+        &self,
+        scope: &BudgetScope,
+    ) -> Result<Option<BudgetRecord>, StoreError> {
+        let row = sqlx::query(
+            r#"
+            SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
+                   upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
+                   created_at, updated_at, source_kind, source_key
+            FROM budgets
+            WHERE scope_key = $1
+            ORDER BY updated_at DESC, created_at DESC
             LIMIT 1
             "#,
         )
@@ -35,7 +58,7 @@ impl BudgetRepository for PostgresStore {
                 r#"
                 SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                       created_at, updated_at
+                       created_at, updated_at, source_kind, source_key
                 FROM budgets
                 WHERE scope_kind = $1
                   AND is_active = 1
@@ -51,7 +74,7 @@ impl BudgetRepository for PostgresStore {
                 r#"
                 SELECT budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                        upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                       created_at, updated_at
+                       created_at, updated_at, source_kind, source_key
                 FROM budgets
                 WHERE is_active = 1
                 ORDER BY updated_at DESC, scope_key ASC
@@ -70,19 +93,32 @@ impl BudgetRepository for PostgresStore {
         settings: &BudgetSettings,
         updated_at: OffsetDateTime,
     ) -> Result<BudgetRecord, StoreError> {
+        self.upsert_active_budget_with_source(scope, settings, &BudgetSource::manual(), updated_at)
+            .await
+    }
+
+    async fn upsert_active_budget_with_source(
+        &self,
+        scope: &BudgetScope,
+        settings: &BudgetSettings,
+        source: &BudgetSource,
+        updated_at: OffsetDateTime,
+    ) -> Result<BudgetRecord, StoreError> {
         sqlx::query(
             r#"
             INSERT INTO budgets (
                 budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
                 upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
-                created_at, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 1, $12, $13)
+                created_at, updated_at, source_kind, source_key
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 1, $12, $13, $14, $15)
             ON CONFLICT (scope_key) WHERE is_active = 1
             DO UPDATE SET
                 cadence = excluded.cadence,
                 amount_10000 = excluded.amount_10000,
                 hard_limit = excluded.hard_limit,
                 timezone = excluded.timezone,
+                source_kind = excluded.source_kind,
+                source_key = excluded.source_key,
                 updated_at = excluded.updated_at
             "#,
         )
@@ -99,6 +135,8 @@ impl BudgetRepository for PostgresStore {
         .bind(&settings.timezone)
         .bind(updated_at.unix_timestamp())
         .bind(updated_at.unix_timestamp())
+        .bind(source.kind.as_str())
+        .bind(source.key.as_deref())
         .execute(&self.pool)
         .await
         .map_err(to_query_error)?;
@@ -115,17 +153,22 @@ impl BudgetRepository for PostgresStore {
         scope: &BudgetScope,
         updated_at: OffsetDateTime,
     ) -> Result<bool, StoreError> {
+        let source = BudgetSource::manual_deactivated();
         let updated = sqlx::query(
             r#"
             UPDATE budgets
             SET is_active = 0,
-                updated_at = $1
+                updated_at = $1,
+                source_kind = $3,
+                source_key = $4
             WHERE scope_key = $2
               AND is_active = 1
             "#,
         )
         .bind(updated_at.unix_timestamp())
         .bind(scope.scope_key())
+        .bind(source.kind.as_str())
+        .bind(source.key)
         .execute(&self.pool)
         .await
         .map_err(to_query_error)?

--- a/crates/gateway-store/src/postgres_store/budgets.rs
+++ b/crates/gateway-store/src/postgres_store/budgets.rs
@@ -148,6 +148,93 @@ impl BudgetRepository for PostgresStore {
             })
     }
 
+    async fn upsert_active_budget_with_source_guard(
+        &self,
+        scope: &BudgetScope,
+        settings: &BudgetSettings,
+        source: &BudgetSource,
+        expected_current_source: Option<&BudgetSource>,
+        updated_at: OffsetDateTime,
+    ) -> Result<Option<BudgetRecord>, StoreError> {
+        if let Some(expected_source) = expected_current_source {
+            sqlx::query(
+                r#"
+                INSERT INTO budgets (
+                    budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
+                    upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
+                    created_at, updated_at, source_kind, source_key
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 1, $12, $13, $14, $15)
+                ON CONFLICT (scope_key) WHERE is_active = 1
+                DO UPDATE SET
+                    cadence = excluded.cadence,
+                    amount_10000 = excluded.amount_10000,
+                    hard_limit = excluded.hard_limit,
+                    timezone = excluded.timezone,
+                    source_kind = excluded.source_kind,
+                    source_key = excluded.source_key,
+                    updated_at = excluded.updated_at
+                WHERE budgets.source_kind = $16
+                  AND budgets.source_key IS NOT DISTINCT FROM $17
+                "#,
+            )
+            .bind(Uuid::new_v4().to_string())
+            .bind(scope.kind().as_str())
+            .bind(scope.scope_key())
+            .bind(scope.user_id().map(|id| id.to_string()))
+            .bind(scope.service_account_id().map(|id| id.to_string()))
+            .bind(scope.model_id().map(|id| id.to_string()))
+            .bind(scope.upstream_model().map(ToOwned::to_owned))
+            .bind(settings.cadence.as_str())
+            .bind(settings.amount_usd.as_scaled_i64())
+            .bind(if settings.hard_limit { 1_i64 } else { 0_i64 })
+            .bind(&settings.timezone)
+            .bind(updated_at.unix_timestamp())
+            .bind(updated_at.unix_timestamp())
+            .bind(source.kind.as_str())
+            .bind(source.key.as_deref())
+            .bind(expected_source.kind.as_str())
+            .bind(expected_source.key.as_deref())
+            .execute(&self.pool)
+            .await
+            .map_err(to_query_error)?;
+        } else {
+            sqlx::query(
+                r#"
+                INSERT INTO budgets (
+                    budget_id, scope_kind, scope_key, user_id, service_account_id, model_id,
+                    upstream_model, cadence, amount_10000, hard_limit, timezone, is_active,
+                    created_at, updated_at, source_kind, source_key
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 1, $12, $13, $14, $15)
+                ON CONFLICT (scope_key) WHERE is_active = 1
+                DO NOTHING
+                "#,
+            )
+            .bind(Uuid::new_v4().to_string())
+            .bind(scope.kind().as_str())
+            .bind(scope.scope_key())
+            .bind(scope.user_id().map(|id| id.to_string()))
+            .bind(scope.service_account_id().map(|id| id.to_string()))
+            .bind(scope.model_id().map(|id| id.to_string()))
+            .bind(scope.upstream_model().map(ToOwned::to_owned))
+            .bind(settings.cadence.as_str())
+            .bind(settings.amount_usd.as_scaled_i64())
+            .bind(if settings.hard_limit { 1_i64 } else { 0_i64 })
+            .bind(&settings.timezone)
+            .bind(updated_at.unix_timestamp())
+            .bind(updated_at.unix_timestamp())
+            .bind(source.kind.as_str())
+            .bind(source.key.as_deref())
+            .execute(&self.pool)
+            .await
+            .map_err(to_query_error)?;
+        }
+
+        match self.get_active_budget_by_scope(scope).await? {
+            Some(budget) if budget.source.matches(source) => Ok(Some(budget)),
+            Some(_) | None => Ok(None),
+        }
+    }
+
     async fn deactivate_active_budget(
         &self,
         scope: &BudgetScope,
@@ -169,6 +256,34 @@ impl BudgetRepository for PostgresStore {
         .bind(scope.scope_key())
         .bind(source.kind.as_str())
         .bind(source.key)
+        .execute(&self.pool)
+        .await
+        .map_err(to_query_error)?
+        .rows_affected();
+        Ok(updated > 0)
+    }
+
+    async fn deactivate_active_budget_by_source(
+        &self,
+        scope: &BudgetScope,
+        source: &BudgetSource,
+        updated_at: OffsetDateTime,
+    ) -> Result<bool, StoreError> {
+        let updated = sqlx::query(
+            r#"
+            UPDATE budgets
+            SET is_active = 0,
+                updated_at = $1
+            WHERE scope_key = $2
+              AND is_active = 1
+              AND source_kind = $3
+              AND source_key IS NOT DISTINCT FROM $4
+            "#,
+        )
+        .bind(updated_at.unix_timestamp())
+        .bind(scope.scope_key())
+        .bind(source.kind.as_str())
+        .bind(source.key.as_deref())
         .execute(&self.pool)
         .await
         .map_err(to_query_error)?

--- a/crates/gateway-store/src/postgres_store/mod.rs
+++ b/crates/gateway-store/src/postgres_store/mod.rs
@@ -26,15 +26,15 @@ use gateway_core::{
     BudgetAlertDeliveryStatus, BudgetAlertDispatchTask, BudgetAlertHistoryPage,
     BudgetAlertHistoryQuery, BudgetAlertHistoryRecord, BudgetAlertRecord, BudgetAlertRepository,
     BudgetCadence, BudgetModelSelector, BudgetRecord, BudgetRepository, BudgetScope,
-    BudgetScopeKind, BudgetSettings, ExternalMcpAuthMode, ExternalMcpDiscoveryRunRecord,
-    ExternalMcpDiscoveryStatus, ExternalMcpServerRecord, ExternalMcpServerStatus,
-    ExternalMcpToolRecord, ExternalMcpTransport, FocusExportAggregateRecord,
-    FocusExportDiagnosticsRecord, GatewayModel, GlobalRole, IdentityRepository, IdentityUserRecord,
-    MAX_MCP_TOOL_INVOCATION_PAGE_SIZE, McpAccessRepository, McpAccessResolution,
-    McpAggregateSessionRecord, McpAggregateSessionRepository, McpCatalogAccessResolution,
-    McpCatalogToolRecord, McpGrantSubject, McpRegistryRepository, McpTokenEstimateConfidence,
-    McpTokenEstimateSource, McpTokenOverheadRepository, McpToolGrantRecord,
-    McpToolGrantSubjectKind, McpToolGrantTargetKind, McpToolInvocationDetail,
+    BudgetScopeKind, BudgetSettings, BudgetSource, BudgetSourceKind, ExternalMcpAuthMode,
+    ExternalMcpDiscoveryRunRecord, ExternalMcpDiscoveryStatus, ExternalMcpServerRecord,
+    ExternalMcpServerStatus, ExternalMcpToolRecord, ExternalMcpTransport,
+    FocusExportAggregateRecord, FocusExportDiagnosticsRecord, GatewayModel, GlobalRole,
+    IdentityRepository, IdentityUserRecord, MAX_MCP_TOOL_INVOCATION_PAGE_SIZE, McpAccessRepository,
+    McpAccessResolution, McpAggregateSessionRecord, McpAggregateSessionRepository,
+    McpCatalogAccessResolution, McpCatalogToolRecord, McpGrantSubject, McpRegistryRepository,
+    McpTokenEstimateConfidence, McpTokenEstimateSource, McpTokenOverheadRepository,
+    McpToolGrantRecord, McpToolGrantSubjectKind, McpToolGrantTargetKind, McpToolInvocationDetail,
     McpToolInvocationPage, McpToolInvocationPayloadRecord, McpToolInvocationQuery,
     McpToolInvocationRecord, McpToolInvocationRepository, McpToolInvocationStatus,
     McpToolPolicyResult, McpToolTokenEstimateRecord, McpToolsetRecord, McpToolsetStatus,
@@ -676,6 +676,23 @@ impl GatewayStore for PostgresStore {
             users,
         )
         .await
+    }
+
+    async fn reconcile_human_budget_defaults(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        Self::reconcile_human_budget_defaults(self, defaults, updated_at).await
+    }
+
+    async fn apply_human_budget_defaults_for_user(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        user_id: Uuid,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        Self::apply_human_budget_defaults_for_user(self, defaults, user_id, updated_at).await
     }
 }
 

--- a/crates/gateway-store/src/postgres_store/seed.rs
+++ b/crates/gateway-store/src/postgres_store/seed.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::seed::{
-    generate_seed_api_key_material, managed_api_key_uuid, prevalidate_seed_users,
-    provided_seed_api_key_material, reconcile_seed_teams, reconcile_seed_users,
-    service_account_uuid, validate_seed_service_account_team_references,
+    apply_human_budget_defaults_for_user, generate_seed_api_key_material, managed_api_key_uuid,
+    prevalidate_seed_users, provided_seed_api_key_material, reconcile_human_budget_defaults,
+    reconcile_seed_teams, reconcile_seed_users, service_account_uuid,
+    validate_seed_service_account_team_references,
 };
 use crate::shared::{parse_uuid, serialize_json, serialize_optional_json};
 
@@ -774,5 +775,22 @@ impl PostgresStore {
         reconcile_seed_users(self, &seeded_teams, users, now).await?;
 
         Ok(())
+    }
+
+    pub async fn reconcile_human_budget_defaults(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        reconcile_human_budget_defaults(self, defaults, updated_at).await
+    }
+
+    pub async fn apply_human_budget_defaults_for_user(
+        &self,
+        defaults: &gateway_core::SeedHumanBudgetDefaults,
+        user_id: Uuid,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        apply_human_budget_defaults_for_user(self, defaults, user_id, updated_at).await
     }
 }

--- a/crates/gateway-store/src/postgres_store/support.rs
+++ b/crates/gateway-store/src/postgres_store/support.rs
@@ -498,6 +498,8 @@ pub(super) fn decode_budget_record(row: &PgRow) -> Result<BudgetRecord, StoreErr
     let is_active: i64 = row.try_get(11).map_err(to_query_error)?;
     let created_at: i64 = row.try_get(12).map_err(to_query_error)?;
     let updated_at: i64 = row.try_get(13).map_err(to_query_error)?;
+    let source_kind: String = row.try_get(14).map_err(to_query_error)?;
+    let source_key: Option<String> = row.try_get(15).map_err(to_query_error)?;
 
     let scope = match BudgetScopeKind::from_db(&scope_kind).ok_or_else(|| {
         StoreError::Serialization(format!("unknown budget scope kind `{scope_kind}`"))
@@ -540,6 +542,12 @@ pub(super) fn decode_budget_record(row: &PgRow) -> Result<BudgetRecord, StoreErr
             amount_usd: Money4::from_scaled(amount_10000),
             hard_limit: hard_limit == 1,
             timezone: row.try_get(10).map_err(to_query_error)?,
+        },
+        source: BudgetSource {
+            kind: BudgetSourceKind::from_db(&source_kind).ok_or_else(|| {
+                StoreError::Serialization(format!("unknown budget source kind `{source_kind}`"))
+            })?,
+            key: source_key,
         },
         is_active: is_active == 1,
         created_at: unix_to_datetime(created_at)?,

--- a/crates/gateway-store/src/seed.rs
+++ b/crates/gateway-store/src/seed.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeMap;
 
 use gateway_core::{
-    ApiKeySecretStorageKind, AuthMode, BudgetScope, BudgetSettings, GlobalRole, IdentityUserRecord,
-    MembershipRole, OauthProviderRecord, OidcProviderRecord, SeedApiKeySecretMaterial,
-    SeedManagedServiceAccountApiKey, SeedServiceAccount, SeedTeam, SeedUser, StoreError,
-    TeamRecord, UserStatus, encrypt_gateway_api_key_secret, generate_gateway_api_key_value,
-    hash_gateway_key_secret, parse_gateway_api_key,
+    ApiKeySecretStorageKind, AuthMode, BudgetModelSelector, BudgetScope, BudgetSettings,
+    BudgetSource, BudgetSourceKind, GlobalRole, IdentityUserRecord, MembershipRole,
+    OauthProviderRecord, OidcProviderRecord, SeedApiKeySecretMaterial, SeedHumanBudgetDefaults,
+    SeedManagedServiceAccountApiKey, SeedServiceAccount, SeedTeam, SeedUser,
+    SeedUserModelBudgetDefault, StoreError, TeamRecord, UserStatus, encrypt_gateway_api_key_secret,
+    generate_gateway_api_key_value, hash_gateway_key_secret, parse_gateway_api_key,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -197,6 +198,148 @@ where
     Ok(())
 }
 
+pub(crate) async fn reconcile_human_budget_defaults<S>(
+    store: &S,
+    defaults: &SeedHumanBudgetDefaults,
+    now: OffsetDateTime,
+) -> Result<(), StoreError>
+where
+    S: GatewayStore + ?Sized,
+{
+    for identity_user in store.list_identity_users().await? {
+        apply_human_budget_defaults_for_user(store, defaults, identity_user.user.user_id, now)
+            .await?;
+    }
+
+    deactivate_stale_config_default_budgets(store, defaults, now).await
+}
+
+pub(crate) async fn apply_human_budget_defaults_for_user<S>(
+    store: &S,
+    defaults: &SeedHumanBudgetDefaults,
+    user_id: Uuid,
+    now: OffsetDateTime,
+) -> Result<(), StoreError>
+where
+    S: GatewayStore + ?Sized,
+{
+    if let Some(default_budget) = defaults.default_user_budget.as_ref() {
+        let scope = BudgetScope::User { user_id };
+        upsert_if_config_default_allowed(
+            store,
+            &scope,
+            &budget_settings(default_budget),
+            &BudgetSource::config_user_default(),
+            now,
+        )
+        .await?;
+    }
+
+    for model_default in &defaults.model_defaults {
+        apply_user_model_default(store, model_default, user_id, now).await?;
+    }
+
+    Ok(())
+}
+
+async fn apply_user_model_default<S>(
+    store: &S,
+    model_default: &SeedUserModelBudgetDefault,
+    user_id: Uuid,
+    now: OffsetDateTime,
+) -> Result<(), StoreError>
+where
+    S: GatewayStore + ?Sized,
+{
+    let scope = BudgetScope::UserModel {
+        user_id,
+        selector: BudgetModelSelector::Model {
+            model_id: model_default.model_id,
+        },
+    };
+    upsert_if_config_default_allowed(
+        store,
+        &scope,
+        &budget_settings(&model_default.budget),
+        &BudgetSource::config_user_model_default(&model_default.model_key),
+        now,
+    )
+    .await
+}
+
+async fn upsert_if_config_default_allowed<S>(
+    store: &S,
+    scope: &BudgetScope,
+    settings: &BudgetSettings,
+    source: &BudgetSource,
+    now: OffsetDateTime,
+) -> Result<(), StoreError>
+where
+    S: GatewayStore + ?Sized,
+{
+    if let Some(existing) = store.get_active_budget_by_scope(scope).await?
+        && !existing.source.matches(source)
+    {
+        return Ok(());
+    }
+
+    if let Some(latest) = store.get_latest_budget_by_scope(scope).await?
+        && !latest.is_active
+        && latest.source.is_manual_deactivation()
+    {
+        return Ok(());
+    }
+
+    store
+        .upsert_active_budget_with_source(scope, settings, source, now)
+        .await?;
+    Ok(())
+}
+
+async fn deactivate_stale_config_default_budgets<S>(
+    store: &S,
+    defaults: &SeedHumanBudgetDefaults,
+    now: OffsetDateTime,
+) -> Result<(), StoreError>
+where
+    S: GatewayStore + ?Sized,
+{
+    let active_model_source_keys = defaults
+        .model_defaults
+        .iter()
+        .map(|default| {
+            BudgetSource::config_user_model_default(&default.model_key)
+                .key
+                .expect("model default source key")
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+
+    for budget in store.list_active_budgets(None).await? {
+        let should_deactivate = match budget.source.kind {
+            BudgetSourceKind::ConfigUserDefault => defaults.default_user_budget.is_none(),
+            BudgetSourceKind::ConfigUserModelDefault => match budget.source.key.as_ref() {
+                Some(key) => !active_model_source_keys.contains(key),
+                None => true,
+            },
+            BudgetSourceKind::Manual | BudgetSourceKind::ConfigUserOverride => false,
+        };
+        if should_deactivate {
+            store.deactivate_active_budget(&budget.scope, now).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn budget_settings(budget: &gateway_core::SeedBudget) -> BudgetSettings {
+    BudgetSettings {
+        cadence: budget.cadence,
+        amount_usd: budget.amount_usd,
+        hard_limit: budget.hard_limit,
+        timezone: budget.timezone.clone(),
+    }
+}
+
 async fn prevalidate_seed_user<S>(
     store: &S,
     identity_users: &[IdentityUserRecord],
@@ -311,25 +454,20 @@ where
     identity_user = load_identity_user(store, existing_user.user_id).await?;
     sync_seed_user_membership(store, &identity_user, teams_by_key, seed_user, now).await?;
 
-    match &seed_user.budget {
-        Some(budget) => {
-            let scope = BudgetScope::User {
-                user_id: existing_user.user_id,
-            };
-            let settings = BudgetSettings {
-                cadence: budget.cadence,
-                amount_usd: budget.amount_usd,
-                hard_limit: budget.hard_limit,
-                timezone: budget.timezone.clone(),
-            };
-            store.upsert_active_budget(&scope, &settings, now).await?;
+    if let Some(budget) = &seed_user.budget {
+        let scope = BudgetScope::User {
+            user_id: existing_user.user_id,
+        };
+        let settings = budget_settings(budget);
+        let source = BudgetSource::config_user_override(&seed_user.email_normalized);
+        if let Some(existing) = store.get_active_budget_by_scope(&scope).await?
+            && existing.source.kind == BudgetSourceKind::Manual
+        {
+            return Ok(());
         }
-        None => {
-            let scope = BudgetScope::User {
-                user_id: existing_user.user_id,
-            };
-            store.deactivate_active_budget(&scope, now).await?;
-        }
+        store
+            .upsert_active_budget_with_source(&scope, &settings, &source, now)
+            .await?;
     }
 
     Ok(())

--- a/crates/gateway-store/src/seed.rs
+++ b/crates/gateway-store/src/seed.rs
@@ -1,12 +1,13 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use gateway_core::{
     ApiKeySecretStorageKind, AuthMode, BudgetModelSelector, BudgetScope, BudgetSettings,
     BudgetSource, BudgetSourceKind, GlobalRole, IdentityUserRecord, MembershipRole,
-    OauthProviderRecord, OidcProviderRecord, SeedApiKeySecretMaterial, SeedHumanBudgetDefaults,
-    SeedManagedServiceAccountApiKey, SeedServiceAccount, SeedTeam, SeedUser,
-    SeedUserModelBudgetDefault, StoreError, TeamRecord, UserStatus, encrypt_gateway_api_key_secret,
-    generate_gateway_api_key_value, hash_gateway_key_secret, parse_gateway_api_key,
+    OauthProviderRecord, OidcProviderRecord, SYSTEM_BOOTSTRAP_ADMIN_USER_ID,
+    SeedApiKeySecretMaterial, SeedHumanBudgetDefaults, SeedManagedServiceAccountApiKey,
+    SeedServiceAccount, SeedTeam, SeedUser, SeedUserModelBudgetDefault, StoreError, TeamRecord,
+    UserStatus, encrypt_gateway_api_key_secret, generate_gateway_api_key_value,
+    hash_gateway_key_secret, parse_gateway_api_key,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -206,9 +207,23 @@ pub(crate) async fn reconcile_human_budget_defaults<S>(
 where
     S: GatewayStore + ?Sized,
 {
+    let mut user_ids = BTreeSet::new();
     for identity_user in store.list_identity_users().await? {
-        apply_human_budget_defaults_for_user(store, defaults, identity_user.user.user_id, now)
-            .await?;
+        user_ids.insert(identity_user.user.user_id);
+    }
+
+    let bootstrap_admin_user_id = Uuid::parse_str(SYSTEM_BOOTSTRAP_ADMIN_USER_ID)
+        .map_err(|error| StoreError::Unexpected(error.to_string()))?;
+    if store
+        .get_user_by_id(bootstrap_admin_user_id)
+        .await?
+        .is_some()
+    {
+        user_ids.insert(bootstrap_admin_user_id);
+    }
+
+    for user_id in user_ids {
+        apply_human_budget_defaults_for_user(store, defaults, user_id, now).await?;
     }
 
     deactivate_stale_config_default_budgets(store, defaults, now).await
@@ -277,8 +292,10 @@ async fn upsert_if_config_default_allowed<S>(
 where
     S: GatewayStore + ?Sized,
 {
-    if let Some(existing) = store.get_active_budget_by_scope(scope).await?
-        && !existing.source.matches(source)
+    let existing = store.get_active_budget_by_scope(scope).await?;
+    if existing
+        .as_ref()
+        .is_some_and(|budget| !budget.source.matches(source))
     {
         return Ok(());
     }
@@ -290,8 +307,15 @@ where
         return Ok(());
     }
 
+    let expected_current_source = existing.as_ref().map(|budget| &budget.source);
     store
-        .upsert_active_budget_with_source(scope, settings, source, now)
+        .upsert_active_budget_with_source_guard(
+            scope,
+            settings,
+            source,
+            expected_current_source,
+            now,
+        )
         .await?;
     Ok(())
 }
@@ -324,7 +348,9 @@ where
             BudgetSourceKind::Manual | BudgetSourceKind::ConfigUserOverride => false,
         };
         if should_deactivate {
-            store.deactivate_active_budget(&budget.scope, now).await?;
+            store
+                .deactivate_active_budget_by_source(&budget.scope, &budget.source, now)
+                .await?;
         }
     }
 
@@ -454,19 +480,32 @@ where
     identity_user = load_identity_user(store, existing_user.user_id).await?;
     sync_seed_user_membership(store, &identity_user, teams_by_key, seed_user, now).await?;
 
+    let scope = BudgetScope::User {
+        user_id: existing_user.user_id,
+    };
+    let source = BudgetSource::config_user_override(&seed_user.email_normalized);
     if let Some(budget) = &seed_user.budget {
-        let scope = BudgetScope::User {
-            user_id: existing_user.user_id,
-        };
-        let settings = budget_settings(budget);
-        let source = BudgetSource::config_user_override(&seed_user.email_normalized);
-        if let Some(existing) = store.get_active_budget_by_scope(&scope).await?
-            && existing.source.kind == BudgetSourceKind::Manual
+        let existing = store.get_active_budget_by_scope(&scope).await?;
+        if existing
+            .as_ref()
+            .is_some_and(|budget| budget.source.kind == BudgetSourceKind::Manual)
         {
             return Ok(());
         }
+        let settings = budget_settings(budget);
+        let expected_current_source = existing.as_ref().map(|budget| &budget.source);
         store
-            .upsert_active_budget_with_source(&scope, &settings, &source, now)
+            .upsert_active_budget_with_source_guard(
+                &scope,
+                &settings,
+                &source,
+                expected_current_source,
+                now,
+            )
+            .await?;
+    } else {
+        store
+            .deactivate_active_budget_by_source(&scope, &source, now)
             .await?;
     }
 

--- a/crates/gateway-store/src/store.rs
+++ b/crates/gateway-store/src/store.rs
@@ -702,12 +702,44 @@ impl BudgetRepository for AnyStore {
         )
     }
 
+    async fn upsert_active_budget_with_source_guard(
+        &self,
+        scope: &gateway_core::BudgetScope,
+        settings: &gateway_core::BudgetSettings,
+        source: &gateway_core::BudgetSource,
+        expected_current_source: Option<&gateway_core::BudgetSource>,
+        updated_at: OffsetDateTime,
+    ) -> Result<Option<gateway_core::BudgetRecord>, StoreError> {
+        dispatch_store!(
+            self,
+            upsert_active_budget_with_source_guard(
+                scope,
+                settings,
+                source,
+                expected_current_source,
+                updated_at
+            )
+        )
+    }
+
     async fn deactivate_active_budget(
         &self,
         scope: &gateway_core::BudgetScope,
         updated_at: OffsetDateTime,
     ) -> Result<bool, StoreError> {
         dispatch_store!(self, deactivate_active_budget(scope, updated_at))
+    }
+
+    async fn deactivate_active_budget_by_source(
+        &self,
+        scope: &gateway_core::BudgetScope,
+        source: &gateway_core::BudgetSource,
+        updated_at: OffsetDateTime,
+    ) -> Result<bool, StoreError> {
+        dispatch_store!(
+            self,
+            deactivate_active_budget_by_source(scope, source, updated_at)
+        )
     }
 
     async fn get_usage_ledger_by_request_and_scope(

--- a/crates/gateway-store/src/store.rs
+++ b/crates/gateway-store/src/store.rs
@@ -9,9 +9,10 @@ use gateway_core::{
     MembershipRole, ModelRepository, OauthLoginStateRecord, OauthProviderRecord,
     OidcLoginStateRecord, OidcProviderRecord, PasswordInvitationRecord, PricingCatalogRepository,
     ProviderRepository, RequestLogRepository, RequestTag, ReviewAgentRepository, SeedApiKey,
-    SeedModel, SeedOauthProvider, SeedOidcProvider, SeedProvider, SeedServiceAccount, SeedTeam,
-    SeedUser, StoreError, StoreHealth, TeamMembershipRecord, TeamRecord, UserOauthAuthRecord,
-    UserOidcAuthRecord, UserPasswordAuthRecord, UserRecord, UserSessionRecord, UserStatus,
+    SeedHumanBudgetDefaults, SeedModel, SeedOauthProvider, SeedOidcProvider, SeedProvider,
+    SeedServiceAccount, SeedTeam, SeedUser, StoreError, StoreHealth, TeamMembershipRecord,
+    TeamRecord, UserOauthAuthRecord, UserOidcAuthRecord, UserPasswordAuthRecord, UserRecord,
+    UserSessionRecord, UserStatus,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -366,6 +367,17 @@ pub trait GatewayStore:
         teams: &[SeedTeam],
         users: &[SeedUser],
     ) -> Result<(), StoreError>;
+    async fn reconcile_human_budget_defaults(
+        &self,
+        defaults: &SeedHumanBudgetDefaults,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError>;
+    async fn apply_human_budget_defaults_for_user(
+        &self,
+        defaults: &SeedHumanBudgetDefaults,
+        user_id: Uuid,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError>;
 }
 
 #[derive(Clone)]
@@ -654,6 +666,13 @@ impl BudgetRepository for AnyStore {
         dispatch_store!(self, get_active_budget_by_scope(scope))
     }
 
+    async fn get_latest_budget_by_scope(
+        &self,
+        scope: &gateway_core::BudgetScope,
+    ) -> Result<Option<gateway_core::BudgetRecord>, StoreError> {
+        dispatch_store!(self, get_latest_budget_by_scope(scope))
+    }
+
     async fn list_active_budgets(
         &self,
         scope_kind: Option<gateway_core::BudgetScopeKind>,
@@ -668,6 +687,19 @@ impl BudgetRepository for AnyStore {
         updated_at: OffsetDateTime,
     ) -> Result<gateway_core::BudgetRecord, StoreError> {
         dispatch_store!(self, upsert_active_budget(scope, settings, updated_at))
+    }
+
+    async fn upsert_active_budget_with_source(
+        &self,
+        scope: &gateway_core::BudgetScope,
+        settings: &gateway_core::BudgetSettings,
+        source: &gateway_core::BudgetSource,
+        updated_at: OffsetDateTime,
+    ) -> Result<gateway_core::BudgetRecord, StoreError> {
+        dispatch_store!(
+            self,
+            upsert_active_budget_with_source(scope, settings, source, updated_at)
+        )
     }
 
     async fn deactivate_active_budget(
@@ -1644,6 +1676,26 @@ impl GatewayStore for AnyStore {
                 teams,
                 users
             )
+        )
+    }
+
+    async fn reconcile_human_budget_defaults(
+        &self,
+        defaults: &SeedHumanBudgetDefaults,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        dispatch_store!(self, reconcile_human_budget_defaults(defaults, updated_at))
+    }
+
+    async fn apply_human_budget_defaults_for_user(
+        &self,
+        defaults: &SeedHumanBudgetDefaults,
+        user_id: Uuid,
+        updated_at: OffsetDateTime,
+    ) -> Result<(), StoreError> {
+        dispatch_store!(
+            self,
+            apply_human_budget_defaults_for_user(defaults, user_id, updated_at)
         )
     }
 }

--- a/crates/gateway/openapi/admin-api.json
+++ b/crates/gateway/openapi/admin-api.json
@@ -5417,6 +5417,23 @@
           }
         }
       },
+      "BudgetSourceView": {
+        "type": "object",
+        "required": [
+          "kind"
+        ],
+        "properties": {
+          "key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "kind": {
+            "type": "string"
+          }
+        }
+      },
       "BudgetUserModelByModelScopeRequest": {
         "type": "object",
         "required": [
@@ -7745,6 +7762,7 @@
               "scope",
               "scope_key",
               "budget",
+              "budget_source",
               "current_window_spend_usd_10000"
             ],
             "properties": {
@@ -7753,6 +7771,9 @@
               },
               "budget_id": {
                 "type": "string"
+              },
+              "budget_source": {
+                "$ref": "#/components/schemas/BudgetSourceView"
               },
               "current_window_spend_usd_10000": {
                 "type": "integer",
@@ -10085,6 +10106,16 @@
               }
             ]
           },
+          "budget_source": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BudgetSourceView"
+              }
+            ]
+          },
           "current_window_spend_usd_10000": {
             "type": "integer",
             "format": "int64"
@@ -10116,6 +10147,7 @@
           "scope_key",
           "user_id",
           "budget",
+          "budget_source",
           "current_window_spend_usd_10000",
           "alert_email_ready",
           "alert_recipient_summary"
@@ -10132,6 +10164,9 @@
           },
           "budget_id": {
             "type": "string"
+          },
+          "budget_source": {
+            "$ref": "#/components/schemas/BudgetSourceView"
           },
           "current_window_spend_usd_10000": {
             "type": "integer",
@@ -10181,6 +10216,16 @@
               },
               {
                 "$ref": "#/components/schemas/BudgetSettingsView"
+              }
+            ]
+          },
+          "budget_source": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BudgetSourceView"
               }
             ]
           },
@@ -10676,6 +10721,7 @@
           "scope",
           "scope_key",
           "budget",
+          "budget_source",
           "current_window_spend_usd_10000"
         ],
         "properties": {
@@ -10684,6 +10730,9 @@
           },
           "budget_id": {
             "type": "string"
+          },
+          "budget_source": {
+            "$ref": "#/components/schemas/BudgetSourceView"
           },
           "current_window_spend_usd_10000": {
             "type": "integer",

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -9,9 +9,10 @@ use gateway_core::{
     OpenAiCompatRouteCompatibility, OpenRouterMaxPrice, OpenRouterPercentileCutoffs,
     OpenRouterPercentilePreference, OpenRouterProviderRouting, OpenRouterRouteCompatibility,
     ProviderCapabilities, RequestLogRetentionWindow, RouteCompatibility, SeedApiKeySecretMaterial,
-    SeedBudget, SeedManagedServiceAccountApiKey, SeedModel, SeedModelRoute, SeedOauthProvider,
-    SeedOidcProvider, SeedProvider, SeedServiceAccount, SeedTeam, SeedUser, SeedUserMembership,
-    hash_gateway_key_secret, parse_gateway_api_key,
+    SeedBudget, SeedHumanBudgetDefaults, SeedManagedServiceAccountApiKey, SeedModel,
+    SeedModelRoute, SeedOauthProvider, SeedOidcProvider, SeedProvider, SeedServiceAccount,
+    SeedTeam, SeedUser, SeedUserMembership, SeedUserModelBudgetDefault, hash_gateway_key_secret,
+    parse_gateway_api_key,
 };
 use gateway_providers::{
     BedrockAuthConfig, BedrockEndpointKind, BedrockProviderConfig, CloudRunOpenAiCompatAuth,
@@ -24,6 +25,7 @@ use gateway_service::{
 use gateway_store::StoreConnectionOptions;
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
+use uuid::Uuid;
 
 mod providers;
 
@@ -44,6 +46,8 @@ pub struct GatewayConfig {
     pub auth: AuthConfig,
     #[serde(default)]
     pub budget_alerts: BudgetAlertConfig,
+    #[serde(default)]
+    pub budgets: BudgetsConfig,
     #[serde(default)]
     pub request_logging: RequestLoggingConfig,
     #[serde(default)]
@@ -384,6 +388,8 @@ impl GatewayConfig {
             }
         }
 
+        self.validate_budget_defaults(&model_by_id)?;
+
         let mut team_keys = std::collections::BTreeSet::new();
         for team in &self.teams {
             let team_key = normalize_config_team_key(&team.id)?;
@@ -545,6 +551,32 @@ impl GatewayConfig {
             if let Some(budget) = &user.budget {
                 budget.validate(&format!("user `{}` budget", user.email))?;
             }
+        }
+
+        Ok(())
+    }
+
+    fn validate_budget_defaults(
+        &self,
+        model_by_id: &BTreeMap<&str, &ModelConfig>,
+    ) -> anyhow::Result<()> {
+        if let Some(default_budget) = &self.budgets.users.default {
+            default_budget.validate("budgets.users.default")?;
+        }
+
+        let mut model_defaults = std::collections::BTreeSet::new();
+        for model_default in &self.budgets.users.model_defaults {
+            let model_key = normalize_config_model_key(&model_default.model)
+                .context("budgets.users.model_defaults model")?;
+            if !model_by_id.contains_key(model_key.as_str()) {
+                bail!("budgets.users.model_defaults references unknown model `{model_key}`");
+            }
+            if !model_defaults.insert(model_key.clone()) {
+                bail!("duplicate budgets.users.model_defaults model `{model_key}`");
+            }
+            model_default.budget.validate(&format!(
+                "budgets.users.model_defaults `{model_key}` budget"
+            ))?;
         }
 
         Ok(())
@@ -925,6 +957,35 @@ impl GatewayConfig {
                 })
             })
             .collect()
+    }
+
+    pub fn seed_human_budget_defaults(&self) -> anyhow::Result<SeedHumanBudgetDefaults> {
+        let default_user_budget = self
+            .budgets
+            .users
+            .default
+            .as_ref()
+            .map(BudgetConfig::seed_budget)
+            .transpose()?;
+        let model_defaults = self
+            .budgets
+            .users
+            .model_defaults
+            .iter()
+            .map(|model_default| {
+                let model_key = normalize_config_model_key(&model_default.model)?;
+                Ok(SeedUserModelBudgetDefault {
+                    model_id: config_model_uuid(&model_key),
+                    model_key,
+                    budget: model_default.budget.seed_budget()?,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(SeedHumanBudgetDefaults {
+            default_user_budget,
+            model_defaults,
+        })
     }
 
     pub fn openai_compatible_provider_configs(&self) -> anyhow::Result<Vec<OpenAiCompatConfig>> {
@@ -1908,6 +1969,29 @@ pub struct UserMembershipConfig {
     pub role: MembershipRole,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BudgetsConfig {
+    #[serde(default)]
+    pub users: UserBudgetDefaultsConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct UserBudgetDefaultsConfig {
+    #[serde(default)]
+    pub default: Option<BudgetConfig>,
+    #[serde(default)]
+    pub model_defaults: Vec<UserModelBudgetDefaultConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserModelBudgetDefaultConfig {
+    pub model: String,
+    pub budget: BudgetConfig,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct BudgetConfig {
     pub cadence: BudgetCadence,
@@ -2545,6 +2629,21 @@ fn normalize_config_team_key(team_key: &str) -> anyhow::Result<String> {
         bail!("team key cannot be empty");
     }
     Ok(normalized)
+}
+
+fn normalize_config_model_key(model_key: &str) -> anyhow::Result<String> {
+    let normalized = model_key.trim().to_string();
+    if normalized.is_empty() {
+        bail!("model key cannot be empty");
+    }
+    Ok(normalized)
+}
+
+fn config_model_uuid(model_key: &str) -> Uuid {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("model:{model_key}").as_bytes(),
+    )
 }
 
 fn normalize_config_service_account_key(service_account_key: &str) -> anyhow::Result<String> {
@@ -4647,6 +4746,125 @@ users:
         assert_eq!(user_budget.amount_usd, Money4::from_scaled(750_000));
         assert!(!user_budget.hard_limit);
         assert_eq!(user_budget.timezone, "Europe/London");
+    }
+
+    #[test]
+    fn parses_human_budget_defaults_into_seed_inputs() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+budgets:
+  users:
+    default:
+      cadence: daily
+      amount_usd: "70.0000"
+      hard_limit: true
+      timezone: UTC
+    model_defaults:
+      - model: " fable-5 "
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+          hard_limit: true
+          timezone: UTC
+models:
+  - id: fable-5
+    routes:
+      - provider: openai
+        upstream_model: fable-5
+providers:
+  - id: openai
+    type: openai_compat
+    base_url: https://api.openai.com/v1
+    pricing_provider_id: openai
+"#,
+        );
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+        let defaults = config
+            .seed_human_budget_defaults()
+            .expect("seed budget defaults");
+
+        let default_budget = defaults.default_user_budget.expect("default user budget");
+        assert_eq!(default_budget.cadence, BudgetCadence::Daily);
+        assert_eq!(default_budget.amount_usd, Money4::from_scaled(700_000));
+        assert!(default_budget.hard_limit);
+
+        assert_eq!(defaults.model_defaults.len(), 1);
+        assert_eq!(defaults.model_defaults[0].model_key, "fable-5");
+        assert_eq!(
+            defaults.model_defaults[0].budget.amount_usd,
+            Money4::from_scaled(400_000)
+        );
+    }
+
+    #[test]
+    fn rejects_human_budget_default_for_unknown_model() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+budgets:
+  users:
+    model_defaults:
+      - model: missing
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("budgets.users.model_defaults references unknown model `missing`"),
+            "unexpected error: {error_text}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_human_budget_model_defaults() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+
+        write_config(
+            &config_path,
+            r#"
+budgets:
+  users:
+    model_defaults:
+      - model: fable-5
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+      - model: " fable-5 "
+        budget:
+          cadence: daily
+          amount_usd: "30.0000"
+models:
+  - id: fable-5
+    routes:
+      - provider: openai
+        upstream_model: fable-5
+providers:
+  - id: openai
+    type: openai_compat
+    base_url: https://api.openai.com/v1
+    pricing_provider_id: openai
+"#,
+        );
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("duplicate budgets.users.model_defaults model `fable-5`"),
+            "unexpected error: {error_text}"
+        );
     }
 
     #[test]

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -714,6 +714,12 @@ pub struct BudgetSettingsView {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
+pub struct BudgetSourceView {
+    pub kind: String,
+    pub key: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SpendBudgetUserView {
     pub user_id: String,
     pub name: String,
@@ -721,6 +727,7 @@ pub struct SpendBudgetUserView {
     pub team_id: Option<String>,
     pub team_name: Option<String>,
     pub budget: Option<BudgetSettingsView>,
+    pub budget_source: Option<BudgetSourceView>,
     pub current_window_spend_usd_10000: i64,
     pub alert_email_ready: bool,
     pub alert_recipient_summary: String,
@@ -734,6 +741,7 @@ pub struct SpendBudgetUserModelView {
     pub model_id: Option<String>,
     pub upstream_model: Option<String>,
     pub budget: BudgetSettingsView,
+    pub budget_source: BudgetSourceView,
     pub current_window_spend_usd_10000: i64,
     pub alert_email_ready: bool,
     pub alert_recipient_summary: String,
@@ -748,6 +756,7 @@ pub struct SpendBudgetServiceAccountView {
     pub team_name: String,
     pub team_key: String,
     pub budget: Option<BudgetSettingsView>,
+    pub budget_source: Option<BudgetSourceView>,
     pub current_window_spend_usd_10000: i64,
     pub alert_email_ready: bool,
     pub alert_recipient_summary: String,
@@ -888,6 +897,7 @@ pub struct UpsertBudgetResultView {
     pub scope: BudgetScopeView,
     pub scope_key: String,
     pub budget: BudgetSettingsView,
+    pub budget_source: BudgetSourceView,
     pub current_window_spend_usd_10000: i64,
 }
 

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -754,6 +754,14 @@ pub async fn create_identity_user(
             .set_user_oauth_link(user.user_id, &provider.oauth_provider_id, created_at)
             .await?;
     }
+    state
+        .store
+        .apply_human_budget_defaults_for_user(
+            state.budget_defaults.as_ref(),
+            user.user_id,
+            created_at,
+        )
+        .await?;
 
     let response = build_onboarding_response(
         &state,
@@ -1968,6 +1976,10 @@ async fn create_jit_oidc_user(
         .store
         .update_user_status(user.user_id, UserStatus::Active, now)
         .await?;
+    state
+        .store
+        .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
+        .await?;
 
     state
         .store
@@ -2048,6 +2060,10 @@ async fn create_jit_oauth_user(
     state
         .store
         .update_user_status(user.user_id, UserStatus::Active, now)
+        .await?;
+    state
+        .store
+        .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
         .await?;
 
     state

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -1371,6 +1371,10 @@ pub async fn oidc_callback(
         if user.status == UserStatus::Disabled {
             return Ok(oidc_error_redirect("denied"));
         }
+        state
+            .store
+            .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
+            .await?;
         if user.status == UserStatus::Invited {
             state
                 .store
@@ -1395,6 +1399,10 @@ pub async fn oidc_callback(
                 Some(email.as_str()),
                 now,
             )
+            .await?;
+        state
+            .store
+            .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
             .await?;
         state
             .store
@@ -1606,6 +1614,10 @@ pub async fn oauth_callback_github(
         if user.status == UserStatus::Disabled {
             return Ok(oidc_error_redirect("denied"));
         }
+        state
+            .store
+            .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
+            .await?;
         if user.status == UserStatus::Invited {
             state
                 .store
@@ -1630,6 +1642,10 @@ pub async fn oauth_callback_github(
                 Some(email.as_str()),
                 now,
             )
+            .await?;
+        state
+            .store
+            .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
             .await?;
         state
             .store
@@ -1974,11 +1990,11 @@ async fn create_jit_oidc_user(
         .await?;
     state
         .store
-        .update_user_status(user.user_id, UserStatus::Active, now)
+        .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
         .await?;
     state
         .store
-        .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
+        .update_user_status(user.user_id, UserStatus::Active, now)
         .await?;
 
     state
@@ -2059,11 +2075,11 @@ async fn create_jit_oauth_user(
         .await?;
     state
         .store
-        .update_user_status(user.user_id, UserStatus::Active, now)
+        .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
         .await?;
     state
         .store
-        .apply_human_budget_defaults_for_user(state.budget_defaults.as_ref(), user.user_id, now)
+        .update_user_status(user.user_id, UserStatus::Active, now)
         .await?;
 
     state

--- a/crates/gateway/src/http/spend.rs
+++ b/crates/gateway/src/http/spend.rs
@@ -7,8 +7,8 @@ use axum::{
 use gateway_core::{
     ApiKeyOwnerKind, BudgetAlertChannel, BudgetAlertDeliveryStatus, BudgetAlertHistoryQuery,
     BudgetAlertRepository, BudgetCadence, BudgetModelSelector, BudgetRecord, BudgetRepository,
-    BudgetScope, BudgetScopeKind, BudgetSettings, GatewayError, IdentityRepository, MembershipRole,
-    ModelRepository, Money4, UserStatus, budget_window_utc,
+    BudgetScope, BudgetScopeKind, BudgetSettings, BudgetSource, GatewayError, IdentityRepository,
+    MembershipRole, ModelRepository, Money4, UserStatus, budget_window_utc,
 };
 use gateway_store::GatewayStore;
 use time::{Date, Duration, Month, OffsetDateTime, UtcOffset};
@@ -19,13 +19,14 @@ use crate::http::{
     admin_contract::{
         BudgetAlertHistoryItemView, BudgetAlertHistoryRequestQuery, BudgetAlertHistoryView,
         BudgetScopeRequest, BudgetScopeView, BudgetServiceAccountScopeKind,
-        BudgetServiceAccountScopeView, BudgetSettingsView, BudgetUserModelByModelScopeView,
-        BudgetUserModelByUpstreamModelScopeView, BudgetUserModelScopeKind, BudgetUserScopeKind,
-        BudgetUserScopeView, DeactivateBudgetRequest, DeactivateBudgetResultView, Envelope,
-        FocusExportQuery, FocusSelfExportQuery, SpendBudgetServiceAccountView,
-        SpendBudgetUserModelView, SpendBudgetUserView, SpendBudgetsView, SpendDailyPointView,
-        SpendModelBreakdownView, SpendOwnerBreakdownView, SpendReportQuery, SpendReportView,
-        SpendTotalsView, UpsertBudgetRequest, UpsertBudgetResultView, envelope, format_timestamp,
+        BudgetServiceAccountScopeView, BudgetSettingsView, BudgetSourceView,
+        BudgetUserModelByModelScopeView, BudgetUserModelByUpstreamModelScopeView,
+        BudgetUserModelScopeKind, BudgetUserScopeKind, BudgetUserScopeView,
+        DeactivateBudgetRequest, DeactivateBudgetResultView, Envelope, FocusExportQuery,
+        FocusSelfExportQuery, SpendBudgetServiceAccountView, SpendBudgetUserModelView,
+        SpendBudgetUserView, SpendBudgetsView, SpendDailyPointView, SpendModelBreakdownView,
+        SpendOwnerBreakdownView, SpendReportQuery, SpendReportView, SpendTotalsView,
+        UpsertBudgetRequest, UpsertBudgetResultView, envelope, format_timestamp,
     },
     error::AppError,
     focus_export::{FocusCsvExport, build_focus_csv_export},
@@ -262,6 +263,9 @@ pub async fn list_spend_budgets(
             team_id: user.team_id.map(|value| value.to_string()),
             team_name: user.team_name,
             budget: budget.as_ref().map(budget_to_settings_view),
+            budget_source: budget
+                .as_ref()
+                .map(|budget| budget_source_to_view(&budget.source)),
             current_window_spend_usd_10000: current_window_spend.as_scaled_i64(),
             alert_email_ready: true,
             alert_recipient_summary: user_email,
@@ -305,6 +309,9 @@ pub async fn list_spend_budgets(
             team_name: team.team_name.clone(),
             team_key: team.team_key.clone(),
             budget: budget.as_ref().map(budget_to_settings_view),
+            budget_source: budget
+                .as_ref()
+                .map(|budget| budget_source_to_view(&budget.source)),
             current_window_spend_usd_10000: current_window_spend.as_scaled_i64(),
             alert_email_ready: !recipients.is_empty(),
             alert_recipient_summary: if recipients.is_empty() {
@@ -365,6 +372,7 @@ pub async fn upsert_budget(
         scope: scope_to_view(&budget.scope),
         scope_key: budget.scope_key.clone(),
         budget: budget_to_settings_view(&budget),
+        budget_source: budget_source_to_view(&budget.source),
         current_window_spend_usd_10000: current_window_spend.as_scaled_i64(),
     })))
 }
@@ -474,6 +482,13 @@ fn budget_to_settings_view(record: &BudgetRecord) -> BudgetSettingsView {
     }
 }
 
+fn budget_source_to_view(source: &BudgetSource) -> BudgetSourceView {
+    BudgetSourceView {
+        kind: source.kind.as_str().to_string(),
+        key: source.key.clone(),
+    }
+}
+
 async fn active_user_model_budget_views(
     state: &AppState,
     now: OffsetDateTime,
@@ -505,6 +520,7 @@ async fn active_user_model_budget_views(
             model_id,
             upstream_model,
             budget: budget_to_settings_view(&budget),
+            budget_source: budget_source_to_view(&budget.source),
             current_window_spend_usd_10000: current_window_spend.as_scaled_i64(),
             alert_email_ready: user.is_some(),
             alert_recipient_summary: user

--- a/crates/gateway/src/http/state.rs
+++ b/crates/gateway/src/http/state.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gateway_core::ProviderRegistry;
+use gateway_core::{ProviderRegistry, SeedHumanBudgetDefaults};
 use gateway_service::{GatewayService, WeightedRoutePlanner};
 use gateway_store::AnyStore;
 
@@ -19,4 +19,5 @@ pub struct AppState {
     pub oidc_public_base_url: Arc<Option<String>>,
     pub oauth_public_base_url: Arc<Option<String>>,
     pub client_config_gateway_base_url: Arc<Option<String>>,
+    pub budget_defaults: Arc<SeedHumanBudgetDefaults>,
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -10,7 +10,7 @@ use gateway::{
     http::{build_router, state::AppState},
     observability,
 };
-use gateway_core::ProviderRegistry;
+use gateway_core::{ProviderRegistry, SeedHumanBudgetDefaults};
 use gateway_providers::{BedrockProvider, OpenAiCompatProvider, VertexProvider};
 use gateway_service::{
     DEFAULT_PRICING_CATALOG_REFRESH_INTERVAL, GatewayService, McpCredentialService,
@@ -119,6 +119,7 @@ where
     let oauth_providers_seed = config.seed_oauth_providers()?;
     let teams_seed = config.seed_teams()?;
     let users_seed = config.seed_users()?;
+    let human_budget_defaults = config.seed_human_budget_defaults()?;
 
     store
         .seed_from_inputs(
@@ -132,7 +133,11 @@ where
             &users_seed,
         )
         .await
-        .context("failed to seed foundational config data")
+        .context("failed to seed foundational config data")?;
+    store
+        .reconcile_human_budget_defaults(&human_budget_defaults, time::OffsetDateTime::now_utc())
+        .await
+        .context("failed to reconcile human budget defaults")
 }
 
 async fn run_serve(
@@ -156,10 +161,16 @@ async fn run_serve_with_store(
     metrics: Arc<observability::GatewayMetrics>,
     args: ServeArgs,
 ) -> anyhow::Result<()> {
+    let human_budget_defaults = Arc::new(config.seed_human_budget_defaults()?);
+
     if args.bootstrap_admin {
-        ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin)
-            .await
-            .context("failed to ensure bootstrap admin access")?;
+        ensure_bootstrap_admin(
+            &store,
+            &config.auth.bootstrap_admin,
+            human_budget_defaults.as_ref(),
+        )
+        .await
+        .context("failed to ensure bootstrap admin access")?;
     }
 
     if args.seed_config {
@@ -209,6 +220,7 @@ async fn run_serve_with_store(
                 load_client_config_gateway_base_url()
                     .context("failed resolving client config gateway base URL")?,
             ),
+            budget_defaults: human_budget_defaults,
         },
         load_admin_ui_config(),
     );
@@ -261,7 +273,8 @@ async fn run_bootstrap_admin_command(config: &GatewayConfig) -> anyhow::Result<(
             .await
             .context("failed to initialize gateway store")?,
     );
-    ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin).await
+    let human_budget_defaults = config.seed_human_budget_defaults()?;
+    ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin, &human_budget_defaults).await
 }
 
 async fn run_seed_config_command(config: &GatewayConfig) -> anyhow::Result<()> {
@@ -284,7 +297,8 @@ async fn run_seed_local_demo_command(config: &GatewayConfig) -> anyhow::Result<(
             .await
             .context("failed to initialize gateway store")?,
     );
-    ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin).await?;
+    let human_budget_defaults = config.seed_human_budget_defaults()?;
+    ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin, &human_budget_defaults).await?;
     seed_config(store.as_ref(), config).await?;
     let raw_keys = seed_local_demo_data(store.as_ref()).await?;
 
@@ -308,6 +322,7 @@ fn print_migration_status(status: &MigrationStatus) {
 async fn ensure_bootstrap_admin(
     store: &Arc<AnyStore>,
     config: &BootstrapAdminConfig,
+    human_budget_defaults: &SeedHumanBudgetDefaults,
 ) -> anyhow::Result<()> {
     if !config.enabled {
         return Ok(());
@@ -330,14 +345,15 @@ async fn ensure_bootstrap_admin(
         .context("failed resolving bootstrap admin password")?;
     let password_hash =
         hash_gateway_key_secret(&password).context("failed hashing bootstrap admin password")?;
+    let now = time::OffsetDateTime::now_utc();
     store
-        .store_user_password(
-            user.user_id,
-            &password_hash,
-            time::OffsetDateTime::now_utc(),
-        )
+        .store_user_password(user.user_id, &password_hash, now)
         .await
         .context("failed storing bootstrap admin password")?;
+    store
+        .apply_human_budget_defaults_for_user(human_budget_defaults, user.user_id, now)
+        .await
+        .context("failed applying bootstrap admin budget defaults")?;
 
     Ok(())
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -163,6 +163,10 @@ async fn run_serve_with_store(
 ) -> anyhow::Result<()> {
     let human_budget_defaults = Arc::new(config.seed_human_budget_defaults()?);
 
+    if args.seed_config {
+        seed_config(store.as_ref(), config).await?;
+    }
+
     if args.bootstrap_admin {
         ensure_bootstrap_admin(
             &store,
@@ -171,10 +175,6 @@ async fn run_serve_with_store(
         )
         .await
         .context("failed to ensure bootstrap admin access")?;
-    }
-
-    if args.seed_config {
-        seed_config(store.as_ref(), config).await?;
     }
 
     let service = build_gateway_service(config, store)?;

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -298,8 +298,8 @@ async fn run_seed_local_demo_command(config: &GatewayConfig) -> anyhow::Result<(
             .context("failed to initialize gateway store")?,
     );
     let human_budget_defaults = config.seed_human_budget_defaults()?;
-    ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin, &human_budget_defaults).await?;
     seed_config(store.as_ref(), config).await?;
+    ensure_bootstrap_admin(&store, &config.auth.bootstrap_admin, &human_budget_defaults).await?;
     let raw_keys = seed_local_demo_data(store.as_ref()).await?;
 
     println!("seeded local demo dataset");

--- a/docs/access/budgets.md
+++ b/docs/access/budgets.md
@@ -19,7 +19,7 @@ Supported budget types:
 - Service account budget: applies to all spend from one service account.
 - User model budget: applies to one user's spend for one gateway model or, when no gateway model id is available, one exact trimmed upstream model name.
 
-There is no global model budget. Model-specific spend control is scoped to a user through a user model budget.
+There is no standalone global model budget. Model-specific spend control is scoped to users. Admins can define config defaults that create a user model budget for every user for selected expensive models.
 
 Teams are not budget principals. Teams group users, own service accounts, and provide reporting metadata for service-account spend.
 
@@ -59,6 +59,19 @@ If a user has both a user model budget and a user budget, the model-specific bud
 
 User model budgets match the resolved gateway model id when one is available. Use the upstream model fallback only when the gateway cannot attach a model id to the ledger row; it matches the exact trimmed upstream model string.
 
+## Budget Sources
+
+Active budgets can come from:
+
+- admin UI or admin API changes
+- `users[*].budget` entries for config-seeded users
+- the global default user budget under `budgets.users.default`
+- per-model default user budgets under `budgets.users.model_defaults`
+
+Admin UI and admin API edits are manual overrides. Editing an inherited default budget converts that budget to manual, so later config reloads do not overwrite it.
+
+Deactivating an inherited budget through the admin API or UI is also a manual override. The budget remains inactive on later config reloads unless an admin creates a new manual budget or a config-seeded per-user budget explicitly owns that user's budget.
+
 ## Configure In The Admin UI
 
 Open `/admin/spend-controls`.
@@ -90,6 +103,13 @@ List budgets and current-window spend:
 curl -sS "$OCEANS_BASE_URL/api/v1/admin/spend/budgets" \
   -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE"
 ```
+
+Budget list and upsert responses include `budget_source` with:
+
+- `kind`: `manual`, `config_user_override`, `config_user_default`, or `config_user_model_default`
+- `key`: source-specific metadata, such as the config path or seeded user email
+
+Any `PUT /api/v1/admin/spend/budgets` request writes a manual budget, even when the previous row was inherited from config.
 
 Create or update a user budget:
 
@@ -202,7 +222,42 @@ users:
       timezone: UTC
 ```
 
-Omitting `budget` for a listed config-seeded user deactivates that user's active user budget during seed reconciliation.
+Omitting `budget` for a listed config-seeded user does not deactivate that user's active budget. Absence inherits the global default user budget when configured, or leaves any existing manual/API state alone.
+
+Set a default user budget for all human users with `budgets.users.default`:
+
+```yaml
+budgets:
+  users:
+    default:
+      cadence: daily
+      amount_usd: "70.0000"
+      hard_limit: true
+      timezone: UTC
+```
+
+Set default user model budgets for selected gateway models with `budgets.users.model_defaults`:
+
+```yaml
+budgets:
+  users:
+    default:
+      cadence: daily
+      amount_usd: "70.0000"
+      hard_limit: true
+      timezone: UTC
+    model_defaults:
+      - model: fable-5
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+          hard_limit: true
+          timezone: UTC
+```
+
+The `model` value is the configured gateway model id from `models[*].id`. These defaults apply to all human users, including config-seeded users, bootstrap admins, admin-created users, and JIT OIDC/OAuth users. They do not apply to service accounts.
+
+Config-seeded `users[*].budget` is a per-user override over `budgets.users.default`. Manual admin/API changes still take precedence over inherited defaults.
 
 Declarative service accounts define their owning team, budget, and managed gateway API keys:
 
@@ -226,7 +281,7 @@ service_accounts:
 
 The owning team must be declared in `teams`. The budget block is required.
 
-User model budgets are not currently part of the declarative YAML seed contract. Configure them in `/admin/spend-controls` or with `PUT /api/v1/admin/spend/budgets`.
+User-specific model budget overrides are configured in `/admin/spend-controls` or with `PUT /api/v1/admin/spend/budgets`.
 
 ## Monitor Budgets
 

--- a/docs/access/budgets.md
+++ b/docs/access/budgets.md
@@ -21,6 +21,8 @@ Supported budget types:
 
 There is no standalone global model budget. Model-specific spend control is scoped to users. Admins can define config defaults that create a user model budget for every user for selected expensive models.
 
+This is why model-specific defaults are configured under `budgets.users.model_defaults`, not under `models[*]`. A `models[*].budget` field would read like one shared cap for the model across the whole platform, or like a cap that also applies to service accounts. The actual behavior is narrower: each human user receives their own budget for that gateway model. Service-account spend remains controlled by that service account's own budget.
+
 Teams are not budget principals. Teams group users, own service accounts, and provide reporting metadata for service-account spend.
 
 MCP tool grants and toolsets are separate access controls. MCP token-overhead estimates report context-window pressure from tool definitions and results; they are not spend-budget accounting and do not create budget charges.
@@ -255,7 +257,9 @@ budgets:
           timezone: UTC
 ```
 
-The `model` value is the configured gateway model id from `models[*].id`. These defaults apply to all human users, including config-seeded users, bootstrap admins, admin-created users, and JIT OIDC/OAuth users. They do not apply to service accounts.
+The `model` value is the configured gateway model id from `models[*].id`. This does not create one shared `fable-5` budget. It creates a separate `fable-5` user model budget for each human user, so one user's spend does not consume another user's model-specific cap. These defaults apply to config-seeded users, bootstrap admins, admin-created users, and JIT OIDC/OAuth users. They do not apply to service accounts.
+
+Do not put budget defaults under `models[*]`. Model configuration defines routing, provider behavior, and access metadata for the gateway model. Budget defaults define spend policy for human users, so they live under the user budget policy.
 
 Config-seeded `users[*].budget` is a per-user override over `budgets.users.default`. Manual admin/API changes still take precedence over inherited defaults.
 

--- a/docs/access/budgets.md
+++ b/docs/access/budgets.md
@@ -4,7 +4,7 @@
 
 Budgets limit or monitor gateway spend for principals that can generate spend. They are spend controls, not model authorization controls; API-key grants and model access policies decide whether a caller may use a model before budget enforcement runs.
 
-## Budget Taxonomy
+## Taxonomy
 
 Spend-bearing principals are:
 
@@ -19,21 +19,32 @@ Supported budget types:
 - Service account budget: applies to all spend from one service account.
 - User model budget: applies to one user's spend for one gateway model or, when no gateway model id is available, one exact trimmed upstream model name.
 
+There is no global model budget. Model-specific spend control is scoped to a user through a user model budget.
+
 Teams are not budget principals. Teams group users, own service accounts, and provide reporting metadata for service-account spend.
 
 MCP tool grants and toolsets are separate access controls. MCP token-overhead estimates report context-window pressure from tool definitions and results; they are not spend-budget accounting and do not create budget charges.
 
-## Hard And Soft Budgets
+## Budget Levers
+
+Every budget has the same settings:
+
+- `cadence`: `daily`, `weekly`, or `monthly`
+- `amount_usd`: the spend cap, stored with four decimal places
+- `hard_limit`: `true` blocks chargeable traffic after the cap is reached; `false` only reports and alerts
+- `timezone`: stored with the budget for display and future window behavior
+
+Live enforcement windows currently use UTC:
+
+- daily windows start at `00:00:00 UTC`
+- weekly windows start at `Monday 00:00:00 UTC`
+- monthly windows start at `00:00:00 UTC` on the first day of the month
+
+## Hard And Soft Limits
 
 Hard budgets reject new chargeable traffic when the active window is already exhausted. If a request starts under the limit but its final priced usage would push the window over the budget, the gateway rejects that completed charge before recording it as spend.
 
 Soft budgets never reject traffic. They are useful for alerting and reporting when a team wants visibility before enforcing a hard cap.
-
-Both hard and soft budgets use an active window by cadence:
-
-- daily
-- weekly
-- monthly
 
 ## Overlap Rules
 
@@ -45,6 +56,197 @@ For human user traffic, Oceans checks budgets in this order:
 For service-account traffic, Oceans checks only the service-account budget.
 
 If a user has both a user model budget and a user budget, the model-specific budget is evaluated first. Both can still alert independently. Budgets do not grant model access; a request blocked by API-key grants or an allowlist never reaches the budget gate.
+
+User model budgets match the resolved gateway model id when one is available. Use the upstream model fallback only when the gateway cannot attach a model id to the ledger row; it matches the exact trimmed upstream model string.
+
+## Configure In The Admin UI
+
+Open `/admin/spend-controls`.
+
+The page has three budget sections:
+
+- User Budgets
+- Service Account Budgets
+- User Model Budgets
+
+Use User Budgets for normal human access. Choose the user, cadence, amount, timezone, and whether the budget is hard or soft.
+
+Use Service Account Budgets before activating automation credentials. Choose the service account and the same budget controls. Active service-account API keys require this budget.
+
+Use User Model Budgets when one user needs a lower or separate limit for a specific model. Choose the user, then choose either:
+
+- a gateway model from the model selector, when the gateway model id is known
+- the exact trimmed upstream model name only for fallback cases where no gateway model id is available
+
+Then set cadence, amount, timezone, and hard-limit behavior.
+
+## Configure With The Admin API
+
+Admins can manage the same budget scopes through `/api/v1/admin/spend/budgets`.
+
+List budgets and current-window spend:
+
+```bash
+curl -sS "$OCEANS_BASE_URL/api/v1/admin/spend/budgets" \
+  -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE"
+```
+
+Create or update a user budget:
+
+```bash
+curl -sS -X PUT "$OCEANS_BASE_URL/api/v1/admin/spend/budgets" \
+  -H "content-type: application/json" \
+  -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE" \
+  --data '{
+    "scope": {
+      "kind": "user",
+      "user_id": "00000000-0000-0000-0000-000000000000"
+    },
+    "cadence": "monthly",
+    "amount_usd": "100.0000",
+    "hard_limit": true,
+    "timezone": "UTC"
+  }'
+```
+
+Create or update a service-account budget:
+
+```bash
+curl -sS -X PUT "$OCEANS_BASE_URL/api/v1/admin/spend/budgets" \
+  -H "content-type: application/json" \
+  -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE" \
+  --data '{
+    "scope": {
+      "kind": "service_account",
+      "service_account_id": "00000000-0000-0000-0000-000000000000"
+    },
+    "cadence": "daily",
+    "amount_usd": "25.0000",
+    "hard_limit": true,
+    "timezone": "UTC"
+  }'
+```
+
+Create or update a user model budget with the managed gateway model id:
+
+```bash
+curl -sS -X PUT "$OCEANS_BASE_URL/api/v1/admin/spend/budgets" \
+  -H "content-type: application/json" \
+  -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE" \
+  --data '{
+    "scope": {
+      "kind": "user_model",
+      "user_id": "00000000-0000-0000-0000-000000000000",
+      "model_id": "00000000-0000-0000-0000-000000000000"
+    },
+    "cadence": "daily",
+    "amount_usd": "5.0000",
+    "hard_limit": true,
+    "timezone": "UTC"
+  }'
+```
+
+Create or update a user model budget with the upstream-model fallback:
+
+```bash
+curl -sS -X PUT "$OCEANS_BASE_URL/api/v1/admin/spend/budgets" \
+  -H "content-type: application/json" \
+  -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE" \
+  --data '{
+    "scope": {
+      "kind": "user_model",
+      "user_id": "00000000-0000-0000-0000-000000000000",
+      "upstream_model": "gpt-5"
+    },
+    "cadence": "daily",
+    "amount_usd": "5.0000",
+    "hard_limit": true,
+    "timezone": "UTC"
+  }'
+```
+
+Deactivate a budget by posting the same scope:
+
+```bash
+curl -sS -X POST "$OCEANS_BASE_URL/api/v1/admin/spend/budgets/deactivate" \
+  -H "content-type: application/json" \
+  -H "cookie: $OCEANS_ADMIN_SESSION_COOKIE" \
+  --data '{
+    "scope": {
+      "kind": "user_model",
+      "user_id": "00000000-0000-0000-0000-000000000000",
+      "model_id": "00000000-0000-0000-0000-000000000000"
+    }
+  }'
+```
+
+`model_id` is the gateway model UUID from the admin models API/UI, not the model key that callers send as `model`.
+
+## Configure From YAML
+
+Config-seeded users can include one active user budget:
+
+```yaml
+users:
+  - name: Platform Admin
+    email: ops@example.com
+    auth_mode: password
+    global_role: platform_admin
+    membership:
+      team: platform
+      role: admin
+    budget:
+      cadence: monthly
+      amount_usd: "100.0000"
+      hard_limit: true
+      timezone: UTC
+```
+
+Omitting `budget` for a listed config-seeded user deactivates that user's active user budget during seed reconciliation.
+
+Declarative service accounts define their owning team, budget, and managed gateway API keys:
+
+```yaml
+service_accounts:
+  - id: ci-indexer
+    name: CI Indexer
+    team: platform
+    budget:
+      cadence: daily
+      amount_usd: "25.0000"
+      hard_limit: true
+      timezone: UTC
+    keys:
+      - id: primary
+        name: CI Indexer Primary
+        value: env.CI_INDEXER_GATEWAY_API_KEY
+        allowed_models:
+          - fast
+```
+
+The owning team must be declared in `teams`. The budget block is required.
+
+User model budgets are not currently part of the declarative YAML seed contract. Configure them in `/admin/spend-controls` or with `PUT /api/v1/admin/spend/budgets`.
+
+## Monitor Budgets
+
+`/admin/spend-controls` shows:
+
+- each user budget and current-window spend
+- each service-account budget and current-window spend
+- active user model budgets and current-window spend
+- alert recipient readiness
+- recent threshold alert delivery status
+
+Budget alert history is also available from `GET /api/v1/admin/spend/budget-alerts`.
+
+Alerts are created when remaining budget crosses to `20%` or less. User and user model budget alerts go to the user's email. Service-account budget alerts go to active owners and admins of the owning team.
+
+Spend reporting and export live outside the budget setup page:
+
+- `GET /api/v1/admin/spend/report`
+- `GET /api/v1/admin/spend/focus.csv`
+- `GET /api/v1/me/spend/focus.csv`
 
 ## Embedding Spend
 
@@ -74,48 +276,3 @@ To cap automation that uses embeddings, create or select the gateway service acc
 Active service-account API keys require an active service-account budget. This is true for keys created in the admin UI and keys seeded from configuration.
 
 Admins cannot deactivate a service-account budget while active API keys exist for that service account. Revoke or deactivate the keys first.
-
-## Admin UI Setup
-
-Open `/admin/spend-controls`.
-
-The page has three budget sections:
-
-- User Budgets
-- Service Account Budgets
-- User Model Budgets
-
-Use User Budgets for normal human access. Choose the user, cadence, amount, timezone, and whether the budget is hard or soft.
-
-Use Service Account Budgets before activating automation credentials. Choose the service account and the same budget controls. Active service-account API keys require this budget.
-
-Use User Model Budgets when one user needs a lower or separate limit for a specific model. Choose the user, then choose either:
-
-- a gateway model from the model selector, when the gateway model id is known
-- the exact trimmed upstream model name only for fallback cases where no gateway model id is available
-
-Then set cadence, amount, timezone, and hard-limit behavior.
-
-## Config-Seeded Service Accounts
-
-Declarative service accounts define their owning team, budget, and managed gateway API keys:
-
-```yaml
-service_accounts:
-  - id: ci-indexer
-    name: CI Indexer
-    team: platform
-    budget:
-      cadence: daily
-      amount_usd: "25.0000"
-      hard_limit: true
-      timezone: UTC
-    keys:
-      - id: primary
-        name: CI Indexer Primary
-        value: env.CI_INDEXER_GATEWAY_API_KEY
-        allowed_models:
-          - fast
-```
-
-The owning team must be declared in `teams`. The budget block is required.

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -22,6 +22,7 @@ This page owns config syntax and parse-time rules. It does not own the full runt
 - `server`
 - `database`
 - `auth`
+- `budgets`
 - `budget_alerts`
 - `request_logging`
 - `providers`
@@ -89,6 +90,21 @@ auth:
     password: env.GATEWAY_BOOTSTRAP_ADMIN_PASSWORD
     require_password_change: true
 
+budgets:
+  users:
+    default:
+      cadence: daily
+      amount_usd: "70.0000"
+      hard_limit: true
+      timezone: UTC
+    model_defaults:
+      - model: gemini-2.0-flash
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+          hard_limit: true
+          timezone: UTC
+
 providers:
   - id: vertex
     type: gcp_vertex
@@ -150,6 +166,8 @@ Important defaults from config parsing and domain deserialization:
 - `request_logging.payloads.stream_max_events` defaults to `128`
 - `request_logging.purge.enabled` defaults to `false`
 - `request_logging.purge.retention` defaults to `7d`
+- `budgets.users.default` is absent by default; when present, it creates inherited user budgets for all human users
+- `budgets.users.model_defaults` is empty by default; entries create inherited user model budgets for all human users for selected gateway models
 
 The startup meaning of bootstrap-admin lives in [runtime-bootstrap-and-access.md](../setup/runtime-bootstrap-and-access.md). Non-human data-plane access is managed through [service accounts](../access/service-accounts.md), not config-seeded legacy runtime keys.
 
@@ -395,6 +413,49 @@ Important `users` fields:
 - `membership.role`
 - `budget`
 
+## `budgets`
+
+`budgets.users` defines inherited budget policy for human users. It does not apply to service accounts.
+
+```yaml
+budgets:
+  users:
+    default:
+      cadence: daily
+      amount_usd: "70.0000"
+      hard_limit: true
+      timezone: UTC
+    model_defaults:
+      - model: fable-5
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+          hard_limit: true
+          timezone: UTC
+```
+
+Important fields:
+
+- `users.default`: optional default user budget for all human users
+- `users.model_defaults[].model`: gateway model id from `models[*].id`
+- `users.model_defaults[].budget`: default user model budget applied per human user for that model
+
+Validation rules:
+
+- default budget amounts must be non-negative
+- model-default entries must reference an existing configured gateway model
+- duplicate model-default entries are rejected after model id normalization
+
+Runtime semantics:
+
+- defaults apply to config-seeded users, bootstrap admins, admin-created users, and JIT OIDC/OAuth users
+- `users[*].budget` is a config-seeded per-user override over `budgets.users.default`
+- admin UI/API edits convert inherited default rows to manual rows
+- admin UI/API deactivation is the escape hatch from inheritance
+- omitting a `users[*].budget` block means inherit; it does not deactivate a budget
+
+For the full budget taxonomy and precedence rules, see [budgets.md](../access/budgets.md).
+
 Validation rules that matter:
 
 - team IDs must be unique
@@ -416,8 +477,8 @@ Seed semantics that matter:
 - listed managed service-account keys are upserted by `service_accounts[*].keys[*].id`
 - listed users are upserted by normalized email
 - new config-seeded users are created as `invited`
-- listed membership and active-budget state is reconciled for listed users
-- omitting a `budget` block for a listed user deactivates that user's active budget
+- listed membership and explicit `users[*].budget` state is reconciled for listed users
+- omitting a `budget` block for a listed user inherits global defaults or leaves manual/API state untouched
 - unlisted teams, service accounts, keys, and users are left untouched
 
 OIDC and OAuth provider existence is validated at seed time against enabled runtime providers, not YAML parse time.

--- a/docs/contributing/operations/budgets-and-spending.md
+++ b/docs/contributing/operations/budgets-and-spending.md
@@ -69,6 +69,19 @@ Supported `scope_kind` values:
 
 Team budget scopes do not exist. Migration-only references to historical team budget tables are confined to migration SQL.
 
+## Budget Sources
+
+Budget rows carry source metadata:
+
+- `manual`: admin UI/API-created budgets and admin UI/API deactivation tombstones
+- `config_user_override`: explicit `users[*].budget` entries
+- `config_user_default`: inherited `budgets.users.default` rows
+- `config_user_model_default`: inherited `budgets.users.model_defaults` rows
+
+Source metadata is exposed in v1 admin spend API responses as `budget_source`. It lets the admin UI distinguish inherited rows from manual rows without guessing from scope or amount.
+
+Manual rows are precedence boundaries. Default reconciliation does not overwrite an active manual budget. Deactivation writes a manual inactive tombstone so absence continues to inherit by default, while admin/API deactivation remains the explicit escape hatch.
+
 ## Enforcement Order
 
 Budget checks run after authentication, model access evaluation, and model resolution. API-key grants, principal-centric allowlists, and model-level allowlists can deny a request before the budget guard runs; those denials do not consume budget windows.
@@ -145,6 +158,7 @@ Budget mutation requests use typed `scope` objects. Responses include:
 - typed `scope`
 - computed `scope_key`
 - settings
+- source metadata
 - current-window spend
 - alert readiness
 
@@ -173,6 +187,16 @@ Config-seeded API keys must declare the service account they create or reconcile
 - model grants
 
 There is no implicit singleton service account, no reserved `system-legacy` team, and no team-owned runtime key fallback.
+
+Human budget defaults are reconciled after ordinary config seeding:
+
+- `budgets.users.default` applies a user budget to every human user unless a manual budget or manual deactivation exists for that scope
+- `budgets.users.model_defaults` applies a user model budget to every human user for each listed gateway model unless a manual budget or manual deactivation exists for that user/model scope
+- `users[*].budget` creates a config-owned per-user override for listed users
+- omitting `users[*].budget` is a no-op for that user's budget; inheritance and manual/API state decide the active row
+- removing a config default deactivates active rows still owned by that config default source
+
+Runtime user creation paths also apply the same defaults for bootstrap admins, admin-created users, and JIT OIDC/OAuth users.
 
 ## Validation
 

--- a/docs/plans/2026-07-06-issue-227-budget-default-policies.md
+++ b/docs/plans/2026-07-06-issue-227-budget-default-policies.md
@@ -1,0 +1,524 @@
+# Issue 227: Declarative Default User And User-Model Budget Policies
+
+`See also`: [Budgets](../access/budgets.md), [Configuration Reference](../configuration/configuration-reference.md), [Budgets and Spending](../contributing/operations/budgets-and-spending.md), [Identity and Access](../access/identity-and-access.md), [Request Lifecycle and Failure Modes](../reference/request-lifecycle-and-failure-modes.md), [Data Relationships](../contributing/reference/data-relationships.md), [ADR: Declarative Config-Seeded Identity and Budget Reconciliation](../adr/2026-03-31-declarative-config-seeded-identity-and-budget-reconciliation.md)
+
+- Date: 2026-07-06
+- Status: Draft plan
+- GitHub issue: [#227](https://github.com/ahstn/oceans-llm/issues/227)
+- Primary target: declarative budget defaults for all human users, plus selected per-user model defaults for expensive gateway models
+
+## Summary
+
+Add a top-level `budgets` config object that lets admins express the common platform spend posture once:
+
+```yaml
+budgets:
+  users:
+    default:
+      cadence: daily
+      amount_usd: "70.0000"
+      hard_limit: true
+      timezone: UTC
+    model_defaults:
+      - model: fable-5
+        budget:
+          cadence: daily
+          amount_usd: "40.0000"
+          hard_limit: true
+          timezone: UTC
+```
+
+The defaults must apply to every human user represented in the gateway, including config-seeded users, admin-created users, bootstrap-created admins, and OIDC/OAuth/JIT-created users. Existing `users[*].budget` stays as an explicit per-user override. Service-account budget semantics do not change.
+
+Implementation should materialize defaults into the existing `BudgetScope::User` and `BudgetScope::UserModel` rows so request-path enforcement remains unchanged. The main new work is policy parsing, source-aware budget reconciliation, and user-creation hooks that keep future users covered.
+
+## Terms
+
+- Default user budget: a per-user budget created from `budgets.users.default`. It is not a single shared pool.
+- Default user-model budget: a per-user, per-model budget created from `budgets.users.model_defaults[*]`.
+- Explicit user budget: a `users[*].budget` block for a config-seeded user.
+- Manual budget: a budget created or edited through the admin UI/API.
+- Aggregate global user budget: one shared cap across all human users. This is out of scope for issue #227.
+
+## Goals
+
+- Add declarative config for one default user budget.
+- Add declarative config for a concise list of selected model-specific user budget defaults.
+- Apply defaults to all human users regardless of creation path.
+- Preserve explicit per-user overrides.
+- Preserve manual admin-created exceptions unless config explicitly owns that scope.
+- Reconcile default updates and removals predictably.
+- Keep enforcement, ledger writes, alerts, and spend reports on the existing budget scopes.
+- Update user-facing budget docs, config syntax docs, and maintainer-facing budget internals.
+
+## Non-Goals
+
+- A single aggregate budget shared by all users.
+- Team budgets or team budget principals.
+- Service-account budget defaults.
+- Adding budget fields under every `models[*]` entry.
+- Adding upstream-model declarative defaults in v1.
+- Changing request-path enforcement order.
+- Changing budget windows or introducing timezone-based enforcement.
+
+## Decisions
+
+1. Use a top-level `budgets` object.
+   - Budget policy is spend governance. It should not be scattered through mostly empty `models[*]` entries.
+   - Model-specific defaults are expected to be rare and expensive-model focused, so a short list under `budgets.users.model_defaults` is easier to audit.
+
+2. `model_defaults[*].model` references `models[*].id`.
+   - Config already uses model keys for declarative references such as service-account `allowed_models`.
+   - Stored budget scopes should use the deterministic gateway model UUID resolved from that key.
+   - Do not require admins to duplicate provider upstream model strings.
+
+3. Defaults materialize into ordinary active budget rows.
+   - `BudgetGuard` and `applicable_budget_scopes` already enforce user-model then user budgets.
+   - Request handling should not learn a second policy system.
+
+4. Budget rows need ownership metadata.
+   - The current `budgets` table cannot distinguish a default-derived row from an admin-created row.
+   - Source metadata is required to update/remove config-owned rows without clobbering manual exceptions.
+   - Source metadata should be exposed in v1 admin API responses.
+
+5. Defaults apply to all human users.
+   - Do not filter by role, auth mode, status, or creation source.
+   - Disabled users may receive reconciled default rows; they cannot spend while disabled.
+
+6. Admin edits convert inherited rows to manual.
+   - If an admin edits a config-default-owned budget through the UI/API, the active row becomes a manual exception.
+   - Future config-default reconciliation must not overwrite that scope unless the manual row is removed or deactivated.
+
+7. Absence always inherits.
+   - A listed user without `users[*].budget` inherits the platform default when one exists.
+   - Manual/API deactivation is the escape hatch for users that should not have an active budget.
+   - Do not add an opt-out YAML syntax in v1.
+
+## External Context
+
+Exa search found two useful industry patterns:
+
+- Cloudflare AI Gateway spend limits can scope cost caps by model and custom metadata such as user/team, and distinguish per-value partitions from shared buckets: https://developers.cloudflare.com/ai-gateway/features/spend-limits/
+- LangSmith LLM Gateway spend policies distinguish defaults from materialized child policies and retain parent/source ownership metadata for safe updates and deletes: https://docs.langchain.com/langsmith/llm-gateway-spend-policies
+
+The relevant lesson is not to copy either API shape. The useful pattern is source-owned default materialization: defaults create per-user children, and future reconciliation knows which rows it may manage.
+
+## Current Local State
+
+- `crates/gateway-core/src/budgets.rs` defines `BudgetScope::{User, ServiceAccount, UserModel}` and `BudgetModelSelector::{Model, UpstreamModel}`.
+- `crates/gateway-service/src/budget_scopes.rs` evaluates human user scopes as user-model first, then user.
+- `crates/gateway-service/src/budget_guard.rs` enforces active budget rows before provider execution and again before recording priced usage.
+- `crates/gateway-store/migrations/V28__generic_budget_scopes.sql` created the generic `budgets` table with one active row per `scope_key`.
+- `crates/gateway-store/src/libsql_store/budgets.rs` and `crates/gateway-store/src/postgres_store/budgets.rs` implement `upsert_active_budget` as a blind active-scope upsert.
+- `crates/gateway/src/config.rs` supports `users[*].budget` and required `service_accounts[*].budget`, but no top-level `budgets` object.
+- `crates/gateway-store/src/seed.rs::reconcile_seed_user` currently treats `users[*].budget: None` as deactivation of that user's active user budget.
+- Admin-created users are created in `crates/gateway/src/http/identity.rs::create_identity_user`.
+- OIDC/OAuth JIT users are created in `create_jit_oidc_user` and `create_jit_oauth_user`.
+- `AppState` does not currently carry a compact budget-default policy.
+
+## Target Architecture
+
+```mermaid
+flowchart TD
+    Config["gateway.yaml budgets.users"] --> Parse["GatewayConfig validation"]
+    Parse --> Policy["HumanBudgetDefaults"]
+    Policy --> Seed["startup config seed reconciliation"]
+    Policy --> Runtime["AppState budget default reconciler"]
+    Seed --> Existing["existing human users"]
+    Runtime --> AdminCreate["admin-created users"]
+    Runtime --> JitCreate["OIDC/OAuth JIT users"]
+    Existing --> Materialized["active budget rows with source metadata"]
+    AdminCreate --> Materialized
+    JitCreate --> Materialized
+    Materialized --> Guard["existing BudgetGuard enforcement"]
+```
+
+Boundary placement:
+
+- YAML parsing and model-key validation stay in `crates/gateway/src/config.rs`.
+- Durable policy DTOs belong near the budget domain in `crates/gateway-core/src/budgets.rs` or a sibling module.
+- Store-specific budget source columns and source-aware upserts belong in `gateway-store`.
+- A small budget-default reconciliation service should live outside `http/spend.rs`; spend APIs remain direct budget mutation endpoints.
+- Request-path enforcement remains unchanged.
+
+## Config Contract
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BudgetsConfig {
+    #[serde(default)]
+    pub users: UserBudgetDefaultsConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct UserBudgetDefaultsConfig {
+    #[serde(default)]
+    pub default: Option<BudgetConfig>,
+    #[serde(default)]
+    pub model_defaults: Vec<UserModelBudgetDefaultConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UserModelBudgetDefaultConfig {
+    pub model: String,
+    pub budget: BudgetConfig,
+}
+```
+
+Validation rules:
+
+- `budgets.users.default`, when present, uses existing `BudgetConfig::validate`.
+- `model_defaults[*].model` trims and normalizes as a config model key.
+- `model_defaults[*].model` must reference a configured `models[*].id`.
+- duplicate model defaults are rejected after normalization.
+- `model_defaults[*].budget` uses existing budget validation.
+- unknown fields are rejected.
+- negative amounts remain rejected.
+
+Seed/domain shape:
+
+```rust
+pub struct SeedHumanBudgetDefaults {
+    pub default_user_budget: Option<SeedBudget>,
+    pub model_defaults: Vec<SeedUserModelBudgetDefault>,
+}
+
+pub struct SeedUserModelBudgetDefault {
+    pub model_key: String,
+    pub model_id: Uuid,
+    pub budget: SeedBudget,
+}
+```
+
+Use deterministic model UUID resolution from config model key so the stored `UserModel` scope uses `BudgetModelSelector::Model`.
+
+## Budget Source Metadata
+
+Add source metadata to active and historical budget rows.
+
+Recommended columns:
+
+```sql
+source_kind TEXT NOT NULL DEFAULT 'manual'
+source_key TEXT
+```
+
+Recommended `source_kind` values:
+
+- `manual`: admin UI/API-created or pre-migration rows
+- `config_user_override`: row is owned by a `users[*].budget` block
+- `config_user_default`: row is owned by `budgets.users.default`
+- `config_user_model_default`: row is owned by `budgets.users.model_defaults[*]`
+
+Recommended `source_key` values:
+
+- `NULL` for `manual`
+- normalized user email for `config_user_override`
+- `budgets.users.default` for the default user policy
+- `budgets.users.model_defaults:<model_key>` for model defaults
+
+Store invariants:
+
+- Existing rows migrate as `manual`.
+- Admin UI/API upserts write `manual`.
+- Explicit `users[*].budget` upserts may replace a config-default-owned row for that same user scope.
+- Default reconciliation may update only rows whose active scope is absent or whose source matches the same default source.
+- Default reconciliation must skip active `manual` and `config_user_override` rows.
+- Removing a default deactivates only active rows with the matching config-default source.
+
+This metadata should be returned on internal `BudgetRecord` and exposed in v1 admin API budget responses. Label it as source/ownership state rather than a user-editable field.
+
+## Reconciliation Semantics
+
+### Startup Seed
+
+The seed entrypoint should pass `SeedHumanBudgetDefaults` into store reconciliation.
+
+Reconciliation order:
+
+1. Seed providers and models.
+2. Seed teams and service accounts.
+3. Seed configured users and explicit `users[*].budget` overrides.
+4. Apply default user budget to all human users without an active manual or explicit override.
+5. Apply model defaults to all human users without an active manual or explicit per-user model budget for that model.
+6. Deactivate stale config-default rows whose source keys are no longer present.
+
+Important change: `users[*].budget: None` should no longer mean "deactivate any active user budget" when a platform default exists. It should mean "this listed user has no explicit override; use the default unless a manual exception exists."
+
+If backwards compatibility requires an explicit way to clear a listed user's inherited default, add that as a follow-up design rather than overloading omission.
+
+### Runtime User Creation
+
+All user creation paths must apply the same default policy after the user row exists:
+
+- admin-created users in `create_identity_user`
+- OIDC JIT users in `create_jit_oidc_user`
+- OAuth JIT users in `create_jit_oauth_user`
+- bootstrap-created admin users if the bootstrap path creates or ensures a human user row
+
+Invited OIDC/OAuth users created by admins should already receive defaults at admin creation time. Activation should not duplicate work, though an idempotent reconciliation call after activation is acceptable if simpler.
+
+Runtime paths need access to the parsed policy. Recommended option:
+
+- derive a compact `HumanBudgetDefaults` value from `GatewayConfig`
+- store it in `AppState` as `Arc<HumanBudgetDefaults>`
+- call a shared `apply_budget_defaults_for_user(store, policy, user_id, now)` helper
+
+Do not keep the full `GatewayConfig` in `AppState`.
+
+### Updates And Removal
+
+When `budgets.users.default` changes:
+
+- update all active `config_user_default` rows
+- leave `manual` and `config_user_override` rows unchanged
+- create missing default rows for users without an active override
+
+When `budgets.users.default` is removed:
+
+- deactivate only active `config_user_default` rows
+- leave manual and explicit override rows unchanged
+
+When a model default changes:
+
+- update all active `config_user_model_default` rows for that model source key
+- create missing rows for users without an active override for that model scope
+
+When a model default is removed:
+
+- deactivate only active `config_user_model_default` rows for that source key
+
+When a `users[*].budget` override is added:
+
+- replace a default-owned active user budget for that user with a `config_user_override` row/settings
+- do not overwrite an active manual user budget unless this is explicitly decided and documented
+
+## Store And Trait Work
+
+Core/domain:
+
+- Extend `BudgetRecord` with source metadata.
+- Add a `BudgetSource` enum or stringly-safe domain type.
+- Add seed structs for human budget defaults.
+
+Traits:
+
+- Keep `BudgetRepository::upsert_active_budget` as the manual/admin mutation surface, or add an explicit source parameter with a manual default at call sites.
+- Add source-aware methods for reconciliation, for example:
+  - `upsert_config_owned_budget`
+  - `deactivate_config_owned_budgets_by_source`
+  - `list_budget_sources_for_active_scopes`
+- Add a user listing method if existing `list_identity_users` is too admin-shaped for store-level reconciliation.
+
+Migrations:
+
+- Add a new migration after the current active migration.
+- Update libsql and Postgres variants.
+- Update `migration_registry.rs`.
+- Update app-table/schema detection where needed.
+- Backfill existing rows to `source_kind = 'manual'`.
+
+Store implementations:
+
+- Update budget SELECT/decode helpers to read source metadata.
+- Ensure admin upsert writes `manual`.
+- Implement source-aware reconciliation in both libsql and Postgres.
+- Keep source checks inside SQL transactions where a race could otherwise overwrite a manual exception.
+
+## Admin API And UI
+
+Minimum v1:
+
+- Existing admin spend APIs continue to create manual budget rows.
+- Existing UI continues to edit budgets as manual exceptions.
+- Listing budgets exposes source metadata.
+- Editing source directly is not exposed.
+
+Recommended UI enhancement:
+
+- Show a small read-only label for inherited/config-default budgets versus manual/explicit budgets on `/admin/spend-controls`.
+- Explain through labels, not long instructional text, that editing an inherited budget creates or preserves a manual exception.
+
+Admin editing an inherited default row converts it to `manual`.
+
+## Documentation Plan
+
+User-facing docs:
+
+- Update `docs/access/budgets.md`.
+  - Explain taxonomy: user, service-account, user-model, default user, default user-model.
+  - Show the `$70/day` user default plus `$40/day` selected model default example.
+  - Explain precedence: manual or explicit per-user budget wins over default; user-model and user budgets both enforce.
+  - Explain that model defaults apply per user and do not create one shared model pool.
+  - Keep service accounts separate.
+
+Config docs:
+
+- Update `docs/configuration/configuration-reference.md`.
+  - Add `budgets` to top-level sections.
+  - Document YAML syntax and validation.
+  - Document seed/reconciliation behavior and source ownership.
+  - Clarify `users[*].budget` as an override rather than the only declarative user budget.
+
+Maintainer docs:
+
+- Update `docs/contributing/operations/budgets-and-spending.md`.
+  - Document source metadata, reconciliation semantics, and request-path non-changes.
+  - Link back to user-facing budget docs for setup.
+
+ADRs:
+
+- Consider a short ADR if implementation chooses a durable ownership model beyond simple `source_kind/source_key`, or if it changes previous seed deletion semantics in a way maintainers must remember.
+
+Do not put this implementation plan in primary user-facing navigation.
+
+## Test Plan
+
+Config tests in `crates/gateway/src/config.rs`:
+
+- parses `budgets.users.default`
+- parses `budgets.users.model_defaults`
+- rejects unknown model key
+- rejects duplicate model default key
+- rejects invalid/negative amount
+- `users[*].budget` still parses as explicit override
+
+Budget domain tests:
+
+- source enum serializes/deserializes expected DB values
+- invalid source values fail cleanly
+
+Migration/store tests:
+
+- existing budget rows migrate to `manual`
+- admin/API upsert writes `manual`
+- config default creates missing user budgets
+- config default skips active manual user budget
+- explicit config user budget overrides a config-default-owned row
+- default update changes only config-default-owned rows
+- default removal deactivates only config-default-owned rows
+- model default creates one user-model row per user per model
+- model default uses gateway model UUID, not upstream string
+- model default skips manual user-model exceptions
+- disabled users are reconciled consistently with active users
+- libsql and Postgres behavior match
+
+Identity tests:
+
+- admin-created user receives default user and model budgets
+- OIDC JIT user receives defaults
+- OAuth JIT user receives defaults
+- invited OIDC/OAuth activation does not duplicate or overwrite manual budgets
+- bootstrap admin receives defaults when represented as a normal human user row
+
+Enforcement regression tests:
+
+- request-path user-model then user order remains unchanged
+- manual exception is enforced instead of default settings
+- priced rows count toward default-materialized scopes
+- unpriced and usage-missing rows remain non-consuming
+
+Docs checks:
+
+```bash
+mise run docs:check
+mise run admin-contract-generate
+mise run admin-contract-check
+mise run lint
+```
+
+Run `cargo clippy --workspace --all-targets -- -D warnings` instead of full lint only if the final implementation is Rust-only and no admin UI/generated contract changes are introduced.
+
+## Implementation Phases
+
+### Phase 1: Source Metadata
+
+Add budget source metadata to core, migrations, libsql, and Postgres.
+
+Done when:
+
+- all active budget reads include source metadata
+- admin budget mutations continue to work as manual rows
+- migration tests pass for both backends
+
+### Phase 2: Config Parsing
+
+Add the top-level `budgets` config object and seed/domain policy DTOs.
+
+Done when:
+
+- YAML parses and validates the new shape
+- model defaults resolve only configured model keys
+- config tests cover valid and invalid cases
+
+### Phase 3: Source-Aware Reconciliation
+
+Implement default budget materialization for all existing users during seed.
+
+Done when:
+
+- defaults apply to all existing users
+- explicit and manual overrides are preserved
+- updates/removals affect only config-owned rows
+- seed tests cover libsql and Postgres
+
+### Phase 4: Runtime User-Creation Hooks
+
+Make parsed defaults available to HTTP/JIT creation paths and apply them after user creation.
+
+Done when:
+
+- admin-created users receive defaults
+- OIDC/OAuth JIT users receive defaults
+- bootstrap-created human admins are covered
+- repeated reconciliation is idempotent
+
+### Phase 5: Admin API/UI Polish
+
+Expose source state where useful and keep manual edits understandable.
+
+Done when:
+
+- admin spend control surfaces do not misrepresent inherited defaults as ordinary one-off rows
+- contract artifacts are regenerated if API shapes change
+- UI tests cover any visible source labels or edit behavior
+
+### Phase 6: Documentation
+
+Update user-facing, config, and maintainer docs.
+
+Done when:
+
+- admins can configure default user budgets and selected model defaults from docs alone
+- docs clearly separate default-per-user policy from aggregate global budget
+- maintainer docs explain ownership metadata and reconciliation
+- `mise run docs:check` passes
+
+## Risks And Mitigations
+
+- Risk: default reconciliation overwrites manual exceptions.
+  - Mitigation: source metadata plus source-aware SQL predicates.
+
+- Risk: removing a default leaves stale active rows.
+  - Mitigation: stable source keys and explicit deactivate-by-source behavior.
+
+- Risk: applying defaults only at startup misses future users.
+  - Mitigation: shared helper used by admin-created and JIT-created user paths.
+
+- Risk: changing `users[*].budget: None` surprises existing deployments.
+  - Mitigation: document the new inheritance semantics and keep explicit override behavior clear.
+
+- Risk: admin UI edits accidentally remain config-owned and are later overwritten.
+  - Mitigation: admin/API upsert converts the active scope to `manual`.
+
+- Risk: aliases create ambiguous model-default expectations.
+  - Mitigation: document that `model_defaults[*].model` targets exactly that gateway model key; aliases do not inherit unless separately listed.
+
+## Open Questions
+
+- Should a follow-up issue add aggregate global user budgets as a distinct `BudgetScope`?


### PR DESCRIPTION
## Description

Closes #227.

- Adds a top-level `budgets.users.default` config policy for default per-user budgets across all human users.
- Adds `budgets.users.model_defaults` for selected expensive gateway models, materialized as per-user model budgets.
- Adds budget source metadata and V38 libsql/Postgres migrations so config-owned rows can be reconciled without overwriting manual admin/API exceptions.
- Applies defaults during config seed and runtime user creation paths: bootstrap admin, admin-created users, OIDC JIT users, and OAuth JIT users.
- Exposes `budget_source` in admin spend API responses and refreshes the generated OpenAPI/TypeScript contract.
- Updates public budget/config docs, maintainer budget docs, and the issue implementation plan.

This keeps request-path enforcement on the existing budget scopes. Defaults materialize into ordinary active budget rows, while admin/API edits convert inherited rows to manual rows. Admin/API deactivation is the escape hatch from inheritance.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional checks run:

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p gateway human_budget`
- [x] `cargo test -p gateway-store libsql_human_budget_defaults_inherit_until_manual_override_or_deactivation`
- [x] `mise run admin-contract-check`
- [x] `mise run docs:check`
