### PR TITLE
feat(admin-ui): add agent harness icons

### DIFF
--- a/crates/admin-ui/web/bun.lock
+++ b/crates/admin-ui/web/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "admin-ui-web",
@@ -7,7 +8,7 @@
         "@fontsource-variable/geist": "5.2.9",
         "@hugeicons/core-free-icons": "4.2.2",
         "@hugeicons/react": "1.1.9",
-        "@lobehub/icons-static-svg": "1.91.0",
+        "@lobehub/icons-static-svg": "1.94.0",
         "@radix-ui/react-dialog": "1.1.17",
         "@radix-ui/react-popover": "1.1.17",
         "@radix-ui/react-select": "2.3.1",
@@ -234,7 +235,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@lobehub/icons-static-svg": ["@lobehub/icons-static-svg@1.91.0", "", {}, "sha512-ZDflEq0uUvAkH4WK4h3qNvvY09ts4OqUb5azD7A0xKfcuYhffGwB1Q/As2RguZYq4Gh4v925CJ8iodiClzc4zw=="],
+    "@lobehub/icons-static-svg": ["@lobehub/icons-static-svg@1.94.0", "", {}, "sha512-Inx1TYkjLH6YeHOIHeVW9+OM/xxRnk8TmcQVKquFUDBmE3X9sUuRGt7kALrrDBNNAbrWz7Qq6fAiFj9E9Mmw9Q=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/crates/admin-ui/web/package.json
+++ b/crates/admin-ui/web/package.json
@@ -22,7 +22,7 @@
     "@fontsource-variable/geist": "5.2.9",
     "@hugeicons/core-free-icons": "4.2.2",
     "@hugeicons/react": "1.1.9",
-    "@lobehub/icons-static-svg": "1.91.0",
+    "@lobehub/icons-static-svg": "1.94.0",
     "@radix-ui/react-dialog": "1.1.17",
     "@radix-ui/react-popover": "1.1.17",
     "@radix-ui/react-select": "2.3.1",

--- a/crates/admin-ui/web/src/components/icons/agent-harness-icon.test.tsx
+++ b/crates/admin-ui/web/src/components/icons/agent-harness-icon.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { AgentHarnessLabel } from '@/components/icons/agent-harness-icon'
+
+describe('AgentHarnessLabel', () => {
+  it.each(['OpenCode', 'Pi', 'Claude Code', 'Codex'])('renders the %s harness icon', (label) => {
+    const { container } = render(<AgentHarnessLabel harnessKey={label}>{label}</AgentHarnessLabel>)
+
+    expect(container.querySelector('[data-agent-harness-icon]')).toBeInTheDocument()
+  })
+
+  it('keeps unknown harness labels text-only', () => {
+    const { container, getByText } = render(
+      <AgentHarnessLabel harnessKey="custom-client">Custom client</AgentHarnessLabel>,
+    )
+
+    expect(getByText('Custom client')).toBeInTheDocument()
+    expect(container.querySelector('[data-agent-harness-icon]')).not.toBeInTheDocument()
+  })
+})

--- a/crates/admin-ui/web/src/components/icons/agent-harness-icon.tsx
+++ b/crates/admin-ui/web/src/components/icons/agent-harness-icon.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
+
+import claudeCodeIcon from '@lobehub/icons-static-svg/icons/claudecode.svg'
+import codexIcon from '@lobehub/icons-static-svg/icons/codex.svg'
+import openCodeIcon from '@lobehub/icons-static-svg/icons/opencode.svg'
+import piIcon from '@lobehub/icons-static-svg/icons/pi.svg'
+
+import { cn } from '@/lib/utils'
+
+const AGENT_HARNESS_ICONS: Record<string, string> = {
+  claudecode: claudeCodeIcon,
+  codex: codexIcon,
+  opencode: openCodeIcon,
+  pi: piIcon,
+}
+
+interface AgentHarnessIconProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'children'> {
+  harnessKey: string
+  size?: number
+}
+
+export function AgentHarnessIcon({
+  className,
+  harnessKey,
+  size = 16,
+  style,
+  ...props
+}: AgentHarnessIconProps) {
+  const source = AGENT_HARNESS_ICONS[normalizeHarnessKey(harnessKey)]
+
+  if (!source) {
+    return null
+  }
+
+  const maskStyle: CSSProperties = {
+    WebkitMask: `url(${source}) center / contain no-repeat`,
+    mask: `url(${source}) center / contain no-repeat`,
+    backgroundColor: 'currentColor',
+    height: size,
+    width: size,
+    ...style,
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('inline-flex shrink-0', className)}
+      data-agent-harness-icon={normalizeHarnessKey(harnessKey)}
+      style={maskStyle}
+      {...props}
+    />
+  )
+}
+
+export function AgentHarnessLabel({
+  children,
+  className,
+  harnessKey,
+  iconSize = 16,
+}: {
+  children: ReactNode
+  className?: string
+  harnessKey: string
+  iconSize?: number
+}) {
+  return (
+    <span className={cn('inline-flex items-center gap-1.5', className)}>
+      <AgentHarnessIcon harnessKey={harnessKey} size={iconSize} />
+      <span>{children}</span>
+    </span>
+  )
+}
+
+function normalizeHarnessKey(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '')
+}

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -18,6 +18,7 @@ import { toast } from 'sonner'
 
 import { BrandIcon } from '@/components/icons/brand-icon'
 import { AppIcon } from '@/components/icons/app-icon'
+import { AgentHarnessLabel } from '@/components/icons/agent-harness-icon'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -1018,7 +1019,7 @@ function ClientConfigDialog({
               >
                 {clientConfigurations.map((config) => (
                   <ToggleGroupItem key={config.key} value={config.key} aria-label={config.label}>
-                    {config.label}
+                    <AgentHarnessLabel harnessKey={config.key}>{config.label}</AgentHarnessLabel>
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>

--- a/crates/admin-ui/web/src/routes/observability/agent-harnesses.tsx
+++ b/crates/admin-ui/web/src/routes/observability/agent-harnesses.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts'
 import { toast } from 'sonner'
 
+import { AgentHarnessLabel } from '@/components/icons/agent-harness-icon'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   ChartContainer,
@@ -55,7 +56,11 @@ export function AgentHarnessesPage() {
 
   const chartConfig = chartSeries.reduce<ChartConfig>((config, harness) => {
     config[harness.key] = {
-      label: harness.agent_harness_label,
+      label: (
+        <AgentHarnessLabel harnessKey={harness.agent_harness_key} iconSize={14}>
+          {harness.agent_harness_label}
+        </AgentHarnessLabel>
+      ),
       color: harness.color,
     }
     return config
@@ -231,7 +236,11 @@ export function AgentHarnessesPage() {
                       <TableCell className="font-medium text-[var(--color-text-soft)]">
                         {index + 1}
                       </TableCell>
-                      <TableCell className="font-medium">{leader.agent_harness_label}</TableCell>
+                      <TableCell className="font-medium">
+                        <AgentHarnessLabel harnessKey={leader.agent_harness_key}>
+                          {leader.agent_harness_label}
+                        </AgentHarnessLabel>
+                      </TableCell>
                       <TableCell className="text-right">
                         {NUMBER_FORMATTER.format(leader.total_requests)}
                       </TableCell>

--- a/crates/admin-ui/web/src/test/routes/agent-harnesses-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/agent-harnesses-route.test.tsx
@@ -99,6 +99,9 @@ describe('AgentHarnessesPage', () => {
     expect(scope.getAllByText('Opencode').length).toBeGreaterThan(0)
     expect(scope.getAllByText('Claude Code').length).toBeGreaterThan(0)
     expect(scope.getByText('opencode')).toBeInTheDocument()
+    expect(
+      scope.getByTestId('harness-usage-table').querySelectorAll('[data-agent-harness-icon]'),
+    ).toHaveLength(2)
   })
 
   it('refetches harness data when the date range changes', async () => {

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -518,7 +518,9 @@ describe('ModelsPage', () => {
     expect(getModelClientConfigsMock).toHaveBeenCalledWith({
       data: { model_keys: ['claude-sonnet'] },
     })
-    expect(await screen.findByRole('dialog', { name: 'Client config' })).toBeInTheDocument()
+    const clientConfigDialog = await screen.findByRole('dialog', { name: 'Client config' })
+    expect(clientConfigDialog).toBeInTheDocument()
+    expect(clientConfigDialog.querySelectorAll('[data-agent-harness-icon]')).toHaveLength(4)
     expect(screen.getByText('~/.config/opencode/opencode.json')).toBeInTheDocument()
     expect(screen.getByText('Base URL')).toBeInTheDocument()
     expect(screen.getByText(/Base URL can change depending on API format/)).toBeInTheDocument()


### PR DESCRIPTION
## Description

Add recognizable Lobe icons beside agent harness names in the model client configuration and observability views.

- Introduces a shared `AgentHarnessIcon` / `AgentHarnessLabel` component for OpenCode, Pi, Claude Code, and Codex.
- Uses monochrome SVG masks so each icon inherits the surrounding foreground color without a background.
- Adds icons to model client configuration toggles, observability chart labels and tooltips, and the ranked harness table.
- Preserves text-only rendering for unknown harness keys.
- Updates `@lobehub/icons-static-svg` to 1.94.0 for the new harness assets.
- Adds component and route coverage for known icons and unknown-harness fallback behavior.

This keeps harness matching and presentation in one shared UI component while leaving existing API labels and accessibility names unchanged. The primary tradeoff is the small static icon dependency update.

Validation:

- `mise run ui-check` (format check, UI lint, 113 UI tests, and production build)
- `git diff --check`

## Release Readiness Checklist

- [ ] `mise run lint` (UI-only change; covered by `mise run ui-check`)
- [ ] `mise run test` (UI-only change; covered by `mise run ui-check`)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:check` (not applicable)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:test:postgres` (not applicable)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:smoke:postgres` (not applicable)
