### PR TITLE
fix(admin-ui): compact model allow list

### DIFF
--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -336,7 +336,7 @@ export function ModelsPage() {
               <div className="flex flex-wrap gap-2">
                 <Button
                   type="button"
-                  variant="secondary"
+                  variant="outline"
                   size="sm"
                   className="gap-2"
                   onClick={openSelectedClientConfig}
@@ -428,7 +428,7 @@ export function ModelsPage() {
                         </TableHead>
                       ) : null}
                       <TableHead className="w-[12rem] px-3 py-2 font-semibold text-[var(--color-text-soft)]">
-                        Model allowlist
+                        Allow List
                       </TableHead>
                     </TableRow>
                   </TableHeader>
@@ -1181,6 +1181,30 @@ function ModelAllowlistDetail({ compact = false, model }: { compact?: boolean; m
         <AppIcon icon={CircleCheckIcon} size={compact ? 13 : 14} stroke={1.5} />
         Unrestricted
       </span>
+    )
+  }
+
+  if (compact) {
+    const userCount = model.allowlist.users.length
+    const teamCount = model.allowlist.teams.length
+
+    return (
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="inline-flex items-center gap-1.5 text-sm text-[var(--color-text)]">
+          <AppIcon icon={CircleCheckIcon} size={13} stroke={1.5} />
+          Restricted
+        </span>
+        {userCount > 0 || teamCount > 0 ? (
+          <span className="flex flex-wrap gap-x-2 text-xs text-[var(--color-text-soft)]">
+            {userCount > 0 ? (
+              <span>{`${userCount} ${userCount === 1 ? 'User' : 'Users'}`}</span>
+            ) : null}
+            {teamCount > 0 ? (
+              <span>{`${teamCount} ${teamCount === 1 ? 'Team' : 'Teams'}`}</span>
+            ) : null}
+          </span>
+        ) : null}
+      </div>
     )
   }
 

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -289,6 +289,12 @@ describe('ModelsPage', () => {
       screen.getByText('Review routed models, upstream targets, and current health status.'),
     ).toBeInTheDocument()
     expect(screen.getByText('Select models to generate multi-model config')).toBeInTheDocument()
+
+    const clearButton = screen.getByRole('button', { name: 'Clear' })
+    const generateConfigButton = screen.getByRole('button', { name: 'Generate config' })
+    expect(clearButton).toBeDisabled()
+    expect(generateConfigButton).toBeDisabled()
+    expect(generateConfigButton).toHaveAttribute('data-variant', clearButton.dataset.variant)
   })
 
   it('renders the desktop table with the expected column order and stacked routing cells', () => {
@@ -312,7 +318,7 @@ describe('ModelsPage', () => {
       'Actions',
       'Provider & Model',
       'Cost / 1M tokens',
-      'Model allowlist',
+      'Allow List',
     ])
     expect(within(table).getByRole('columnheader', { name: 'Provider & Model' })).toHaveClass(
       'w-[18rem]',
@@ -361,7 +367,7 @@ describe('ModelsPage', () => {
     )
 
     const table = screen.getAllByTestId('models-desktop-table')[0]
-    expect(within(table).getByRole('columnheader', { name: 'Model allowlist' })).toBeInTheDocument()
+    expect(within(table).getByRole('columnheader', { name: 'Allow List' })).toBeInTheDocument()
 
     const fastRow = within(table).getByText('fast').closest('tr')
     expect(fastRow).not.toBeNull()
@@ -373,11 +379,14 @@ describe('ModelsPage', () => {
     const claudeAllowlistCell = within(claudeRow as HTMLElement).getAllByRole(
       'cell',
     )[5] as HTMLElement
-    expect(within(claudeAllowlistCell).getByText('Users')).toBeInTheDocument()
-    expect(within(claudeAllowlistCell).getByText('alice@example.com')).toBeInTheDocument()
-    expect(within(claudeAllowlistCell).getByText('bob@example.com')).toBeInTheDocument()
-    expect(within(claudeAllowlistCell).getByText('Teams')).toBeInTheDocument()
-    expect(within(claudeAllowlistCell).getByText('platform')).toBeInTheDocument()
+    expect(within(claudeAllowlistCell).getByText('Restricted')).toBeInTheDocument()
+    expect(within(claudeAllowlistCell).getByText('2 Users')).toBeInTheDocument()
+    expect(within(claudeAllowlistCell).getByText('1 Team')).toBeInTheDocument()
+    expect(within(claudeAllowlistCell).queryByText('0 Users')).not.toBeInTheDocument()
+    expect(within(claudeAllowlistCell).queryByText('0 Teams')).not.toBeInTheDocument()
+    expect(within(claudeAllowlistCell).queryByText('alice@example.com')).not.toBeInTheDocument()
+    expect(within(claudeAllowlistCell).queryByText('bob@example.com')).not.toBeInTheDocument()
+    expect(within(claudeAllowlistCell).queryByText('platform')).not.toBeInTheDocument()
 
     for (const allowlistCell of [fastAllowlistCell, claudeAllowlistCell]) {
       expect(within(allowlistCell).queryByRole('button')).not.toBeInTheDocument()

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -294,7 +294,8 @@ describe('ModelsPage', () => {
     const generateConfigButton = screen.getByRole('button', { name: 'Generate config' })
     expect(clearButton).toBeDisabled()
     expect(generateConfigButton).toBeDisabled()
-    expect(generateConfigButton).toHaveAttribute('data-variant', clearButton.dataset.variant)
+    expect(clearButton).toHaveAttribute('data-variant', 'outline')
+    expect(generateConfigButton).toHaveAttribute('data-variant', 'outline')
   })
 
   it('renders the desktop table with the expected column order and stacked routing cells', () => {
@@ -358,7 +359,31 @@ describe('ModelsPage', () => {
   })
 
   it('renders model allowlists in the desktop table as read-only details', () => {
-    routeMock.useLoaderData.mockReturnValue({ data: modelPage })
+    const allowlistPage: ModelPageView = {
+      ...modelPage,
+      items: modelPage.items.map((model) => {
+        if (model.id === 'fast') {
+          return {
+            ...model,
+            allowlist: {
+              users: ['solo@example.com'],
+              teams: [],
+            },
+          }
+        }
+        if (model.id === 'backup-fast') {
+          return {
+            ...model,
+            allowlist: {
+              users: [],
+              teams: ['platform', 'research'],
+            },
+          }
+        }
+        return model
+      }),
+    }
+    routeMock.useLoaderData.mockReturnValue({ data: allowlistPage })
 
     render(
       <TooltipProvider>
@@ -372,7 +397,18 @@ describe('ModelsPage', () => {
     const fastRow = within(table).getByText('fast').closest('tr')
     expect(fastRow).not.toBeNull()
     const fastAllowlistCell = within(fastRow as HTMLElement).getAllByRole('cell')[5] as HTMLElement
-    expect(within(fastAllowlistCell).getByText('Unrestricted')).toBeInTheDocument()
+    expect(within(fastAllowlistCell).getByText('Restricted')).toBeInTheDocument()
+    expect(within(fastAllowlistCell).getByText('1 User')).toBeInTheDocument()
+    expect(within(fastAllowlistCell).queryByText(/Teams?/)).not.toBeInTheDocument()
+
+    const backupRow = within(table).getByText('backup-fast').closest('tr')
+    expect(backupRow).not.toBeNull()
+    const backupAllowlistCell = within(backupRow as HTMLElement).getAllByRole(
+      'cell',
+    )[5] as HTMLElement
+    expect(within(backupAllowlistCell).getByText('Restricted')).toBeInTheDocument()
+    expect(within(backupAllowlistCell).getByText('2 Teams')).toBeInTheDocument()
+    expect(within(backupAllowlistCell).queryByText(/Users?/)).not.toBeInTheDocument()
 
     const claudeRow = within(table).getByText('claude-sonnet').closest('tr')
     expect(claudeRow).not.toBeNull()
@@ -382,13 +418,11 @@ describe('ModelsPage', () => {
     expect(within(claudeAllowlistCell).getByText('Restricted')).toBeInTheDocument()
     expect(within(claudeAllowlistCell).getByText('2 Users')).toBeInTheDocument()
     expect(within(claudeAllowlistCell).getByText('1 Team')).toBeInTheDocument()
-    expect(within(claudeAllowlistCell).queryByText('0 Users')).not.toBeInTheDocument()
-    expect(within(claudeAllowlistCell).queryByText('0 Teams')).not.toBeInTheDocument()
     expect(within(claudeAllowlistCell).queryByText('alice@example.com')).not.toBeInTheDocument()
     expect(within(claudeAllowlistCell).queryByText('bob@example.com')).not.toBeInTheDocument()
     expect(within(claudeAllowlistCell).queryByText('platform')).not.toBeInTheDocument()
 
-    for (const allowlistCell of [fastAllowlistCell, claudeAllowlistCell]) {
+    for (const allowlistCell of [fastAllowlistCell, backupAllowlistCell, claudeAllowlistCell]) {
       expect(within(allowlistCell).queryByRole('button')).not.toBeInTheDocument()
       expect(within(allowlistCell).queryByRole('link')).not.toBeInTheDocument()
       expect(within(allowlistCell).queryByRole('checkbox')).not.toBeInTheDocument()


### PR DESCRIPTION
## Description

Polishes the models table's remaining action and allow-list presentation inconsistencies.

- Makes the disabled **Generate config** button use the same outline treatment as **Clear**.
- Renames the desktop column to **Allow List**.
- Summarizes restricted access as user and team counts with singular/plural handling and zero-count omission.
- Keeps the detailed user and team identities available in the mobile/detail presentation.
- Updates route tests to cover the button variant, compact counts, omitted zero counts, and hidden identities.

This keeps the high-density desktop table scannable without changing the underlying allow-list or client-configuration behavior.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:check`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:test:postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:smoke:postgres`

The gateway-store checks are not applicable because this PR only changes admin UI rendering and its tests.
