### PR TITLE
style(admin-ui): add page headers

### DIFF
--- a/crates/admin-ui/web/src/components/layout/page-header.tsx
+++ b/crates/admin-ui/web/src/components/layout/page-header.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+
+export function PageHeader({
+  section,
+  title,
+  description,
+  actions,
+}: {
+  section: string
+  title: string
+  description: ReactNode
+  actions?: ReactNode
+}) {
+  return (
+    <header className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-muted-foreground text-sm">{section}</p>
+          <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        </div>
+        {actions}
+      </div>
+      <p className="text-muted-foreground max-w-3xl text-sm">{description}</p>
+    </header>
+  )
+}

--- a/crates/admin-ui/web/src/routes/api-keys.tsx
+++ b/crates/admin-ui/web/src/routes/api-keys.tsx
@@ -6,6 +6,7 @@ import {
   CreatedApiKeyAlert,
   ManageApiKeyDialog,
 } from '@/routes/api-keys/-components'
+import { PageHeader } from '@/components/layout/page-header'
 import { requireAuthenticatedSession } from '@/routes/-admin-guard'
 import { isPlatformAdminSession } from '@/routes/-auth-routing'
 import { getApiKeys } from '@/server/admin-data.functions'
@@ -37,7 +38,17 @@ export function ApiKeysPage() {
   })
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Control Plane"
+        title="API keys"
+        description={
+          isPlatformAdmin
+            ? 'Create and manage keys that identities use to send requests.'
+            : 'Review the keys that you and your team use to send requests.'
+        }
+      />
+
       {isPlatformAdmin ? (
         <CreatedApiKeyAlert
           result={state.createdResult}
@@ -90,6 +101,6 @@ export function ApiKeysPage() {
           onSubmit={state.actions.handleUpdateApiKey}
         />
       ) : null}
-    </div>
+    </main>
   )
 }

--- a/crates/admin-ui/web/src/routes/api-keys.tsx
+++ b/crates/admin-ui/web/src/routes/api-keys.tsx
@@ -38,7 +38,7 @@ export function ApiKeysPage() {
   })
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Control Plane"
         title="API keys"
@@ -101,6 +101,6 @@ export function ApiKeysPage() {
           onSubmit={state.actions.handleUpdateApiKey}
         />
       ) : null}
-    </main>
+    </div>
   )
 }

--- a/crates/admin-ui/web/src/routes/api-keys/-components.tsx
+++ b/crates/admin-ui/web/src/routes/api-keys/-components.tsx
@@ -110,11 +110,11 @@ export function ApiKeysCard({
     <Card>
       <CardHeader className="flex flex-row items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
-          <CardTitle>API Keys</CardTitle>
+          <CardTitle>Keys</CardTitle>
           <CardDescription>
             {onCreate
-              ? 'Issue gateway credentials with explicit owners and model grant modes, then revoke them when access should stop.'
-              : 'Review your personal gateway credentials and any service-account credentials you can manage for your team.'}
+              ? 'Review each key owner, model access, status, and recent use.'
+              : 'Review the keys that you can use or manage.'}
           </CardDescription>
         </div>
         {onCreate ? (

--- a/crates/admin-ui/web/src/routes/identity/-read-only-directory.tsx
+++ b/crates/admin-ui/web/src/routes/identity/-read-only-directory.tsx
@@ -9,7 +9,7 @@ export function ReadOnlyUsersDirectory({ users }: { users: IdentityDirectoryUser
       <CardHeader>
         <CardTitle>User list</CardTitle>
         <CardDescription>
-          Select a user to review account and team details. Only administrators can make changes.
+          Review each user's account and team details. Only administrators can make changes.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -54,7 +54,7 @@ export function ReadOnlyTeamsDirectory({ teams }: { teams: IdentityDirectoryTeam
       <CardHeader>
         <CardTitle>Team list</CardTitle>
         <CardDescription>
-          Select a team to review its members. Only administrators can make changes.
+          Review each team and its members. Only administrators can make changes.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/crates/admin-ui/web/src/routes/identity/-read-only-directory.tsx
+++ b/crates/admin-ui/web/src/routes/identity/-read-only-directory.tsx
@@ -7,10 +7,9 @@ export function ReadOnlyUsersDirectory({ users }: { users: IdentityDirectoryUser
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Users</CardTitle>
+        <CardTitle>User list</CardTitle>
         <CardDescription>
-          View user identity, access role, team membership, and account status. Only platform
-          administrators can change users.
+          Select a user to review account and team details. Only administrators can make changes.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -53,10 +52,9 @@ export function ReadOnlyTeamsDirectory({ teams }: { teams: IdentityDirectoryTeam
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Teams</CardTitle>
+        <CardTitle>Team list</CardTitle>
         <CardDescription>
-          View all teams and their current membership. Only platform administrators can change teams
-          or membership.
+          Select a team to review its members. Only administrators can make changes.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/crates/admin-ui/web/src/routes/identity/service-accounts.tsx
+++ b/crates/admin-ui/web/src/routes/identity/service-accounts.tsx
@@ -2,6 +2,7 @@ import { Link, createFileRoute } from '@tanstack/react-router'
 import { RoboticIcon, SearchIcon } from '@hugeicons/core-free-icons'
 
 import { AppIcon } from '@/components/icons/app-icon'
+import { PageHeader } from '@/components/layout/page-header'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -47,14 +48,19 @@ export function ServiceAccountsPage() {
   const rows = buildServiceAccountRows(serviceAccounts, apiKeys)
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Identity"
+        title="Service accounts"
+        description="Review automated accounts, their teams, and the API keys that they use."
+      />
+
       <Card>
         <CardHeader>
           <div className="flex flex-col gap-1">
-            <CardTitle>Service Accounts</CardTitle>
+            <CardTitle>Account list</CardTitle>
             <CardDescription>
-              Review non-human gateway principals, their owning teams, and attached API-key
-              credentials. This page is read-only.
+              Open a team or API key from the table. You cannot make changes on this page.
             </CardDescription>
           </div>
         </CardHeader>
@@ -78,7 +84,7 @@ export function ServiceAccountsPage() {
           )}
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/identity/service-accounts.tsx
+++ b/crates/admin-ui/web/src/routes/identity/service-accounts.tsx
@@ -48,7 +48,7 @@ export function ServiceAccountsPage() {
   const rows = buildServiceAccountRows(serviceAccounts, apiKeys)
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Identity"
         title="Service accounts"
@@ -84,7 +84,7 @@ export function ServiceAccountsPage() {
           )}
         </CardContent>
       </Card>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/identity/teams.tsx
+++ b/crates/admin-ui/web/src/routes/identity/teams.tsx
@@ -210,10 +210,10 @@ export function TeamsPage() {
 
   if (!isPlatformAdmin) {
     return (
-      <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <div className="flex min-w-0 flex-1 flex-col gap-6">
         {pageHeader}
         <ReadOnlyTeamsDirectory teams={directoryData?.teams ?? []} />
-      </main>
+      </div>
     )
   }
 
@@ -425,7 +425,7 @@ export function TeamsPage() {
   }
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       {pageHeader}
 
       <Card>
@@ -1186,7 +1186,7 @@ export function TeamsPage() {
           ) : null}
         </DialogContent>
       </Dialog>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/identity/teams.tsx
+++ b/crates/admin-ui/web/src/routes/identity/teams.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, Link, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { AppIcon } from '@/components/icons/app-icon'
+import { PageHeader } from '@/components/layout/page-header'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -199,8 +200,21 @@ export function TeamsPage() {
     [membersTeam, users],
   )
 
+  const pageHeader = (
+    <PageHeader
+      section="Identity"
+      title="Teams"
+      description="Review teams, their administrators, and their members."
+    />
+  )
+
   if (!isPlatformAdmin) {
-    return <ReadOnlyTeamsDirectory teams={directoryData?.teams ?? []} />
+    return (
+      <main className="flex min-w-0 flex-1 flex-col gap-6">
+        {pageHeader}
+        <ReadOnlyTeamsDirectory teams={directoryData?.teams ?? []} />
+      </main>
+    )
   }
 
   async function refreshTeams() {
@@ -411,14 +425,14 @@ export function TeamsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      {pageHeader}
+
       <Card>
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <CardTitle>Teams</CardTitle>
-            <CardDescription>
-              Create teams, assign team admins, and add members over time as users arrive.
-            </CardDescription>
+            <CardTitle>Team list</CardTitle>
+            <CardDescription>Select a team to review its members and settings.</CardDescription>
           </div>
           <Button type="button" onClick={openCreateTeamDialog}>
             Add team
@@ -1172,7 +1186,7 @@ export function TeamsPage() {
           ) : null}
         </DialogContent>
       </Dialog>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -11,6 +11,7 @@ import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { AppIcon } from '@/components/icons/app-icon'
+import { PageHeader } from '@/components/layout/page-header'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -185,8 +186,21 @@ export function UsersPage() {
     setOnboardingResult(null)
   }, [selectedUserId])
 
+  const pageHeader = (
+    <PageHeader
+      section="Identity"
+      title="Users"
+      description="Review user accounts, team assignments, and access settings."
+    />
+  )
+
   if (!isPlatformAdmin) {
-    return <ReadOnlyUsersDirectory users={directoryData?.users ?? []} />
+    return (
+      <main className="flex min-w-0 flex-1 flex-col gap-6">
+        {pageHeader}
+        <ReadOnlyUsersDirectory users={directoryData?.users ?? []} />
+      </main>
+    )
   }
 
   function resetDialog() {
@@ -390,15 +404,14 @@ export function UsersPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      {pageHeader}
+
       <Card>
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <CardTitle>Users</CardTitle>
-            <CardDescription>
-              Create password or SSO users, then hand off the generated onboarding URL. A valid
-              email address is also required for budget alert emails.
-            </CardDescription>
+            <CardTitle>User list</CardTitle>
+            <CardDescription>Select a user to review account and access settings.</CardDescription>
           </div>
 
           <Dialog
@@ -1373,7 +1386,7 @@ export function UsersPage() {
           ) : null}
         </DialogContent>
       </Dialog>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/identity/users.tsx
+++ b/crates/admin-ui/web/src/routes/identity/users.tsx
@@ -196,10 +196,10 @@ export function UsersPage() {
 
   if (!isPlatformAdmin) {
     return (
-      <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <div className="flex min-w-0 flex-1 flex-col gap-6">
         {pageHeader}
         <ReadOnlyUsersDirectory users={directoryData?.users ?? []} />
-      </main>
+      </div>
     )
   }
 
@@ -404,7 +404,7 @@ export function UsersPage() {
   }
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       {pageHeader}
 
       <Card>
@@ -1386,7 +1386,7 @@ export function UsersPage() {
           ) : null}
         </DialogContent>
       </Dialog>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/mcp/index.tsx
+++ b/crates/admin-ui/web/src/routes/mcp/index.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { PageHeader } from '@/components/layout/page-header'
 import { requireAdminSession } from '@/routes/-admin-guard'
 import {
   getApiKeys,
@@ -81,40 +82,38 @@ export function McpWorkspacePage() {
     applySearch({ tab: 'toolsets' })
   }
 
-  const workspaceHeader = (
-    <>
-      <CardTitle>MCP</CardTitle>
-      <CardDescription>
-        Register servers, curate toolsets, and manage access in one workspace.
-      </CardDescription>
-      <CardAction>
-        <SegmentedTabs
-          ariaLabel="MCP workspace sections"
-          value={search.tab}
-          onValueChange={(value) => applySearch({ tab: value as McpTab })}
-          items={workspaceTabs}
-        />
-      </CardAction>
-    </>
+  const workspaceNavigation = (
+    <CardAction>
+      <SegmentedTabs
+        ariaLabel="MCP workspace sections"
+        value={search.tab}
+        onValueChange={(value) => applySearch({ tab: value as McpTab })}
+        items={workspaceTabs}
+      />
+    </CardAction>
   )
 
-  if (search.tab === 'servers') {
-    return (
+  const workspaceContent =
+    search.tab === 'servers' ? (
       <ServersTab
         servers={data.servers}
         recommended={data.recommended}
         selectedServerId={selectedServerId}
-        workspaceHeader={workspaceHeader}
+        workspaceHeader={workspaceNavigation}
         onSelectServer={(serverId) => applySearch({ server_id: serverId ?? undefined })}
         onAddToToolset={handleAddToToolset}
       />
-    )
-  }
-
-  return (
-    <div className="flex min-w-0 flex-col gap-4">
+    ) : (
       <Card className="min-w-0">
-        <CardHeader>{workspaceHeader}</CardHeader>
+        <CardHeader>
+          <CardTitle>{search.tab === 'toolsets' ? 'Toolsets' : 'Access rules'}</CardTitle>
+          <CardDescription>
+            {search.tab === 'toolsets'
+              ? 'Combine related tools so that you can manage them as one group.'
+              : 'Choose which people and accounts can use each tool or group of tools.'}
+          </CardDescription>
+          {workspaceNavigation}
+        </CardHeader>
         <CardContent className="min-w-0">
           {search.tab === 'toolsets' ? (
             <ToolsetsTab
@@ -141,7 +140,17 @@ export function McpWorkspacePage() {
           ) : null}
         </CardContent>
       </Card>
-    </div>
+    )
+
+  return (
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Control Plane"
+        title="MCP"
+        description="Manage the servers and tools exposed to applications and end users."
+      />
+      {workspaceContent}
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/mcp/index.tsx
+++ b/crates/admin-ui/web/src/routes/mcp/index.tsx
@@ -143,14 +143,14 @@ export function McpWorkspacePage() {
     )
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Control Plane"
         title="MCP"
         description="Manage the servers and tools exposed to applications and end users."
       />
       {workspaceContent}
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -246,7 +246,7 @@ export function ModelsPage() {
     null
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Control Plane"
         title="Models"
@@ -612,7 +612,7 @@ export function ModelsPage() {
           }
         }}
       />
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/models.tsx
+++ b/crates/admin-ui/web/src/routes/models.tsx
@@ -21,6 +21,7 @@ import { AppIcon } from '@/components/icons/app-icon'
 import { AgentHarnessLabel } from '@/components/icons/agent-harness-icon'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
@@ -245,13 +246,17 @@ export function ModelsPage() {
     null
 
   return (
-    <div className="flex min-w-0 flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Control Plane"
+        title="Models"
+        description="Review the models that users can select and check their current status."
+      />
+
       <Card className="min-w-0">
         <CardHeader>
-          <CardTitle>Models</CardTitle>
-          <CardDescription>
-            Review routed models, upstream targets, and current health status.
-          </CardDescription>
+          <CardTitle>Model list</CardTitle>
+          <CardDescription>Select models to create a configuration file.</CardDescription>
         </CardHeader>
         <CardContent className="flex min-w-0 flex-col gap-4">
           <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-[var(--color-text-muted)]">
@@ -607,7 +612,7 @@ export function ModelsPage() {
           }
         }}
       />
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/agent-harnesses.tsx
+++ b/crates/admin-ui/web/src/routes/observability/agent-harnesses.tsx
@@ -4,6 +4,7 @@ import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts'
 import { toast } from 'sonner'
 
 import { AgentHarnessLabel } from '@/components/icons/agent-harness-icon'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   ChartContainer,
@@ -109,13 +110,19 @@ export function AgentHarnessesPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Observability"
+        title="Agent harnesses"
+        description="Compare request activity from user harnesses over time."
+      />
+
       <Card>
         <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex flex-col gap-1">
-            <CardTitle>Agent Harnesses</CardTitle>
+            <CardTitle>Request activity</CardTitle>
             <CardDescription>
-              Compare self-reported User-Agent harness traffic over UTC 12-hour windows.
+              Compare request counts for each agent application in 12-hour periods.
             </CardDescription>
           </div>
           <ToggleGroup
@@ -255,7 +262,7 @@ export function AgentHarnessesPage() {
           )}
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/agent-harnesses.tsx
+++ b/crates/admin-ui/web/src/routes/observability/agent-harnesses.tsx
@@ -110,7 +110,7 @@ export function AgentHarnessesPage() {
   }
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Observability"
         title="Agent harnesses"
@@ -122,7 +122,7 @@ export function AgentHarnessesPage() {
           <div className="flex flex-col gap-1">
             <CardTitle>Request activity</CardTitle>
             <CardDescription>
-              Compare request counts for each agent application in 12-hour periods.
+              Compare request counts for each harness in 12-hour periods.
             </CardDescription>
           </div>
           <ToggleGroup
@@ -262,7 +262,7 @@ export function AgentHarnessesPage() {
           )}
         </CardContent>
       </Card>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/leaderboard.tsx
+++ b/crates/admin-ui/web/src/routes/observability/leaderboard.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Area, AreaChart, CartesianGrid, XAxis } from 'recharts'
 import { toast } from 'sonner'
 
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   ChartContainer,
@@ -108,13 +109,19 @@ export function ObservabilityLeaderboardPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Budget & Spending"
+        title="Leaderboard"
+        description="Compare user costs over time and see which users have the highest total cost."
+      />
+
       <Card>
         <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex flex-col gap-1">
-            <CardTitle>Leaderboard</CardTitle>
+            <CardTitle>User costs over time</CardTitle>
             <CardDescription>
-              Compare the top five users by spend over time, bucketed into UTC 12-hour windows.
+              Compare the five users with the highest cost in each 12-hour period.
             </CardDescription>
           </div>
           <ToggleGroup
@@ -257,7 +264,7 @@ export function ObservabilityLeaderboardPage() {
           )}
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/leaderboard.tsx
+++ b/crates/admin-ui/web/src/routes/observability/leaderboard.tsx
@@ -109,7 +109,7 @@ export function ObservabilityLeaderboardPage() {
   }
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Budget & Spending"
         title="Leaderboard"
@@ -121,7 +121,7 @@ export function ObservabilityLeaderboardPage() {
           <div className="flex flex-col gap-1">
             <CardTitle>User costs over time</CardTitle>
             <CardDescription>
-              Compare the five users with the highest cost in each 12-hour period.
+              Compare 12-hour costs for the five users with the highest total cost.
             </CardDescription>
           </div>
           <ToggleGroup
@@ -264,7 +264,7 @@ export function ObservabilityLeaderboardPage() {
           )}
         </CardContent>
       </Card>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/mcp-invocations.tsx
+++ b/crates/admin-ui/web/src/routes/observability/mcp-invocations.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, useRouter } from '@tanstack/react-router'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '@/components/ui/empty'
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field'
@@ -128,13 +129,18 @@ export function McpInvocationsPage() {
   const normalizedFilters = normalizeFilterSearch(filters)
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Observability"
+        title="MCP invocations"
+        description="Review each use of an MCP tool, its result, and the data that the system stored."
+      />
+
       <Card>
         <CardHeader className="flex flex-col gap-1">
-          <CardTitle>MCP Invocations</CardTitle>
+          <CardTitle>Tool activity</CardTitle>
           <CardDescription>
-            Audit request-linked MCP tool calls by API key, user, team, server, tool, policy result,
-            status, and payload retention state.
+            Filter the records, then select one to review more details.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
@@ -410,7 +416,7 @@ export function McpInvocationsPage() {
           </CardContent>
         </Card>
       ) : null}
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/mcp-invocations.tsx
+++ b/crates/admin-ui/web/src/routes/observability/mcp-invocations.tsx
@@ -129,7 +129,7 @@ export function McpInvocationsPage() {
   const normalizedFilters = normalizeFilterSearch(filters)
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Observability"
         title="MCP invocations"
@@ -416,7 +416,7 @@ export function McpInvocationsPage() {
           </CardContent>
         </Card>
       ) : null}
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/request-logs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/request-logs.tsx
@@ -3,6 +3,7 @@ import { Link, createFileRoute, useRouter } from '@tanstack/react-router'
 import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { BrandIcon } from '@/components/icons/brand-icon'
+import { PageHeader } from '@/components/layout/page-header'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -155,14 +156,19 @@ export function RequestLogsPage() {
     Boolean(normalizedFilters.tag_key) !== Boolean(normalizedFilters.tag_value)
 
   return (
-    <>
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Observability"
+        title="Request logs"
+        description="Review each request, how long it took, and the data that the system stored."
+      />
+
       <Card>
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <CardTitle>Request Logs</CardTitle>
+            <CardTitle>Request list</CardTitle>
             <CardDescription>
-              Inspect single-route request execution, latency, and sanitized payloads without
-              dropping into raw traces.
+              Filter requests, then select one to review more details.
             </CardDescription>
           </div>
         </CardHeader>
@@ -549,7 +555,7 @@ export function RequestLogsPage() {
           </div>
         </SheetContent>
       </Sheet>
-    </>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/request-logs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/request-logs.tsx
@@ -156,7 +156,7 @@ export function RequestLogsPage() {
     Boolean(normalizedFilters.tag_key) !== Boolean(normalizedFilters.tag_value)
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Observability"
         title="Request logs"
@@ -555,7 +555,7 @@ export function RequestLogsPage() {
           </div>
         </SheetContent>
       </Sheet>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/usage-costs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/usage-costs.tsx
@@ -65,14 +65,14 @@ export function UsageCostsPage() {
   }
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Budget & Spending"
         title="Usage costs"
         description={
           isPlatformAdmin
             ? 'Review costs over time and see how each account and model affects the total.'
-            : 'Review your costs over time and see the price of each request.'
+            : 'Review your costs over time and see how each model affects the total.'
         }
       />
 
@@ -296,7 +296,7 @@ export function UsageCostsPage() {
           </div>
         </CardContent>
       </Card>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/observability/usage-costs.tsx
+++ b/crates/admin-ui/web/src/routes/observability/usage-costs.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import {
@@ -64,16 +65,22 @@ export function UsageCostsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Budget & Spending"
+        title="Usage costs"
+        description={
+          isPlatformAdmin
+            ? 'Review costs over time and see how each account and model affects the total.'
+            : 'Review your costs over time and see the price of each request.'
+        }
+      />
+
       <Card>
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <CardTitle>Usage Costs</CardTitle>
-            <CardDescription>
-              {isPlatformAdmin
-                ? 'Live spend from the durable usage ledger with owner and model breakdowns.'
-                : 'Your spend and request pricing details from the durable usage ledger.'}
-            </CardDescription>
+            <CardTitle>Cost history</CardTitle>
+            <CardDescription>Choose a date range and review daily costs.</CardDescription>
           </div>
           <div className="flex items-center gap-2">
             <Select
@@ -289,7 +296,7 @@ export function UsageCostsPage() {
           </div>
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/review-agent.tsx
+++ b/crates/admin-ui/web/src/routes/review-agent.tsx
@@ -406,7 +406,7 @@ export function ReviewAgentPage() {
   const serviceAccountById = new Map(serviceAccounts.map((account) => [account.id, account]))
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Control Plane"
         title="Review agent"
@@ -1225,7 +1225,7 @@ export function ReviewAgentPage() {
           ) : null}
         </DialogContent>
       </Dialog>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/review-agent.tsx
+++ b/crates/admin-ui/web/src/routes/review-agent.tsx
@@ -20,6 +20,7 @@ import { AppIcon } from '@/components/icons/app-icon'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
@@ -405,14 +406,19 @@ export function ReviewAgentPage() {
   const serviceAccountById = new Map(serviceAccounts.map((account) => [account.id, account]))
 
   return (
-    <div className="flex flex-col gap-4">
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Control Plane"
+        title="Review agent"
+        description="Set up automatic code reviews and review recent results."
+      />
+
       <Card>
         <CardHeader className="flex flex-row items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
-            <CardTitle>Review Agent</CardTitle>
+            <CardTitle>Repositories</CardTitle>
             <CardDescription>
-              Configure repositories for Pi-powered pull request reviews, then copy the generated
-              GitHub Actions workflow into each repository to finish onboarding.
+              Choose the repositories that use automatic code reviews.
             </CardDescription>
           </div>
 
@@ -1219,7 +1225,7 @@ export function ReviewAgentPage() {
           ) : null}
         </DialogContent>
       </Dialog>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/spend-controls.tsx
+++ b/crates/admin-ui/web/src/routes/spend-controls.tsx
@@ -216,11 +216,11 @@ export function SpendControlsPage() {
   }
 
   return (
-    <main className="flex min-w-0 flex-1 flex-col gap-6">
+    <div className="flex min-w-0 flex-1 flex-col gap-6">
       <PageHeader
         section="Budget & Spending"
         title="Spend controls"
-        description="Set spending limits for people, automated accounts, and models. Review recent alerts."
+        description="Set spending limits for users, automated accounts, and each user's model use. Review recent alerts."
       />
 
       <BudgetTable
@@ -565,7 +565,7 @@ export function SpendControlsPage() {
           </form>
         </DialogContent>
       </Dialog>
-    </main>
+    </div>
   )
 }
 

--- a/crates/admin-ui/web/src/routes/spend-controls.tsx
+++ b/crates/admin-ui/web/src/routes/spend-controls.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Dialog,
@@ -215,15 +216,12 @@ export function SpendControlsPage() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Spend Controls</CardTitle>
-          <CardDescription>
-            Configure budgets for human users, service accounts, and user-specific model scopes.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+    <main className="flex min-w-0 flex-1 flex-col gap-6">
+      <PageHeader
+        section="Budget & Spending"
+        title="Spend controls"
+        description="Set spending limits for people, automated accounts, and models. Review recent alerts."
+      />
 
       <BudgetTable
         title="User Budgets"
@@ -567,7 +565,7 @@ export function SpendControlsPage() {
           </form>
         </DialogContent>
       </Dialog>
-    </div>
+    </main>
   )
 }
 

--- a/crates/admin-ui/web/src/test/routes/agent-harnesses-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/agent-harnesses-route.test.tsx
@@ -92,7 +92,7 @@ describe('AgentHarnessesPage', () => {
     const view = render(<AgentHarnessesPage />)
     const scope = within(view.container)
 
-    expect(scope.getByText('Agent Harnesses')).toBeInTheDocument()
+    expect(scope.getByRole('heading', { level: 1, name: 'Agent harnesses' })).toBeInTheDocument()
     expect(scope.getByRole('radio', { name: 'Last 7 days' })).toBeInTheDocument()
     expect(scope.getByRole('radio', { name: 'Last 31 days' })).toBeInTheDocument()
     expect(scope.getByTestId('harness-usage-table')).toBeInTheDocument()

--- a/crates/admin-ui/web/src/test/routes/api-keys-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/api-keys-route.test.tsx
@@ -531,7 +531,9 @@ describe('ApiKeysPage', () => {
     render(<ApiKeysPage />)
 
     expect(screen.getAllByText('gwk_prod_liv****').length).toBeGreaterThan(0)
-    expect(screen.getByText(/personal gateway credentials/i)).toBeInTheDocument()
+    expect(
+      screen.getByText('Review the keys that you and your team use to send requests.'),
+    ).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Create API key' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument()
   })

--- a/crates/admin-ui/web/src/test/routes/mcp-invocations-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/mcp-invocations-route.test.tsx
@@ -71,7 +71,7 @@ describe('McpInvocationsPage', () => {
 
     render(<McpInvocationsPage />)
 
-    expect(screen.getByText('MCP Invocations')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: 'MCP invocations' })).toBeInTheDocument()
     expect(screen.getByTestId('mcp-filter-request-id')).toBeInTheDocument()
     expect(screen.getByTestId('mcp-filter-server')).toBeInTheDocument()
     expect(screen.getByTestId('mcp-filter-tool')).toBeInTheDocument()

--- a/crates/admin-ui/web/src/test/routes/models-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/models-route.test.tsx
@@ -299,7 +299,7 @@ describe('ModelsPage', () => {
     expect(screen.getByTestId('models-mobile-list')).toBeInTheDocument()
     expect(screen.getByTestId('models-desktop-table')).toBeInTheDocument()
     expect(
-      screen.getByText('Review routed models, upstream targets, and current health status.'),
+      screen.getByText('Review the models that users can select and check their current status.'),
     ).toBeInTheDocument()
     expect(screen.getByText('Select models to generate multi-model config')).toBeInTheDocument()
 

--- a/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/request-logs-route.test.tsx
@@ -109,7 +109,7 @@ describe('RequestLogsPage', () => {
     })
     expect(
       screen.getByText(
-        'Inspect single-route request execution, latency, and sanitized payloads without dropping into raw traces.',
+        'Review each request, how long it took, and the data that the system stored.',
       ),
     ).toBeInTheDocument()
     expect(screen.getAllByText('gpt-4.1-mini')).toHaveLength(2)

--- a/crates/admin-ui/web/src/test/routes/spend-controls-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/spend-controls-route.test.tsx
@@ -100,7 +100,7 @@ describe('SpendControlsPage', () => {
     const { SpendControlsPage } = await import('@/routes/spend-controls')
     render(<SpendControlsPage />)
 
-    expect(screen.getByText('Spend Controls')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: 'Spend controls' })).toBeInTheDocument()
     expect(screen.getAllByText('Jane Admin').length).toBeGreaterThan(0)
     expect(screen.getByText('CI Indexer')).toBeInTheDocument()
     expect(screen.getByText('User Model Budgets')).toBeInTheDocument()

--- a/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/teams-route.test.tsx
@@ -116,7 +116,7 @@ describe('TeamsPage', () => {
     expect(screen.queryByRole('button', { name: 'Add members' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument()
     expect(screen.queryByText('research')).not.toBeInTheDocument()
-    expect(screen.getByText(/Only platform administrators can change teams/)).toBeInTheDocument()
+    expect(screen.getByText(/Only administrators can make changes/)).toBeInTheDocument()
   })
 
   it('teaches the next step when no teams exist', async () => {

--- a/crates/admin-ui/web/src/test/routes/usage-costs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/usage-costs-route.test.tsx
@@ -86,7 +86,7 @@ describe('UsageCostsPage', () => {
     const { UsageCostsPage } = await import('@/routes/observability/usage-costs')
     render(<UsageCostsPage />)
 
-    expect(screen.getByText('Usage Costs')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 1, name: 'Usage costs' })).toBeInTheDocument()
     expect(screen.getByText('CI Indexer')).toBeInTheDocument()
     expect(screen.getByText('fast')).toBeInTheDocument()
     expect(screen.getByText('Priced requests')).toBeInTheDocument()
@@ -126,7 +126,7 @@ describe('UsageCostsPage', () => {
     render(<UsageCostsPage />)
 
     expect(
-      screen.getByText('Your spend and request pricing details from the durable usage ledger.'),
+      screen.getByText('Review your costs over time and see the price of each request.'),
     ).toBeVisible()
     expect(screen.getByText('Spend attributed to your user account.')).toBeVisible()
     expect(screen.queryByText('All owners')).not.toBeInTheDocument()

--- a/crates/admin-ui/web/src/test/routes/usage-costs-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/usage-costs-route.test.tsx
@@ -126,7 +126,7 @@ describe('UsageCostsPage', () => {
     render(<UsageCostsPage />)
 
     expect(
-      screen.getByText('Review your costs over time and see the price of each request.'),
+      screen.getByText('Review your costs over time and see how each model affects the total.'),
     ).toBeVisible()
     expect(screen.getByText('Spend attributed to your user account.')).toBeVisible()
     expect(screen.queryByText('All owners')).not.toBeInTheDocument()

--- a/crates/admin-ui/web/src/test/routes/users-route.test.tsx
+++ b/crates/admin-ui/web/src/test/routes/users-route.test.tsx
@@ -149,7 +149,7 @@ describe('UsersPage', () => {
     expect(screen.queryByRole('button', { name: 'Add user' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Manage' })).not.toBeInTheDocument()
     expect(screen.queryByText('Sign-in')).not.toBeInTheDocument()
-    expect(screen.getByText(/Only platform administrators can change users/)).toBeInTheDocument()
+    expect(screen.getByText(/Only administrators can make changes/)).toBeInTheDocument()
   })
 
   it('teaches the next step when no users exist', async () => {


### PR DESCRIPTION
## Description

This PR adds a shared page header to the admin routes shown in the sidebar.

- Show the navigation group, page title, and a short description above each main card.
- Keep page-specific actions and controls in their existing cards.
- Use plain technical language for each description.
- Describe API key, MCP, and agent harness requests without limiting them to applications.
- Update route tests for the new heading levels and card titles.

The shared component keeps the page hierarchy consistent without changing route data or request behavior.

## Validation

- [x] `mise run ui-check`
  - UI format and lint checks passed.
  - 27 test files passed with 122 tests.
  - Client and server builds passed.

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:check`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:test:postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:smoke:postgres`

The repository-wide and gateway-store checks were not run because this change only affects the admin UI.
