### PR TITLE
fix(admin-ui): redirect bare root to admin app

### DIFF
--- a/crates/admin-ui/src/proxy.rs
+++ b/crates/admin-ui/src/proxy.rs
@@ -5,11 +5,11 @@ use axum::{
     body::{Body, to_bytes},
     extract::State,
     http::{
-        HeaderMap, HeaderName, Request, StatusCode, Uri,
-        header::{CONNECTION, HOST},
+        HeaderMap, HeaderName, HeaderValue, Request, StatusCode, Uri,
+        header::{CONNECTION, HOST, LOCATION},
     },
     response::{IntoResponse, Response},
-    routing::any,
+    routing::{any, get},
 };
 use serde_json::json;
 use tracing::warn;
@@ -18,12 +18,14 @@ use crate::AdminUiConfig;
 
 #[derive(Clone)]
 struct ProxyState {
+    base_path: String,
     upstream: String,
     client: reqwest::Client,
 }
 
 impl ProxyState {
     fn new(config: &AdminUiConfig) -> Self {
+        let base_path = normalize_base_path(&config.base_path);
         let upstream = config.upstream.trim_end_matches('/').to_string();
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
@@ -31,7 +33,11 @@ impl ProxyState {
             .build()
             .expect("failed to build reqwest proxy client");
 
-        Self { upstream, client }
+        Self {
+            base_path,
+            upstream,
+            client,
+        }
     }
 }
 
@@ -43,12 +49,30 @@ pub fn mount_admin_ui(router: Router, config: AdminUiConfig) -> Router {
         format!("{base_path}/{{*path}}")
     };
 
+    let state = ProxyState::new(&config);
     let admin_ui_router = Router::new()
         .route(&base_path, any(proxy_request))
         .route(&wildcard_path, any(proxy_request))
-        .with_state(ProxyState::new(&config));
+        .with_state(state.clone());
+
+    let router = if base_path == "/" {
+        router
+    } else {
+        router.route("/", get(redirect_to_admin_ui).with_state(state.clone()))
+    };
 
     router.merge(admin_ui_router)
+}
+
+async fn redirect_to_admin_ui(State(state): State<ProxyState>) -> Response {
+    Response::builder()
+        .status(StatusCode::FOUND)
+        .header(
+            LOCATION,
+            HeaderValue::from_str(&state.base_path).expect("admin UI base path is a valid header"),
+        )
+        .body(Body::empty())
+        .expect("redirect response should build")
 }
 
 async fn proxy_request(State(state): State<ProxyState>, req: Request<Body>) -> Response {
@@ -330,6 +354,59 @@ mod tests {
             .expect("body to read");
         let body_string = String::from_utf8_lossy(&body);
         assert!(body_string.contains("admin_ui_upstream_unavailable"));
+    }
+
+    #[tokio::test]
+    async fn root_redirects_to_admin_base_path() {
+        let app = mount_admin_ui(Router::new(), AdminUiConfig::default());
+
+        let request = Request::builder()
+            .uri("/")
+            .method("GET")
+            .body(Body::empty())
+            .expect("request must build");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("root redirect should succeed");
+
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert_eq!(
+            response.headers().get("location"),
+            Some(&HeaderValue::from_static("/admin"))
+        );
+    }
+
+    #[tokio::test]
+    async fn root_mount_proxies_root_instead_of_redirecting_to_itself() {
+        let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
+        let upstream = start_upstream(captured.clone()).await;
+
+        let app = mount_admin_ui(
+            Router::new(),
+            AdminUiConfig {
+                base_path: "/".to_string(),
+                upstream,
+                ..AdminUiConfig::default()
+            },
+        );
+
+        let request = Request::builder()
+            .uri("/")
+            .method("GET")
+            .body(Body::empty())
+            .expect("request must build");
+
+        let response = app
+            .oneshot(request)
+            .await
+            .expect("proxy request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = captured.lock().expect("capture lock");
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].path_and_query, "/");
     }
 
     async fn start_upstream(captured: Arc<Mutex<Vec<CapturedRequest>>>) -> String {

--- a/crates/admin-ui/web/e2e/admin-static-assets.e2e.ts
+++ b/crates/admin-ui/web/e2e/admin-static-assets.e2e.ts
@@ -2,6 +2,14 @@ import { expect, test } from 'playwright/test'
 
 import { requireEnv } from './env'
 
+test('bare root redirects into the admin app', async ({ request, baseURL }) => {
+  const root = baseURL ?? requireEnv('E2E_BASE_URL')
+  const response = await request.get(root, { maxRedirects: 0 })
+
+  expect(response.status()).toBe(302)
+  expect(response.headers().location).toBe('/admin')
+})
+
 function extractAttribute(tag: string, name: string): string | null {
   const match = tag.match(new RegExp(`\\s${name}=(['"])(.*?)\\1`, 'i'))
   return match?.[2] ?? null

--- a/crates/admin-ui/web/server.ts
+++ b/crates/admin-ui/web/server.ts
@@ -75,7 +75,7 @@ const server = Bun.serve({
   async fetch(request) {
     const url = new URL(request.url)
     if (url.pathname === '/') {
-      return Response.redirect(new URL('/admin', url), 302)
+      return Response.redirect('/admin', 302)
     }
 
     const candidate = resolveStaticAssetRequest(url.pathname)

--- a/crates/admin-ui/web/server.ts
+++ b/crates/admin-ui/web/server.ts
@@ -74,6 +74,10 @@ const server = Bun.serve({
   port: PORT,
   async fetch(request) {
     const url = new URL(request.url)
+    if (url.pathname === '/') {
+      return Response.redirect(new URL('/admin', url), 302)
+    }
+
     const candidate = resolveStaticAssetRequest(url.pathname)
 
     if (candidate) {

--- a/crates/admin-ui/web/src/routes/index.tsx
+++ b/crates/admin-ui/web/src/routes/index.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
+import { DEFAULT_SIGNED_IN_PATH } from '@/routes/-auth-routing'
+
 export const Route = createFileRoute('/')({
   beforeLoad: () => {
-    throw redirect({ to: '/api-keys' })
+    throw redirect({ to: DEFAULT_SIGNED_IN_PATH })
   },
 })


### PR DESCRIPTION
## Description

Adds a production-server redirect so users who open the bare domain are sent into the admin app at `/admin`, where the existing authenticated route guard decides whether to show login or the signed-in landing page.

- Summary of changes
- Redirect `/` to `/admin` from the admin UI Bun server.
- Reuse `DEFAULT_SIGNED_IN_PATH` for the admin index route instead of hardcoding `/api-keys`.
- Add an e2e assertion that the bare root redirects into the admin app.

- Why this approach was chosen
- It keeps authentication policy centralized in the existing TanStack Router root guard instead of duplicating session checks in the server redirect.

- How it works
- Requests for `/` receive a `302` to `/admin`.
- `/admin` then follows existing admin routing: unauthenticated users reach `/admin/login`, while authenticated users land on the configured signed-in default page.

- Risks, tradeoffs, and alternatives considered
- This introduces one extra redirect for unauthenticated users compared with redirecting directly to `/admin/login`, but avoids splitting auth behavior across server and client routing.

- Additional context for reviewers
- The signed-in landing page remains `/api-keys`; changing `DEFAULT_SIGNED_IN_PATH` will now update the admin index redirect too.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`
