### PR TITLE
fix: update client config generation and onboarding reset links

### DIFF
--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -327,7 +327,12 @@ export function UsersPage() {
           await updateIdentityUser({
             data: {
               userId: selectedUser.id,
-              input: sanitizeOnboardingUpdateForm(updateForm, selectedUser, oidcProviders, oauthProviders),
+              input: sanitizeOnboardingUpdateForm(
+                updateForm,
+                selectedUser,
+                oidcProviders,
+                oauthProviders,
+              ),
             },
           })
           savedOnboardingAuth = true
@@ -1452,6 +1457,11 @@ export function sanitizeOnboardingUpdateForm(
     auth_mode: form.auth_mode,
     oidc_provider_key: form.auth_mode === 'oidc' ? (form.oidc_provider_key ?? null) : null,
     oauth_provider_key: form.auth_mode === 'oauth' ? (form.oauth_provider_key ?? null) : null,
+  }
+
+  if (user.team_role !== 'owner') {
+    update.team_id = user.team_id ?? null
+    update.team_role = user.team_id ? (user.team_role ?? 'member') : null
   }
 
   if (update.auth_mode === 'oidc') {

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -322,6 +322,7 @@ export function UsersPage() {
 
     startTransition(async () => {
       let savedOnboardingAuth = false
+      setOnboardingResult(null)
       try {
         if (selectedUser.status === 'invited' && onboardingAuthChanged(selectedUser, updateForm)) {
           await updateIdentityUser({

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -327,7 +327,7 @@ export function UsersPage() {
           await updateIdentityUser({
             data: {
               userId: selectedUser.id,
-              input: sanitizeOnboardingUpdateForm(updateForm, oidcProviders, oauthProviders),
+              input: sanitizeOnboardingUpdateForm(updateForm, selectedUser, oidcProviders, oauthProviders),
             },
           })
           savedOnboardingAuth = true
@@ -1443,10 +1443,12 @@ function sanitizeUpdateForm(
 
 export function sanitizeOnboardingUpdateForm(
   form: UpdateUserInput,
+  user: UserView,
   oidcProviders: IdentityUsersPayload['oidc_providers'],
   oauthProviders: IdentityUsersPayload['oauth_providers'],
 ): UpdateUserInput {
   const update: UpdateUserInput = {
+    global_role: user.global_role,
     auth_mode: form.auth_mode,
     oidc_provider_key: form.auth_mode === 'oidc' ? (form.oidc_provider_key ?? null) : null,
     oauth_provider_key: form.auth_mode === 'oauth' ? (form.oauth_provider_key ?? null) : null,

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -138,12 +138,12 @@ export function UsersPage() {
   const selectedUser = search.user_id
     ? (users.find((user) => user.id === search.user_id) ?? null)
     : null
+  const selectedUserId = selectedUser?.id ?? null
   const selectedUserSection = search.user_section
 
   useEffect(() => {
     if (!selectedUser) {
       setUpdateForm(initialUpdateForm)
-      setOnboardingResult(null)
       return
     }
 
@@ -162,8 +162,11 @@ export function UsersPage() {
           : null,
       tags: selectedUser.tags,
     })
-    setOnboardingResult(null)
   }, [selectedUser])
+
+  useEffect(() => {
+    setOnboardingResult(null)
+  }, [selectedUserId])
 
   function resetDialog() {
     setForm(initialForm)
@@ -266,12 +269,7 @@ export function UsersPage() {
         await updateIdentityUser({
           data: {
             userId: selectedUser.id,
-            input: sanitizeUpdateForm(
-              updateForm,
-              selectedUser,
-              oidcProviders,
-              oauthProviders,
-            ),
+            input: sanitizeUpdateForm(updateForm, selectedUser, oidcProviders, oauthProviders),
           },
         })
         toast.success('User updated')
@@ -324,6 +322,14 @@ export function UsersPage() {
 
     startTransition(async () => {
       try {
+        if (selectedUser.status === 'invited' && onboardingAuthChanged(selectedUser, updateForm)) {
+          await updateIdentityUser({
+            data: {
+              userId: selectedUser.id,
+              input: sanitizeUpdateForm(updateForm, selectedUser, oidcProviders, oauthProviders),
+            },
+          })
+        }
         const response = await resetIdentityUserOnboarding({ data: { userId: selectedUser.id } })
         setOnboardingResult(response.data)
         toast.success(
@@ -390,7 +396,7 @@ export function UsersPage() {
                     <AlertDescription>
                       {result.kind === 'password_invite'
                         ? `Share this invite before ${result.expires_at}.`
-                        : `Share this URL with ${result.user.email} so they can finish SSO onboarding.`}
+                        : `Share this URL with ${onboardingRecipient(result)} so they can finish SSO onboarding.`}
                     </AlertDescription>
                   </Alert>
 
@@ -530,8 +536,8 @@ export function UsersPage() {
                           <Alert>
                             <AlertTitle>No OAuth providers configured</AlertTitle>
                             <AlertDescription>
-                              Add an OAuth provider in the gateway before inviting users with SSO, or
-                              use password onboarding for now.
+                              Add an OAuth provider in the gateway before inviting users with SSO,
+                              or use password onboarding for now.
                             </AlertDescription>
                           </Alert>
                         ) : null}
@@ -647,10 +653,7 @@ export function UsersPage() {
                     </Button>
                     <Button
                       type="submit"
-                      disabled={
-                        isPending ||
-                        isSsoDisabled(form, oidcProviders, oauthProviders)
-                      }
+                      disabled={isPending || isSsoDisabled(form, oidcProviders, oauthProviders)}
                     >
                       {isPending ? 'Creating…' : 'Create user'}
                     </Button>
@@ -1229,7 +1232,7 @@ export function UsersPage() {
                               <AlertDescription>
                                 {onboardingResult.kind === 'password_invite'
                                   ? `Share this invite before ${onboardingResult.expires_at}.`
-                                  : `Share this URL with ${onboardingResult.user.email} so they can finish SSO onboarding.`}
+                                  : `Share this URL with ${onboardingRecipient(onboardingResult)} so they can finish SSO onboarding.`}
                               </AlertDescription>
 
                               <Field className="mt-3">
@@ -1429,16 +1432,31 @@ function sanitizeUpdateForm(
   return update
 }
 
+function onboardingAuthChanged(user: UserView, form: UpdateUserInput) {
+  if (form.auth_mode !== user.auth_mode) {
+    return true
+  }
+  if (form.auth_mode === 'oidc') {
+    return form.oidc_provider_key !== user.onboarding?.provider_key
+  }
+  if (form.auth_mode === 'oauth') {
+    return form.oauth_provider_key !== user.onboarding?.provider_key
+  }
+  return false
+}
+
+function onboardingRecipient(result: CreateUserResult) {
+  return 'user' in result && result.user ? result.user.email : 'the user'
+}
+
 function isSsoDisabled(
   form: CreateUserInput,
   oidcProviders: IdentityUsersPayload['oidc_providers'],
   oauthProviders: IdentityUsersPayload['oauth_providers'],
 ) {
   return (
-    (form.auth_mode === 'oidc' &&
-      (oidcProviders.length === 0 || !form.oidc_provider_key)) ||
-    (form.auth_mode === 'oauth' &&
-      (oauthProviders.length === 0 || !form.oauth_provider_key))
+    (form.auth_mode === 'oidc' && (oidcProviders.length === 0 || !form.oidc_provider_key)) ||
+    (form.auth_mode === 'oauth' && (oauthProviders.length === 0 || !form.oauth_provider_key))
   )
 }
 

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -321,14 +321,16 @@ export function UsersPage() {
     }
 
     startTransition(async () => {
+      let savedOnboardingAuth = false
       try {
         if (selectedUser.status === 'invited' && onboardingAuthChanged(selectedUser, updateForm)) {
           await updateIdentityUser({
             data: {
               userId: selectedUser.id,
-              input: sanitizeUpdateForm(updateForm, selectedUser, oidcProviders, oauthProviders),
+              input: sanitizeOnboardingUpdateForm(updateForm, oidcProviders, oauthProviders),
             },
           })
+          savedOnboardingAuth = true
         }
         const response = await resetIdentityUserOnboarding({ data: { userId: selectedUser.id } })
         setOnboardingResult(response.data)
@@ -339,7 +341,14 @@ export function UsersPage() {
         )
         await refreshUsers()
       } catch (error) {
-        toast.error(getErrorMessage(error))
+        if (savedOnboardingAuth) {
+          await refreshUsers()
+        }
+        toast.error(
+          savedOnboardingAuth
+            ? `Auth method was saved, but reset failed: ${getErrorMessage(error)}`
+            : getErrorMessage(error),
+        )
       }
     })
   }
@@ -1423,6 +1432,34 @@ function sanitizeUpdateForm(
   }
 
   if (user.status === 'invited' && update.auth_mode === 'oauth') {
+    const validProvider = oauthProviders.find(
+      (provider) => provider.key === update.oauth_provider_key,
+    )
+    update.oauth_provider_key = validProvider ? update.oauth_provider_key : null
+  }
+
+  return update
+}
+
+export function sanitizeOnboardingUpdateForm(
+  form: UpdateUserInput,
+  oidcProviders: IdentityUsersPayload['oidc_providers'],
+  oauthProviders: IdentityUsersPayload['oauth_providers'],
+): UpdateUserInput {
+  const update: UpdateUserInput = {
+    auth_mode: form.auth_mode,
+    oidc_provider_key: form.auth_mode === 'oidc' ? (form.oidc_provider_key ?? null) : null,
+    oauth_provider_key: form.auth_mode === 'oauth' ? (form.oauth_provider_key ?? null) : null,
+  }
+
+  if (update.auth_mode === 'oidc') {
+    const validProvider = oidcProviders.find(
+      (provider) => provider.key === update.oidc_provider_key,
+    )
+    update.oidc_provider_key = validProvider ? update.oidc_provider_key : null
+  }
+
+  if (update.auth_mode === 'oauth') {
     const validProvider = oauthProviders.find(
       (provider) => provider.key === update.oauth_provider_key,
     )

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -65,6 +65,9 @@ const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 2,
 })
 
+const CLIENT_HARNESS_CONFIGURATION_URL =
+  'https://oceans-llm.com/configuration/client-harness-configuration.html'
+
 type ModelInfoSectionKey = 'overview' | 'routing' | 'economics' | 'access'
 
 export const Route = createFileRoute('/models')({
@@ -993,6 +996,25 @@ function ClientConfigDialog({
                       </TableCell>
                     </TableRow>
                   ))}
+                  <TableRow>
+                    <TableCell className="w-32 align-baseline font-medium whitespace-nowrap">
+                      Base URL
+                    </TableCell>
+                    <TableCell className="text-muted-foreground min-w-0 align-baseline whitespace-normal">
+                      Base URL can change depending on API format and client harness. Experiment
+                      with adding or removing <code className="font-mono text-xs">/v1</code> if
+                      requests initially fail. For more info, see:{' '}
+                      <a
+                        href={CLIENT_HARNESS_CONFIGURATION_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline underline-offset-4"
+                      >
+                        client harness configuration
+                      </a>
+                      .
+                    </TableCell>
+                  </TableRow>
                 </TableBody>
               </Table>
             ) : null}

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -455,6 +455,13 @@ describe('ModelsPage', () => {
     })
     expect(await screen.findByRole('dialog', { name: 'Client config' })).toBeInTheDocument()
     expect(screen.getByText('~/.config/opencode/opencode.json')).toBeInTheDocument()
+    expect(screen.getByText('Base URL')).toBeInTheDocument()
+    expect(screen.getByText(/Base URL can change depending on API format/)).toBeInTheDocument()
+    expect(screen.getByText('/v1')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'client harness configuration' })).toHaveAttribute(
+      'href',
+      'https://oceans-llm.com/configuration/client-harness-configuration.html',
+    )
     expect(screen.getByRole('link', { name: 'https://opencode.ai/docs/config/' })).toHaveAttribute(
       'href',
       'https://opencode.ai/docs/config/',

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -292,11 +292,13 @@ describe('UsersPage', () => {
         oidc_provider_key: 'oidc',
         oauth_provider_key: 'github',
       },
+      invitedUser({ global_role: 'user' }),
       [{ key: 'oidc', label: 'OIDC' }],
       [{ key: 'github', label: 'GitHub' }],
     )
 
     expect(input).toEqual({
+      global_role: 'user',
       auth_mode: 'oauth',
       oidc_provider_key: null,
       oauth_provider_key: 'github',

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -46,6 +46,26 @@ const basePayload: IdentityUsersPayload = {
   oauth_providers: [],
 }
 
+type UserPayload = IdentityUsersPayload['users'][number]
+
+function invitedUser(overrides: Partial<UserPayload> = {}): UserPayload {
+  return {
+    id: 'user_1',
+    name: 'Jane Operator',
+    email: 'jane@example.com',
+    auth_mode: 'password',
+    global_role: 'user',
+    team_id: null,
+    team_name: null,
+    team_role: null,
+    request_logging_enabled: true,
+    status: 'invited',
+    tags: [],
+    onboarding: null,
+    ...overrides,
+  }
+}
+
 describe('UsersPage', () => {
   beforeEach(() => {
     if (!Element.prototype.hasPointerCapture) {
@@ -174,24 +194,11 @@ describe('UsersPage', () => {
   })
 
   it('keeps a reset onboarding URL visible after the user list refreshes', async () => {
-    const invitedUser = {
-      id: 'user_1',
-      name: 'Jane Operator',
-      email: 'jane@example.com',
-      auth_mode: 'password',
-      global_role: 'user',
-      team_id: null,
-      team_name: null,
-      team_role: null,
-      request_logging_enabled: true,
-      status: 'invited',
-      tags: [],
-      onboarding: null,
-    } satisfies IdentityUsersPayload['users'][number]
+    const user = invitedUser()
     routeMock.useLoaderData.mockReturnValue({
       data: {
         ...basePayload,
-        users: [invitedUser],
+        users: [user],
       },
     })
     routeMock.useSearch.mockReturnValue({ user_id: 'user_1', user_section: 'auth' })
@@ -200,7 +207,7 @@ describe('UsersPage', () => {
         kind: 'password_invite',
         invite_url: 'http://example.test/invite/reset-user-1',
         expires_at: '2026-03-14T12:00:00Z',
-        user: invitedUser,
+        user,
       },
     })
 
@@ -219,7 +226,7 @@ describe('UsersPage', () => {
     routeMock.useLoaderData.mockReturnValue({
       data: {
         ...basePayload,
-        users: [{ ...invitedUser }],
+        users: [{ ...user }],
       },
     })
     rerender(<UsersPage />)
@@ -230,29 +237,19 @@ describe('UsersPage', () => {
   })
 
   it('renders an OAuth reset onboarding URL', async () => {
-    const invitedUser = {
-      id: 'user_1',
-      name: 'Jane Operator',
-      email: 'jane@example.com',
+    const user = invitedUser({
       auth_mode: 'oauth',
-      global_role: 'user',
-      team_id: null,
-      team_name: null,
-      team_role: null,
-      request_logging_enabled: true,
-      status: 'invited',
-      tags: [],
       onboarding: {
         kind: 'oauth_sign_in',
         provider_key: 'github',
         provider_label: 'GitHub',
         sign_in_url: 'http://example.test/api/v1/auth/oauth/start?provider=github',
       },
-    } satisfies IdentityUsersPayload['users'][number]
+    })
     routeMock.useLoaderData.mockReturnValue({
       data: {
         ...basePayload,
-        users: [invitedUser],
+        users: [user],
         oauth_providers: [{ key: 'github', label: 'GitHub' }],
       },
     })
@@ -280,5 +277,29 @@ describe('UsersPage', () => {
     expect(
       screen.getByText('Share this URL with the user so they can finish SSO onboarding.'),
     ).toBeInTheDocument()
+  })
+
+  it('sanitizes onboarding updates to auth fields only', async () => {
+    const { sanitizeOnboardingUpdateForm } = await import('@/routes/identity/users')
+
+    const input = sanitizeOnboardingUpdateForm(
+      {
+        auth_mode: 'oauth',
+        global_role: 'platform_admin',
+        team_id: 'team_1',
+        team_role: 'admin',
+        tags: [{ key: 'department', value: 'engineering' }],
+        oidc_provider_key: 'oidc',
+        oauth_provider_key: 'github',
+      },
+      [{ key: 'oidc', label: 'OIDC' }],
+      [{ key: 'github', label: 'GitHub' }],
+    )
+
+    expect(input).toEqual({
+      auth_mode: 'oauth',
+      oidc_provider_key: null,
+      oauth_provider_key: 'github',
+    })
   })
 })

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -236,6 +236,43 @@ describe('UsersPage', () => {
     )
   })
 
+  it('clears a stale reset onboarding URL before retrying', async () => {
+    const user = invitedUser()
+    routeMock.useLoaderData.mockReturnValue({
+      data: {
+        ...basePayload,
+        users: [user],
+      },
+    })
+    routeMock.useSearch.mockReturnValue({ user_id: 'user_1', user_section: 'auth' })
+    resetOnboardingMock
+      .mockResolvedValueOnce({
+        data: {
+          kind: 'password_invite',
+          invite_url: 'http://example.test/invite/reset-user-1',
+          expires_at: '2026-03-14T12:00:00Z',
+          user,
+        },
+      })
+      .mockRejectedValueOnce(new Error('reset failed'))
+
+    const { UsersPage } = await import('@/routes/identity/users')
+
+    render(<UsersPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset onboarding' }))
+    await waitFor(() =>
+      expect(screen.getByLabelText('Generated URL')).toHaveValue(
+        'http://example.test/invite/reset-user-1',
+      ),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset onboarding' }))
+
+    await waitFor(() => expect(resetOnboardingMock).toHaveBeenCalledTimes(2))
+    expect(screen.queryByLabelText('Generated URL')).not.toBeInTheDocument()
+  })
+
   it('renders an OAuth reset onboarding URL', async () => {
     const user = invitedUser({
       auth_mode: 'oauth',

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { IdentityUsersPayload } from '@/types/api'
 
@@ -14,6 +14,8 @@ const routerMock = {
 
 const createIdentityUserMock = vi.fn()
 const resendInviteMock = vi.fn()
+const resetOnboardingMock = vi.fn()
+const updateIdentityUserMock = vi.fn()
 
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => () => routeMock,
@@ -32,24 +34,37 @@ vi.mock('@/server/admin-data.functions', () => ({
   createIdentityUser: (...args: unknown[]) => createIdentityUserMock(...args),
   getUsers: vi.fn(),
   reactivateIdentityUser: vi.fn(),
-  resetIdentityUserOnboarding: vi.fn(),
+  resetIdentityUserOnboarding: (...args: unknown[]) => resetOnboardingMock(...args),
   resendIdentityUserPasswordInvite: (...args: unknown[]) => resendInviteMock(...args),
-  updateIdentityUser: vi.fn(),
+  updateIdentityUser: (...args: unknown[]) => updateIdentityUserMock(...args),
 }))
 
 const basePayload: IdentityUsersPayload = {
   users: [],
   teams: [],
   oidc_providers: [],
+  oauth_providers: [],
 }
 
 describe('UsersPage', () => {
   beforeEach(() => {
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = () => false
+    }
+    if (!Element.prototype.releasePointerCapture) {
+      Element.prototype.releasePointerCapture = () => {}
+    }
     routeMock.useLoaderData.mockReset()
     routeMock.useSearch.mockReturnValue({ user_id: undefined, user_section: 'overview' })
     routerMock.invalidate.mockClear()
     createIdentityUserMock.mockReset()
     resendInviteMock.mockReset()
+    resetOnboardingMock.mockReset()
+    updateIdentityUserMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('teaches the next step when no users exist', async () => {
@@ -136,6 +151,7 @@ describe('UsersPage', () => {
         ],
         teams: [{ id: 'team_1', name: 'Core Platform' }],
         oidc_providers: [],
+        oauth_providers: [],
       } satisfies IdentityUsersPayload,
     })
 
@@ -155,5 +171,114 @@ describe('UsersPage', () => {
     expect(screen.getByRole('button', { name: 'Reset onboarding' })).toBeDisabled()
     const authMethodControls = screen.getAllByLabelText('Auth method')
     expect(authMethodControls[authMethodControls.length - 1]).toBeDisabled()
+  })
+
+  it('keeps a reset onboarding URL visible after the user list refreshes', async () => {
+    const invitedUser = {
+      id: 'user_1',
+      name: 'Jane Operator',
+      email: 'jane@example.com',
+      auth_mode: 'password',
+      global_role: 'user',
+      team_id: null,
+      team_name: null,
+      team_role: null,
+      request_logging_enabled: true,
+      status: 'invited',
+      tags: [],
+      onboarding: null,
+    } satisfies IdentityUsersPayload['users'][number]
+    routeMock.useLoaderData.mockReturnValue({
+      data: {
+        ...basePayload,
+        users: [invitedUser],
+      },
+    })
+    routeMock.useSearch.mockReturnValue({ user_id: 'user_1', user_section: 'auth' })
+    resetOnboardingMock.mockResolvedValue({
+      data: {
+        kind: 'password_invite',
+        invite_url: 'http://example.test/invite/reset-user-1',
+        expires_at: '2026-03-14T12:00:00Z',
+        user: invitedUser,
+      },
+    })
+
+    const { UsersPage } = await import('@/routes/identity/users')
+
+    const { rerender } = render(<UsersPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset onboarding' }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Generated URL')).toHaveValue(
+        'http://example.test/invite/reset-user-1',
+      ),
+    )
+
+    routeMock.useLoaderData.mockReturnValue({
+      data: {
+        ...basePayload,
+        users: [{ ...invitedUser }],
+      },
+    })
+    rerender(<UsersPage />)
+
+    expect(screen.getByLabelText('Generated URL')).toHaveValue(
+      'http://example.test/invite/reset-user-1',
+    )
+  })
+
+  it('renders an OAuth reset onboarding URL', async () => {
+    const invitedUser = {
+      id: 'user_1',
+      name: 'Jane Operator',
+      email: 'jane@example.com',
+      auth_mode: 'oauth',
+      global_role: 'user',
+      team_id: null,
+      team_name: null,
+      team_role: null,
+      request_logging_enabled: true,
+      status: 'invited',
+      tags: [],
+      onboarding: {
+        kind: 'oauth_sign_in',
+        provider_key: 'github',
+        provider_label: 'GitHub',
+        sign_in_url: 'http://example.test/api/v1/auth/oauth/start?provider=github',
+      },
+    } satisfies IdentityUsersPayload['users'][number]
+    routeMock.useLoaderData.mockReturnValue({
+      data: {
+        ...basePayload,
+        users: [invitedUser],
+        oauth_providers: [{ key: 'github', label: 'GitHub' }],
+      },
+    })
+    routeMock.useSearch.mockReturnValue({ user_id: 'user_1', user_section: 'auth' })
+    resetOnboardingMock.mockResolvedValue({
+      data: {
+        kind: 'oauth_sign_in',
+        provider_label: 'github',
+        sign_in_url: 'http://example.test/api/v1/auth/oauth/start?provider=github',
+      },
+    })
+
+    const { UsersPage } = await import('@/routes/identity/users')
+
+    render(<UsersPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset onboarding' }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('Generated URL')).toHaveValue(
+        'http://example.test/api/v1/auth/oauth/start?provider=github',
+      ),
+    )
+    expect(updateIdentityUserMock).not.toHaveBeenCalled()
+    expect(
+      screen.getByText('Share this URL with the user so they can finish SSO onboarding.'),
+    ).toBeInTheDocument()
   })
 })

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -279,7 +279,7 @@ describe('UsersPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('sanitizes onboarding updates to auth fields only', async () => {
+  it('sanitizes onboarding updates to auth fields and persisted role/team membership', async () => {
     const { sanitizeOnboardingUpdateForm } = await import('@/routes/identity/users')
 
     const input = sanitizeOnboardingUpdateForm(
@@ -292,13 +292,15 @@ describe('UsersPage', () => {
         oidc_provider_key: 'oidc',
         oauth_provider_key: 'github',
       },
-      invitedUser({ global_role: 'user' }),
+      invitedUser({ global_role: 'user', team_id: 'team_existing', team_role: 'admin' }),
       [{ key: 'oidc', label: 'OIDC' }],
       [{ key: 'github', label: 'GitHub' }],
     )
 
     expect(input).toEqual({
       global_role: 'user',
+      team_id: 'team_existing',
+      team_role: 'admin',
       auth_mode: 'oauth',
       oidc_provider_key: null,
       oauth_provider_key: 'github',

--- a/crates/gateway-client-config/src/cost.rs
+++ b/crates/gateway-client-config/src/cost.rs
@@ -29,10 +29,13 @@ pub(crate) fn pi_cost(input: &ClientConfigInput) -> Value {
             "output".to_string(),
             required_money4_to_number(input.output_cost_per_million_tokens_usd_10000),
         ),
+        ("cacheWrite".to_string(), json!(0)),
     ]);
-    if let Some(cache_read) = money4_to_number(input.cache_read_cost_per_million_tokens_usd_10000) {
-        cost.insert("cacheRead".to_string(), cache_read);
-    }
+    cost.insert(
+        "cacheRead".to_string(),
+        money4_to_number(input.cache_read_cost_per_million_tokens_usd_10000)
+            .unwrap_or_else(|| json!(0)),
+    );
     Value::Object(cost)
 }
 

--- a/crates/gateway-client-config/src/cost.rs
+++ b/crates/gateway-client-config/src/cost.rs
@@ -20,7 +20,7 @@ pub(crate) fn opencode_cost(input: &ClientConfigInput) -> Value {
 }
 
 pub(crate) fn pi_cost(input: &ClientConfigInput) -> Value {
-    let mut cost = Map::from_iter([
+    let cost = Map::from_iter([
         (
             "input".to_string(),
             required_money4_to_number(input.input_cost_per_million_tokens_usd_10000),
@@ -29,13 +29,12 @@ pub(crate) fn pi_cost(input: &ClientConfigInput) -> Value {
             "output".to_string(),
             required_money4_to_number(input.output_cost_per_million_tokens_usd_10000),
         ),
+        (
+            "cacheRead".to_string(),
+            required_money4_to_number(input.cache_read_cost_per_million_tokens_usd_10000),
+        ),
         ("cacheWrite".to_string(), json!(0)),
     ]);
-    cost.insert(
-        "cacheRead".to_string(),
-        money4_to_number(input.cache_read_cost_per_million_tokens_usd_10000)
-            .unwrap_or_else(|| json!(0)),
-    );
     Value::Object(cost)
 }
 

--- a/crates/gateway-client-config/src/templates/claude_code.rs
+++ b/crates/gateway-client-config/src/templates/claude_code.rs
@@ -131,7 +131,7 @@ fn claude_code_gateway_env(inputs: &[&ClientConfigInput]) -> Map<String, Value> 
         ),
         (
             "ANTHROPIC_BASE_URL".to_string(),
-            json!(claude_code_gateway_base_url(input)),
+            json!(input.client_base_url()),
         ),
         (
             "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY".to_string(),
@@ -164,15 +164,6 @@ fn claude_code_model_overrides(inputs: &[&ClientConfigInput]) -> Map<String, Val
             )
         })
         .collect()
-}
-
-fn claude_code_gateway_base_url(input: &ClientConfigInput) -> String {
-    input
-        .gateway_base_url
-        .trim_end_matches('/')
-        .strip_suffix("/v1")
-        .unwrap_or_else(|| input.gateway_base_url.trim_end_matches('/'))
-        .to_string()
 }
 
 fn claude_code_model_override_key(input: &ClientConfigInput) -> String {

--- a/crates/gateway-client-config/src/templates/codex.rs
+++ b/crates/gateway-client-config/src/templates/codex.rs
@@ -25,7 +25,7 @@ impl ClientConfigTemplate for CodexConfigTemplate {
             input.provider_id.clone(),
             CodexModelProviderConfig {
                 name: input.provider_name.clone(),
-                base_url: input.gateway_base_url.clone(),
+                base_url: input.client_base_url(),
                 env_key: input.api_key_env_var.clone(),
                 env_key_instructions: format!("Set {} in your environment", input.api_key_env_var),
                 requires_openai_auth: false,

--- a/crates/gateway-client-config/src/templates/codex.rs
+++ b/crates/gateway-client-config/src/templates/codex.rs
@@ -25,7 +25,7 @@ impl ClientConfigTemplate for CodexConfigTemplate {
             input.provider_id.clone(),
             CodexModelProviderConfig {
                 name: input.provider_name.clone(),
-                base_url: input.client_base_url(),
+                base_url: input.openai_compatible_client_base_url(),
                 env_key: input.api_key_env_var.clone(),
                 env_key_instructions: format!("Set {} in your environment", input.api_key_env_var),
                 requires_openai_auth: false,

--- a/crates/gateway-client-config/src/templates/notes.rs
+++ b/crates/gateway-client-config/src/templates/notes.rs
@@ -33,15 +33,22 @@ impl ClientConfigNote {
     }
 }
 
-pub(crate) fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
-    common_note_items(input)
+pub(crate) fn client_notes(input: &ClientConfigInput) -> Vec<String> {
+    client_note_items(input)
         .into_iter()
         .map(ClientConfigNote::into_message)
         .collect()
 }
 
-fn common_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
-    let mut notes = thinking_note_items(input);
+pub(crate) fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
+    thinking_note_items(input)
+        .into_iter()
+        .map(ClientConfigNote::into_message)
+        .collect()
+}
+
+pub(crate) fn client_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
+    let mut notes = Vec::new();
     if input.context_window_is_capped() {
         notes.push(ClientConfigNote::new(
             ClientConfigNoteKind::ContextWindow,
@@ -65,7 +72,7 @@ pub(crate) fn thinking_note_items(input: &ClientConfigInput) -> Vec<ClientConfig
 }
 
 pub(crate) fn claude_code_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
-    let mut notes = common_note_items(input);
+    let mut notes = client_note_items(input);
     if uses_anthropic_messages_api(input) {
         notes.push(ClientConfigNote::new(
             ClientConfigNoteKind::ClaudeCodeBaseUrl,

--- a/crates/gateway-client-config/src/templates/notes.rs
+++ b/crates/gateway-client-config/src/templates/notes.rs
@@ -33,8 +33,10 @@ impl ClientConfigNote {
     }
 }
 
-pub(crate) fn client_notes(input: &ClientConfigInput) -> Vec<String> {
-    client_note_items(input)
+pub(crate) fn client_notes_for_inputs<'a>(
+    inputs: impl IntoIterator<Item = &'a ClientConfigInput>,
+) -> Vec<String> {
+    client_note_items_for_inputs(inputs)
         .into_iter()
         .map(ClientConfigNote::into_message)
         .collect()
@@ -47,9 +49,14 @@ pub(crate) fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
         .collect()
 }
 
-pub(crate) fn client_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
+pub(crate) fn client_note_items_for_inputs<'a>(
+    inputs: impl IntoIterator<Item = &'a ClientConfigInput>,
+) -> Vec<ClientConfigNote> {
     let mut notes = Vec::new();
-    if input.context_window_is_capped() {
+    if inputs
+        .into_iter()
+        .any(ClientConfigInput::context_window_is_capped)
+    {
         notes.push(ClientConfigNote::new(
             ClientConfigNoteKind::ContextWindow,
             format!(
@@ -59,6 +66,10 @@ pub(crate) fn client_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNo
         ));
     }
     notes
+}
+
+pub(crate) fn client_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
+    client_note_items_for_inputs([input])
 }
 
 pub(crate) fn thinking_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
@@ -86,7 +97,7 @@ pub(crate) fn claude_code_note_items(input: &ClientConfigInput) -> Vec<ClientCon
             ClientConfigNoteKind::ClaudeCodeBaseUrl,
             format!(
             "ANTHROPIC_BASE_URL is set to the Claude-compatible gateway base URL; Claude Code appends Anthropic endpoints such as /v1/messages and /v1/models. Keep the OpenAI-compatible base URL ({}) for OpenCode and Pi.",
-            input.client_base_url()
+            input.openai_compatible_client_base_url()
             ),
         ));
     }

--- a/crates/gateway-client-config/src/templates/notes.rs
+++ b/crates/gateway-client-config/src/templates/notes.rs
@@ -1,12 +1,13 @@
 use crate::{
     api_style::uses_anthropic_messages_api,
-    types::{AnthropicThinkingPolicy, ClientConfigInput},
+    types::{AnthropicThinkingPolicy, ClientConfigInput, MAX_CLIENT_CONTEXT_WINDOW_TOKENS},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum ClientConfigNoteKind {
     ThinkingPolicy,
     ClaudeCodeBaseUrl,
+    ContextWindow,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -33,10 +34,24 @@ impl ClientConfigNote {
 }
 
 pub(crate) fn thinking_notes(input: &ClientConfigInput) -> Vec<String> {
-    thinking_note_items(input)
+    common_note_items(input)
         .into_iter()
         .map(ClientConfigNote::into_message)
         .collect()
+}
+
+fn common_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
+    let mut notes = thinking_note_items(input);
+    if input.context_window_is_capped() {
+        notes.push(ClientConfigNote::new(
+            ClientConfigNoteKind::ContextWindow,
+            format!(
+                "Generated client configs cap the input context window at {} tokens to keep long-context costs predictable; edit the limit in the client config if you want to use a larger window.",
+                MAX_CLIENT_CONTEXT_WINDOW_TOKENS
+            ),
+        ));
+    }
+    notes
 }
 
 pub(crate) fn thinking_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
@@ -50,13 +65,13 @@ pub(crate) fn thinking_note_items(input: &ClientConfigInput) -> Vec<ClientConfig
 }
 
 pub(crate) fn claude_code_note_items(input: &ClientConfigInput) -> Vec<ClientConfigNote> {
-    let mut notes = thinking_note_items(input);
+    let mut notes = common_note_items(input);
     if uses_anthropic_messages_api(input) {
         notes.push(ClientConfigNote::new(
             ClientConfigNoteKind::ClaudeCodeBaseUrl,
             format!(
             "ANTHROPIC_BASE_URL is set to the Claude-compatible gateway base URL; Claude Code appends Anthropic endpoints such as /v1/messages and /v1/models. OpenCode and Pi also use Anthropic Messages for this model via {}.",
-            input.gateway_base_url
+            input.client_base_url()
             ),
         ));
     } else {
@@ -64,7 +79,7 @@ pub(crate) fn claude_code_note_items(input: &ClientConfigInput) -> Vec<ClientCon
             ClientConfigNoteKind::ClaudeCodeBaseUrl,
             format!(
             "ANTHROPIC_BASE_URL is set to the Claude-compatible gateway base URL; Claude Code appends Anthropic endpoints such as /v1/messages and /v1/models. Keep the OpenAI-compatible base URL ({}) for OpenCode and Pi.",
-            input.gateway_base_url
+            input.client_base_url()
             ),
         ));
     }

--- a/crates/gateway-client-config/src/templates/opencode.rs
+++ b/crates/gateway-client-config/src/templates/opencode.rs
@@ -6,7 +6,7 @@ use crate::{
     api_style::{ClientApiStyle, client_api_style, opencode_provider_package_for_style},
     cost::opencode_cost,
     format::to_pretty_json,
-    templates::notes::thinking_notes,
+    templates::notes::{client_notes, thinking_notes},
     types::{
         AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
         ClientConfigInputSet, ClientConfigSetupItem, ClientConfigTemplate,
@@ -70,7 +70,10 @@ impl OpenCodeConfigTemplate {
                 filename: "opencode.json".to_string(),
                 content: to_pretty_json(&config),
             }],
-            notes: input_set.models.iter().flat_map(thinking_notes).collect(),
+            notes: client_notes(first)
+                .into_iter()
+                .chain(input_set.models.iter().flat_map(thinking_notes))
+                .collect(),
         }
     }
 }

--- a/crates/gateway-client-config/src/templates/opencode.rs
+++ b/crates/gateway-client-config/src/templates/opencode.rs
@@ -42,7 +42,7 @@ impl OpenCodeConfigTemplate {
                 "npm": opencode_provider_package_for_style(*style),
                 "name": provider_name_for_style(inputs[0], *style, has_multiple_styles),
                 "options": {
-                    "baseURL": inputs[0].gateway_base_url,
+                    "baseURL": inputs[0].client_base_url(),
                     "apiKey": format!("{{env:{}}}", inputs[0].api_key_env_var),
                 },
                 "models": Value::Object(opencode_models(inputs)),

--- a/crates/gateway-client-config/src/templates/opencode.rs
+++ b/crates/gateway-client-config/src/templates/opencode.rs
@@ -42,7 +42,7 @@ impl OpenCodeConfigTemplate {
                 "npm": opencode_provider_package_for_style(*style),
                 "name": provider_name_for_style(inputs[0], *style, has_multiple_styles),
                 "options": {
-                    "baseURL": inputs[0].client_base_url(),
+                    "baseURL": opencode_base_url(inputs[0], *style),
                     "apiKey": format!("{{env:{}}}", inputs[0].api_key_env_var),
                 },
                 "models": Value::Object(opencode_models(inputs)),
@@ -99,6 +99,13 @@ fn opencode_setup(input: &ClientConfigInput) -> Vec<ClientConfigSetupItem> {
             href: Some(OPENCODE_CONFIG_DOCS_URL.to_string()),
         },
     ]
+}
+
+fn opencode_base_url(input: &ClientConfigInput, style: ClientApiStyle) -> String {
+    match style {
+        ClientApiStyle::OpenAiCompatible => input.openai_compatible_client_base_url(),
+        ClientApiStyle::AnthropicMessages => input.client_base_url(),
+    }
 }
 
 fn grouped_models(

--- a/crates/gateway-client-config/src/templates/opencode.rs
+++ b/crates/gateway-client-config/src/templates/opencode.rs
@@ -6,7 +6,7 @@ use crate::{
     api_style::{ClientApiStyle, client_api_style, opencode_provider_package_for_style},
     cost::opencode_cost,
     format::to_pretty_json,
-    templates::notes::{client_notes, thinking_notes},
+    templates::notes::{client_notes_for_inputs, thinking_notes},
     types::{
         AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
         ClientConfigInputSet, ClientConfigSetupItem, ClientConfigTemplate,
@@ -70,7 +70,7 @@ impl OpenCodeConfigTemplate {
                 filename: "opencode.json".to_string(),
                 content: to_pretty_json(&config),
             }],
-            notes: client_notes(first)
+            notes: client_notes_for_inputs(input_set.models.iter())
                 .into_iter()
                 .chain(input_set.models.iter().flat_map(thinking_notes))
                 .collect(),

--- a/crates/gateway-client-config/src/templates/pi.rs
+++ b/crates/gateway-client-config/src/templates/pi.rs
@@ -39,7 +39,7 @@ impl PiConfigTemplate {
             let style = group.api_style();
             let provider_id = provider_id_for_group(inputs[0], *group, has_multiple_styles);
             let mut provider = Map::from_iter([
-                ("baseUrl".to_string(), json!(inputs[0].gateway_base_url)),
+                ("baseUrl".to_string(), json!(inputs[0].client_base_url())),
                 ("api".to_string(), json!(pi_provider_api_for_style(style))),
                 (
                     "apiKey".to_string(),

--- a/crates/gateway-client-config/src/templates/pi.rs
+++ b/crates/gateway-client-config/src/templates/pi.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     cost::pi_cost,
     format::to_pretty_json,
-    templates::notes::{client_notes, thinking_notes},
+    templates::notes::{client_notes_for_inputs, thinking_notes},
     types::{
         AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
         ClientConfigInputSet, ClientConfigSetupItem, ClientConfigTemplate,
@@ -75,14 +75,10 @@ impl PiConfigTemplate {
                 filename: "models.json".to_string(),
                 content: to_pretty_json(&config),
             }],
-            notes: client_notes(
-                input_set
-                    .first()
-                    .expect("Pi config rendering requires at least one model"),
-            )
-            .into_iter()
-            .chain(input_set.models.iter().flat_map(thinking_notes))
-            .collect(),
+            notes: client_notes_for_inputs(input_set.models.iter())
+                .into_iter()
+                .chain(input_set.models.iter().flat_map(thinking_notes))
+                .collect(),
         }
     }
 }

--- a/crates/gateway-client-config/src/templates/pi.rs
+++ b/crates/gateway-client-config/src/templates/pi.rs
@@ -39,7 +39,7 @@ impl PiConfigTemplate {
             let style = group.api_style();
             let provider_id = provider_id_for_group(inputs[0], *group, has_multiple_styles);
             let mut provider = Map::from_iter([
-                ("baseUrl".to_string(), json!(inputs[0].client_base_url())),
+                ("baseUrl".to_string(), json!(pi_base_url(inputs[0], style))),
                 ("api".to_string(), json!(pi_provider_api_for_style(style))),
                 (
                     "apiKey".to_string(),
@@ -108,6 +108,13 @@ fn pi_setup(input: &ClientConfigInput) -> Vec<ClientConfigSetupItem> {
             href: Some(PI_SETTINGS_DOCS_URL.to_string()),
         },
     ]
+}
+
+fn pi_base_url(input: &ClientConfigInput, style: ClientApiStyle) -> String {
+    match style {
+        ClientApiStyle::OpenAiCompatible => input.openai_compatible_client_base_url(),
+        ClientApiStyle::AnthropicMessages => input.client_base_url(),
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/gateway-client-config/src/templates/pi.rs
+++ b/crates/gateway-client-config/src/templates/pi.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     cost::pi_cost,
     format::to_pretty_json,
-    templates::notes::thinking_notes,
+    templates::notes::{client_notes, thinking_notes},
     types::{
         AnthropicThinkingPolicy, ClientConfig, ClientConfigCodeBlock, ClientConfigInput,
         ClientConfigInputSet, ClientConfigSetupItem, ClientConfigTemplate,
@@ -75,7 +75,14 @@ impl PiConfigTemplate {
                 filename: "models.json".to_string(),
                 content: to_pretty_json(&config),
             }],
-            notes: input_set.models.iter().flat_map(thinking_notes).collect(),
+            notes: client_notes(
+                input_set
+                    .first()
+                    .expect("Pi config rendering requires at least one model"),
+            )
+            .into_iter()
+            .chain(input_set.models.iter().flat_map(thinking_notes))
+            .collect(),
         }
     }
 }

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -194,6 +194,32 @@ fn client_context_window_note_is_emitted_once_for_multi_model_configs() {
 }
 
 #[test]
+fn client_context_window_note_is_emitted_when_later_model_is_capped() {
+    let mut first = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    first.context_window_tokens = Some(200_000);
+    let mut second = first.clone();
+    second.model_id = "claude-haiku".to_string();
+    second.display_name = "Claude Haiku".to_string();
+    second.context_window_tokens = Some(1_000_000);
+    let input_set = ClientConfigInputSet::new(vec![first, second]);
+
+    let opencode = OpenCodeConfigTemplate.render_many(&input_set);
+    let pi = PiConfigTemplate.render_many(&input_set);
+
+    assert!(
+        opencode
+            .notes
+            .iter()
+            .any(|note| note.contains("cap the input context window at 200000 tokens"))
+    );
+    assert!(
+        pi.notes
+            .iter()
+            .any(|note| note.contains("cap the input context window at 200000 tokens"))
+    );
+}
+
+#[test]
 fn infers_safe_effort_for_newer_claude_models() {
     for model in [
         "anthropic/claude-fable-5",
@@ -553,6 +579,12 @@ fn claude_code_render_does_not_panic_for_non_anthropic_input() {
 
     assert_eq!(rendered.model_ids, vec!["qwen-coder"]);
     assert_eq!(gateway_settings["env"]["ANTHROPIC_MODEL"], "qwen-coder");
+    assert!(
+        rendered
+            .notes
+            .iter()
+            .any(|note| note.contains("http://127.0.0.1:3000/v1"))
+    );
 }
 
 #[test]
@@ -669,7 +701,7 @@ fn codex_shape_includes_custom_responses_provider() {
     assert_eq!(provider["name"].as_str(), Some("OpenAI using LLM proxy"));
     assert_eq!(
         provider["base_url"].as_str(),
-        Some("https://oceans.example.com")
+        Some("https://oceans.example.com/v1")
     );
     assert_eq!(provider["env_key"].as_str(), Some("OCEANS_API_KEY"));
     assert_eq!(
@@ -681,8 +713,7 @@ fn codex_shape_includes_custom_responses_provider() {
     assert_eq!(toml["analytics"]["enabled"].as_bool(), Some(false));
     assert_eq!(toml["otel"]["log_user_prompt"].as_bool(), Some(false));
 
-    assert_eq!(content.matches("https://oceans.example.com").count(), 1);
-    assert!(!content.contains("https://oceans.example.com/v1"));
+    assert_eq!(content.matches("https://oceans.example.com/v1").count(), 1);
     assert!(!content.contains("]("));
     assert!(
         rendered

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -165,6 +165,35 @@ fn client_context_window_is_capped_with_note() {
 }
 
 #[test]
+fn client_context_window_note_is_emitted_once_for_multi_model_configs() {
+    let mut first = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    first.context_window_tokens = Some(1_000_000);
+    let mut second = first.clone();
+    second.model_id = "claude-haiku".to_string();
+    second.display_name = "Claude Haiku".to_string();
+    let input_set = ClientConfigInputSet::new(vec![first, second]);
+
+    let opencode = OpenCodeConfigTemplate.render_many(&input_set);
+    let pi = PiConfigTemplate.render_many(&input_set);
+
+    assert_eq!(
+        opencode
+            .notes
+            .iter()
+            .filter(|note| note.contains("cap the input context window at 200000 tokens"))
+            .count(),
+        1
+    );
+    assert_eq!(
+        pi.notes
+            .iter()
+            .filter(|note| note.contains("cap the input context window at 200000 tokens"))
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn infers_safe_effort_for_newer_claude_models() {
     for model in [
         "anthropic/claude-fable-5",

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -363,7 +363,15 @@ fn non_anthropic_models_use_openai_compatible_client_surfaces() {
         opencode["provider"]["oceans-llm"]["npm"],
         "@ai-sdk/openai-compatible"
     );
+    assert_eq!(
+        opencode["provider"]["oceans-llm"]["options"]["baseURL"],
+        "http://127.0.0.1:3000/v1"
+    );
     assert_eq!(pi["providers"]["oceans-llm"]["api"], "openai-completions");
+    assert_eq!(
+        pi["providers"]["oceans-llm"]["baseUrl"],
+        "http://127.0.0.1:3000/v1"
+    );
     assert_eq!(
         pi["providers"]["oceans-llm"]["apiKey"],
         "$OCEANS_LLM_API_KEY"
@@ -391,8 +399,16 @@ fn opencode_and_pi_group_mixed_api_styles_into_separate_providers() {
         "@ai-sdk/anthropic"
     );
     assert_eq!(
+        opencode["provider"]["oceans-llm-anthropic-messages"]["options"]["baseURL"],
+        "http://127.0.0.1:3000"
+    );
+    assert_eq!(
         opencode["provider"]["oceans-llm-openai-compatible"]["npm"],
         "@ai-sdk/openai-compatible"
+    );
+    assert_eq!(
+        opencode["provider"]["oceans-llm-openai-compatible"]["options"]["baseURL"],
+        "http://127.0.0.1:3000/v1"
     );
     assert!(
         opencode["provider"]["oceans-llm-anthropic-messages"]["models"]
@@ -415,8 +431,16 @@ fn opencode_and_pi_group_mixed_api_styles_into_separate_providers() {
         "anthropic-messages"
     );
     assert_eq!(
+        pi["providers"]["oceans-llm-anthropic-messages-adaptive-thinking"]["baseUrl"],
+        "http://127.0.0.1:3000"
+    );
+    assert_eq!(
         pi["providers"]["oceans-llm-openai-compatible"]["api"],
         "openai-completions"
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm-openai-compatible"]["baseUrl"],
+        "http://127.0.0.1:3000/v1"
     );
     assert_eq!(
         pi["providers"]["oceans-llm-anthropic-messages-adaptive-thinking"]["models"][0]["id"],

--- a/crates/gateway-client-config/src/tests.rs
+++ b/crates/gateway-client-config/src/tests.rs
@@ -92,7 +92,7 @@ fn pi_shape_includes_provider_model_cost_and_windows() {
     let provider = &value["providers"]["oceans-llm"];
     let model = &provider["models"][0];
 
-    assert_eq!(provider["baseUrl"], "http://127.0.0.1:3000/v1");
+    assert_eq!(provider["baseUrl"], "http://127.0.0.1:3000");
     assert!(setup_value(&rendered, "Configuration").contains("~/.pi/agent/models.json"));
     assert!(setup_value(&rendered, "Configuration").contains("~/.pi/agent/settings.json"));
     assert!(setup_value(&rendered, "Configuration").contains(".pi/settings.json"));
@@ -108,10 +108,11 @@ fn pi_shape_includes_provider_model_cost_and_windows() {
     assert_eq!(model["contextWindow"], 200_000);
     assert_eq!(model["maxTokens"], 64_000);
     assert_eq!(model["cost"]["cacheRead"], 0.3);
+    assert_eq!(model["cost"]["cacheWrite"], 0);
 }
 
 #[test]
-fn cache_read_is_omitted_when_missing() {
+fn pi_cache_costs_default_to_zero_when_missing() {
     let mut input = input(Some(AnthropicThinkingPolicy::SafeEffort));
     input.cache_read_cost_per_million_tokens_usd_10000 = None;
 
@@ -126,10 +127,40 @@ fn cache_read_is_omitted_when_missing() {
             .get("cache_read")
             .is_none()
     );
+    assert_eq!(
+        pi["providers"]["oceans-llm"]["models"][0]["cost"]["cacheRead"],
+        0
+    );
+    assert_eq!(
+        pi["providers"]["oceans-llm"]["models"][0]["cost"]["cacheWrite"],
+        0
+    );
+}
+
+#[test]
+fn client_context_window_is_capped_with_note() {
+    let mut input = input(Some(AnthropicThinkingPolicy::SafeEffort));
+    input.context_window_tokens = Some(1_000_000);
+    input.input_window_tokens = None;
+
+    let opencode = OpenCodeConfigTemplate.render(&input);
+    let opencode_value: Value = serde_json::from_str(&opencode.blocks[0].content).expect("json");
+    let pi = PiConfigTemplate.render(&input);
+    let pi_value: Value = serde_json::from_str(&pi.blocks[0].content).expect("json");
+
+    assert_eq!(
+        opencode_value["provider"]["oceans-llm"]["models"]["claude-sonnet"]["limit"]["context"],
+        200_000
+    );
+    assert_eq!(
+        pi_value["providers"]["oceans-llm"]["models"][0]["contextWindow"],
+        200_000
+    );
     assert!(
-        pi["providers"]["oceans-llm"]["models"][0]["cost"]
-            .get("cacheRead")
-            .is_none()
+        opencode
+            .notes
+            .iter()
+            .any(|note| note.contains("cap the input context window at 200000 tokens"))
     );
 }
 
@@ -219,7 +250,7 @@ fn opencode_safe_effort_config_matches_expected_full_shape() {
                     "npm": "@ai-sdk/anthropic",
                     "options": {
                         "apiKey": "{env:OCEANS_LLM_API_KEY}",
-                        "baseURL": "http://127.0.0.1:3000/v1"
+                        "baseURL": "http://127.0.0.1:3000"
                     }
                 }
             }
@@ -239,7 +270,7 @@ fn pi_safe_effort_config_matches_expected_full_shape() {
                 "oceans-llm": {
                     "api": "anthropic-messages",
                     "apiKey": "$OCEANS_LLM_API_KEY",
-                    "baseUrl": "http://127.0.0.1:3000/v1",
+                    "baseUrl": "http://127.0.0.1:3000",
                     "compat": {
                         "forceAdaptiveThinking": true
                     },
@@ -248,6 +279,7 @@ fn pi_safe_effort_config_matches_expected_full_shape() {
                             "contextWindow": 200000,
                             "cost": {
                                 "cacheRead": 0.3,
+                                "cacheWrite": 0,
                                 "input": 3.0,
                                 "output": 15.0
                             },
@@ -584,7 +616,7 @@ fn codex_shape_includes_custom_responses_provider() {
     assert_eq!(provider["name"].as_str(), Some("OpenAI using LLM proxy"));
     assert_eq!(
         provider["base_url"].as_str(),
-        Some("https://oceans.example.com/v1")
+        Some("https://oceans.example.com")
     );
     assert_eq!(provider["env_key"].as_str(), Some("OCEANS_API_KEY"));
     assert_eq!(
@@ -596,7 +628,8 @@ fn codex_shape_includes_custom_responses_provider() {
     assert_eq!(toml["analytics"]["enabled"].as_bool(), Some(false));
     assert_eq!(toml["otel"]["log_user_prompt"].as_bool(), Some(false));
 
-    assert_eq!(content.matches("https://oceans.example.com/v1").count(), 1);
+    assert_eq!(content.matches("https://oceans.example.com").count(), 1);
+    assert!(!content.contains("https://oceans.example.com/v1"));
     assert!(!content.contains("]("));
     assert!(
         rendered

--- a/crates/gateway-client-config/src/types.rs
+++ b/crates/gateway-client-config/src/types.rs
@@ -63,6 +63,11 @@ impl ClientConfigInput {
     }
 
     #[must_use]
+    pub fn openai_compatible_client_base_url(&self) -> String {
+        format!("{}/v1", self.client_base_url())
+    }
+
+    #[must_use]
     pub fn output_window(&self) -> i64 {
         self.output_window_tokens.unwrap_or_default()
     }

--- a/crates/gateway-client-config/src/types.rs
+++ b/crates/gateway-client-config/src/types.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-pub const DEFAULT_GATEWAY_BASE_URL: &str = "http://127.0.0.1:3000/v1";
+pub const DEFAULT_GATEWAY_BASE_URL: &str = "http://127.0.0.1:3000";
 pub const DEFAULT_API_KEY_ENV_VAR: &str = "OCEANS_LLM_API_KEY";
 pub const DEFAULT_PROVIDER_ID: &str = "oceans-llm";
+pub const MAX_CLIENT_CONTEXT_WINDOW_TOKENS: i64 = 200_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -42,9 +43,28 @@ pub struct ClientConfigInput {
 impl ClientConfigInput {
     #[must_use]
     pub fn context_window(&self) -> i64 {
+        let window = self
+            .input_window_tokens
+            .or(self.context_window_tokens)
+            .unwrap_or_default();
+        if window > 0 {
+            window.min(MAX_CLIENT_CONTEXT_WINDOW_TOKENS)
+        } else {
+            window
+        }
+    }
+
+    #[must_use]
+    pub fn context_window_is_capped(&self) -> bool {
         self.input_window_tokens
             .or(self.context_window_tokens)
-            .unwrap_or_default()
+            .is_some_and(|window| window > MAX_CLIENT_CONTEXT_WINDOW_TOKENS)
+    }
+
+    #[must_use]
+    pub fn client_base_url(&self) -> String {
+        let trimmed = self.gateway_base_url.trim_end_matches('/');
+        trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
     }
 
     #[must_use]

--- a/crates/gateway-client-config/src/types.rs
+++ b/crates/gateway-client-config/src/types.rs
@@ -43,15 +43,10 @@ pub struct ClientConfigInput {
 impl ClientConfigInput {
     #[must_use]
     pub fn context_window(&self) -> i64 {
-        let window = self
-            .input_window_tokens
+        self.input_window_tokens
             .or(self.context_window_tokens)
-            .unwrap_or_default();
-        if window > 0 {
-            window.min(MAX_CLIENT_CONTEXT_WINDOW_TOKENS)
-        } else {
-            window
-        }
+            .unwrap_or_default()
+            .min(MAX_CLIENT_CONTEXT_WINDOW_TOKENS)
     }
 
     #[must_use]

--- a/crates/gateway-service/src/admin_models.rs
+++ b/crates/gateway-service/src/admin_models.rs
@@ -1386,7 +1386,7 @@ mod tests {
         assert!(
             items[0].client_configurations[0].blocks[0]
                 .content
-                .contains("\"baseURL\": \"https://gateway.example.com/v1\"")
+                .contains("\"baseURL\": \"https://gateway.example.com\"")
         );
         assert!(
             items[0].client_configurations[2].blocks[0]

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -5,7 +5,7 @@ use gateway_service::{
     AdminModelStatus as ServiceAdminModelStatus, ModelIconKey as ServiceModelIconKey,
     ProviderIconKey as ServiceProviderIconKey,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use utoipa::{
@@ -414,11 +414,22 @@ pub struct AddTeamMembersRequest {
 pub struct UpdateUserRequest {
     pub global_role: String,
     pub auth_mode: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_nullable_string")]
     pub team_id: Option<Option<String>>,
+    #[serde(default, deserialize_with = "deserialize_optional_nullable_string")]
     pub team_role: Option<Option<String>>,
     pub oidc_provider_key: Option<String>,
     pub oauth_provider_key: Option<String>,
     pub tags: Option<Vec<AdminEntityTagView>>,
+}
+
+fn deserialize_optional_nullable_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -1314,7 +1325,9 @@ pub fn format_timestamp(value: OffsetDateTime) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::admin_openapi;
+    use serde_json::json;
+
+    use super::{UpdateUserRequest, admin_openapi};
 
     #[test]
     fn openapi_document_version_is_release_agnostic() {
@@ -1378,5 +1391,31 @@ mod tests {
         );
         assert!(components.schemas.contains_key("AdminModelAllowlistView"));
         assert!(components.schemas.contains_key("AdminModelView"));
+    }
+
+    #[test]
+    fn update_user_request_distinguishes_omitted_and_null_team_fields() {
+        let omitted: UpdateUserRequest =
+            serde_json::from_value(json!({ "global_role": "user" })).expect("request");
+        assert_eq!(omitted.team_id, None);
+        assert_eq!(omitted.team_role, None);
+
+        let cleared: UpdateUserRequest = serde_json::from_value(json!({
+            "global_role": "user",
+            "team_id": null,
+            "team_role": null
+        }))
+        .expect("request");
+        assert_eq!(cleared.team_id, Some(None));
+        assert_eq!(cleared.team_role, Some(None));
+
+        let assigned: UpdateUserRequest = serde_json::from_value(json!({
+            "global_role": "user",
+            "team_id": "team_1",
+            "team_role": "admin"
+        }))
+        .expect("request");
+        assert_eq!(assigned.team_id, Some(Some("team_1".to_string())));
+        assert_eq!(assigned.team_role, Some(Some("admin".to_string())));
     }
 }

--- a/crates/gateway/src/http/admin_contract.rs
+++ b/crates/gateway/src/http/admin_contract.rs
@@ -414,8 +414,8 @@ pub struct AddTeamMembersRequest {
 pub struct UpdateUserRequest {
     pub global_role: String,
     pub auth_mode: Option<String>,
-    pub team_id: Option<String>,
-    pub team_role: Option<String>,
+    pub team_id: Option<Option<String>>,
+    pub team_role: Option<Option<String>>,
     pub oidc_provider_key: Option<String>,
     pub oauth_provider_key: Option<String>,
     pub tags: Option<Vec<AdminEntityTagView>>,

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -3237,8 +3237,10 @@ mod tests {
         let team_id = Uuid::new_v4();
         let current = Some((team_id, MembershipRole::Owner));
 
-        let membership =
-            parse_update_requested_membership(current, None, None).expect("membership parses");
+        let membership = match parse_update_requested_membership(current, None, None) {
+            Ok(membership) => membership,
+            Err(_) => panic!("membership should parse"),
+        };
 
         assert_eq!(membership, current);
     }
@@ -3248,8 +3250,11 @@ mod tests {
         let team_id = Uuid::new_v4();
         let current = Some((team_id, MembershipRole::Admin));
 
-        let membership = parse_update_requested_membership(current, Some(&None), Some(&None))
-            .expect("membership parses");
+        let membership = match parse_update_requested_membership(current, Some(&None), Some(&None))
+        {
+            Ok(membership) => membership,
+            Err(_) => panic!("membership should parse"),
+        };
 
         assert_eq!(membership, None);
     }

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -843,13 +843,11 @@ pub async fn update_identity_user(
     .map_err(AppError)?;
     if membership_update_requested(&identity_user, requested_membership) {
         ensure_mutable_membership(identity_user.membership_role).map_err(AppError)?;
-    }
-    if let Some((team_id, _)) = requested_membership {
-        state
-            .store
-            .get_team_by_id(team_id)
-            .await?
-            .ok_or_else(|| AppError(GatewayError::InvalidRequest("team not found".to_string())))?;
+        if let Some((team_id, _)) = requested_membership {
+            state.store.get_team_by_id(team_id).await?.ok_or_else(|| {
+                AppError(GatewayError::InvalidRequest("team not found".to_string()))
+            })?;
+        }
     }
 
     let now = OffsetDateTime::now_utc();

--- a/crates/gateway/src/http/identity.rs
+++ b/crates/gateway/src/http/identity.rs
@@ -798,8 +798,11 @@ pub async fn update_identity_user(
         .map(parse_auth_mode)
         .transpose()?
         .unwrap_or(identity_user.user.auth_mode);
-    let requested_membership =
-        parse_requested_membership(request.team_id.as_deref(), request.team_role.as_deref())?;
+    let requested_membership = parse_update_requested_membership(
+        current_membership(&identity_user),
+        request.team_id.as_ref(),
+        request.team_role.as_ref(),
+    )?;
     let tags = match request.tags.as_ref() {
         Some(tags) => parse_entity_tag_views(tags, "user tags")?,
         None => identity_user.user.tags.clone(),
@@ -2453,6 +2456,23 @@ fn parse_requested_membership(
     }
 }
 
+fn parse_update_requested_membership(
+    current_membership: Option<(Uuid, MembershipRole)>,
+    team_id: Option<&Option<String>>,
+    team_role: Option<&Option<String>>,
+) -> Result<Option<(Uuid, MembershipRole)>, AppError> {
+    match (team_id, team_role) {
+        (None, None) => Ok(current_membership),
+        (Some(None), Some(None)) => Ok(None),
+        (Some(Some(team_id)), Some(Some(role))) => {
+            parse_requested_membership(Some(team_id), Some(role))
+        }
+        _ => Err(AppError(GatewayError::InvalidRequest(
+            "team_id and team_role must either both be present or both be absent".to_string(),
+        ))),
+    }
+}
+
 async fn resolve_requested_oidc_provider(
     store: &AnyStore,
     auth_mode: AuthMode,
@@ -3145,9 +3165,12 @@ pub async fn list_public_oauth_providers(
 
 #[cfg(test)]
 mod tests {
+    use gateway_core::{GatewayError, MembershipRole};
+    use uuid::Uuid;
+
     use super::{
         GithubEmailLookupError, GithubEmailResponse, github_email_domain_allowed,
-        select_github_primary_email,
+        parse_update_requested_membership, select_github_primary_email,
     };
 
     #[test]
@@ -3207,5 +3230,40 @@ mod tests {
         let email = select_github_primary_email(&emails, false).expect("email should be selected");
 
         assert_eq!(email, "alice@example.com");
+    }
+
+    #[test]
+    fn update_membership_parser_preserves_membership_when_fields_are_omitted() {
+        let team_id = Uuid::new_v4();
+        let current = Some((team_id, MembershipRole::Owner));
+
+        let membership =
+            parse_update_requested_membership(current, None, None).expect("membership parses");
+
+        assert_eq!(membership, current);
+    }
+
+    #[test]
+    fn update_membership_parser_removes_membership_when_fields_are_null() {
+        let team_id = Uuid::new_v4();
+        let current = Some((team_id, MembershipRole::Admin));
+
+        let membership = parse_update_requested_membership(current, Some(&None), Some(&None))
+            .expect("membership parses");
+
+        assert_eq!(membership, None);
+    }
+
+    #[test]
+    fn update_membership_parser_rejects_partial_membership_fields() {
+        let team_id = Some(Uuid::new_v4().to_string());
+
+        let error = parse_update_requested_membership(None, Some(&team_id), Some(&None))
+            .expect_err("partial membership should fail");
+
+        assert!(matches!(
+            error.0,
+            GatewayError::InvalidRequest(message) if message.contains("team_id and team_role")
+        ));
     }
 }

--- a/docs/configuration/client-harness-configuration.md
+++ b/docs/configuration/client-harness-configuration.md
@@ -17,7 +17,20 @@ Generated snippets are available for:
 
 The snippets use the gateway model ids shown in the Models table. API keys are still created and governed in Oceans; the local client config only tells the harness which gateway URL, key variable, and model ids to use.
 
-By default, snippets use the local development gateway base URL `http://127.0.0.1:3000/v1`. Production deployments should set `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway process, or `gateway.clientConfigGatewayBaseUrl` in the Helm chart, to the public gateway API base URL users can reach, for example `https://gateway.example.com/v1`.
+By default, snippets use the local development gateway base URL `http://127.0.0.1:3000`. Production deployments should set `GATEWAY_CLIENT_CONFIG_BASE_URL` on the gateway process, or `gateway.clientConfigGatewayBaseUrl` in the Helm chart, to the public gateway URL users can reach, for example `https://api.oceans-llm.com`.
+
+Base URL can change depending on API format and client harness. Experiment with adding or removing `/v1` if requests initially fail.
+
+For a gateway hosted at `https://api.oceans-llm.com`, generated client configs use:
+
+| Client harness | API format or provider | Generated base URL |
+| --- | --- | --- |
+| Claude Code | Anthropic Messages | `https://api.oceans-llm.com` |
+| Codex | Responses API | `https://api.oceans-llm.com/v1` |
+| OpenCode | `@ai-sdk/anthropic` | `https://api.oceans-llm.com` |
+| OpenCode | `@ai-sdk/openai-compatible` | `https://api.oceans-llm.com/v1` |
+| Pi | `anthropic-messages` | `https://api.oceans-llm.com` |
+| Pi | `openai-completions` | `https://api.oceans-llm.com/v1` |
 
 OpenCode and Pi can include multiple selected models in one generated file. When the selection mixes Anthropic Messages models and OpenAI-compatible models, Oceans emits separate provider entries so each provider keeps the correct client adapter. Claude Code only includes selected models that use Anthropic Messages; non-Anthropic selections are ignored for the Claude Code tab instead of generating invalid overrides. Codex snippets require a single Responses-capable model selection.
 


### PR DESCRIPTION
## Description

Fixes the client configuration and admin onboarding reset issues found during testing.

- Summary of changes
  - Drop `/v1` from generated gateway client base URLs and normalize explicit `/v1` inputs.
  - Cap generated client context windows at `200000` tokens and include a note that users can edit the generated limit.
  - Emit Pi `cacheRead` and `cacheWrite` cost fields, defaulting to `0` when cache pricing is unavailable.
  - Keep reset onboarding URLs visible after the users list refreshes.
  - Handle OAuth reset onboarding URLs without relying on password-invite-only response fields.
- Why this approach was chosen
  - The generated clients append or target their own API paths, so the gateway root is the safer base URL.
  - The context cap keeps generated configs away from disproportionately expensive long-context defaults while remaining user-editable.
  - Pi accepts the documented shape more reliably in practice when cache cost fields are present.
  - The reset link should be cleared when the selected user changes, not when the same user is reloaded into a fresh object.
- How it works
  - `ClientConfigInput` now exposes normalized client base URLs and capped context windows.
  - Shared client-config notes include a context-window cap note when applicable.
  - User onboarding reset state is keyed by selected user id, and invited-user auth/provider edits are persisted before reset when needed.
- Risks, tradeoffs, and alternatives considered
  - Existing configs generated before this change may still include `/v1`; users should regenerate or edit them.
  - The 200K cap is intentionally conservative and documented in the generated notes.
  - The commit hook could not complete because it stashes unrelated dirty worktree files before running full lint, exposing unrelated `tags` initializer compile errors outside this PR. The focused checks and a full `mise run lint` were run successfully before publishing in the active worktree.
- Additional context for reviewers
  - Browser validation covered password reset and OAuth reset onboarding URLs remaining visible after refresh latency.

## Release Readiness Checklist

- [x] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run check-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-rust-postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run test-gateway-postgres-smoke`

Additional validation:

- [x] `cargo test -p gateway-client-config`
- [x] `cargo test -p gateway-service admin_models`
- [x] `bun run --cwd crates/admin-ui/web test src/test/routes/users-route.test.tsx`
