### PR TITLE
fix(helm): validate gateway config before migration wait

### DIFF
--- a/crates/gateway/src/cli.rs
+++ b/crates/gateway/src/cli.rs
@@ -21,12 +21,19 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    #[command(subcommand)]
+    Config(ConfigCommand),
     Serve(ServeArgs),
     Migrate(MigrateArgs),
     PurgeRequestLogs(PurgeRequestLogsArgs),
     BootstrapAdmin,
     SeedConfig,
     SeedLocalDemo,
+}
+
+#[derive(Debug, Clone, Copy, Subcommand)]
+pub enum ConfigCommand {
+    Validate,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -130,7 +137,16 @@ mod tests {
 
     use gateway_core::RequestLogRetentionWindow;
 
-    use super::{Cli, Command, MigrateAction};
+    use super::{Cli, Command, ConfigCommand, MigrateAction};
+
+    #[test]
+    fn parses_config_validate_command() {
+        let cli = Cli::parse_from(["gateway", "config", "validate"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Config(ConfigCommand::Validate))
+        ));
+    }
 
     #[test]
     fn serve_flags_accept_explicit_false_values() {

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, env, fs, path::Path};
+use std::{collections::BTreeMap, env, fs, net::SocketAddr, path::Path};
 
 use anyhow::{Context, bail};
 use gateway_core::{
@@ -85,6 +85,7 @@ impl GatewayConfig {
     }
 
     fn validate(&self) -> anyhow::Result<()> {
+        self.server.validate()?;
         let _ = self.database.connection_options()?;
         self.budget_alerts.validate()?;
         self.request_logging.validate()?;
@@ -1248,6 +1249,34 @@ impl Default for ServerConfig {
             otel_export_interval_secs: default_otel_export_interval_secs(),
         }
     }
+}
+
+impl ServerConfig {
+    fn validate(&self) -> anyhow::Result<()> {
+        let _ = self.bind_address()?;
+        validate_otel_endpoint("server.otel_endpoint", self.otel_endpoint.as_deref())?;
+        validate_otel_endpoint(
+            "server.otel_metrics_endpoint",
+            self.otel_metrics_endpoint.as_deref(),
+        )?;
+        Ok(())
+    }
+
+    pub fn bind_address(&self) -> anyhow::Result<SocketAddr> {
+        self.bind
+            .parse()
+            .with_context(|| format!("server.bind `{}` is not a valid socket address", self.bind))
+    }
+}
+
+fn validate_otel_endpoint(field: &str, endpoint: Option<&str>) -> anyhow::Result<()> {
+    let Some(endpoint) = endpoint else {
+        return Ok(());
+    };
+    let _: http::Uri = endpoint
+        .parse()
+        .with_context(|| format!("{field} `{endpoint}` is not a valid URI"))?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -3266,6 +3295,33 @@ mod tests {
 
     fn write_config(path: &Path, yaml: &str) {
         std::fs::write(path, yaml).expect("write config");
+    }
+
+    #[test]
+    fn rejects_invalid_server_bind_address() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+        write_config(&config_path, "server:\n  bind: not-a-socket-address\n");
+
+        let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+
+        assert!(format!("{error:#}").contains("server.bind"));
+    }
+
+    #[test]
+    fn rejects_invalid_otel_endpoints() {
+        for field in ["otel_endpoint", "otel_metrics_endpoint"] {
+            let tmp = tempdir().expect("tempdir");
+            let config_path = tmp.path().join("gateway.yaml");
+            write_config(
+                &config_path,
+                &format!("server:\n  {field}: 'not a valid URI'\n"),
+            );
+
+            let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+
+            assert!(format!("{error:#}").contains(&format!("server.{field}")));
+        }
     }
 
     #[test]

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, net::SocketAddr, path::Path, sync::Arc, time::Duration};
+use std::{env, path::Path, sync::Arc, time::Duration};
 
 use admin_ui::AdminUiConfig;
 use anyhow::Context;
@@ -31,13 +31,14 @@ use local_demo_seed::{LOCAL_DEMO_USER_PASSWORD, seed_local_demo_data};
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let command = cli.command.unwrap_or(Command::Serve(ServeArgs::default()));
-    let config = load_config(&cli.config)?;
 
     if matches!(&command, Command::Config(ConfigCommand::Validate)) {
+        validate_config_file(&cli.config)?;
         println!("gateway configuration `{}` is valid", cli.config);
         return Ok(());
     }
 
+    let config = load_config(&cli.config)?;
     let observability = observability::init_observability(&config.server)?;
 
     let result = match command {
@@ -56,6 +57,14 @@ async fn main() -> anyhow::Result<()> {
 fn load_config(config_path: &str) -> anyhow::Result<GatewayConfig> {
     GatewayConfig::from_path(Path::new(config_path))
         .with_context(|| format!("failed to load gateway configuration from `{config_path}`"))
+}
+
+fn validate_config_file(config_path: &str) -> anyhow::Result<()> {
+    if !Path::new(config_path).exists() {
+        anyhow::bail!("gateway configuration `{config_path}` does not exist");
+    }
+    let _ = load_config(config_path)?;
+    Ok(())
 }
 
 fn database_options(
@@ -202,11 +211,7 @@ async fn run_serve_with_store(
     )
     .context("invalid MCP credential runtime configuration")?;
 
-    let bind_address: SocketAddr = config
-        .server
-        .bind
-        .parse()
-        .with_context(|| format!("invalid bind address `{}`", config.server.bind))?;
+    let bind_address = config.server.bind_address()?;
 
     let app = build_router(
         AppState {
@@ -524,4 +529,22 @@ fn env_u64(key: &str, default: u64) -> u64 {
 fn load_identity_token_secret() -> String {
     env::var("GATEWAY_IDENTITY_TOKEN_SECRET")
         .unwrap_or_else(|_| "local-dev-identity-secret".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::validate_config_file;
+
+    #[test]
+    fn config_validation_requires_an_existing_file() {
+        let tmp = tempdir().expect("tempdir");
+        let missing_path = tmp.path().join("missing.yaml");
+
+        let error = validate_config_file(missing_path.to_str().expect("utf-8 path"))
+            .expect_err("missing config should fail");
+
+        assert!(format!("{error:#}").contains("does not exist"));
+    }
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -4,7 +4,7 @@ use admin_ui::AdminUiConfig;
 use anyhow::Context;
 use clap::Parser;
 use gateway::{
-    cli::{Cli, Command, MigrateAction, ServeArgs},
+    cli::{Cli, Command, ConfigCommand, MigrateAction, ServeArgs},
     config::{BootstrapAdminConfig, BudgetAlertEmailConfig, GatewayConfig},
     email::build_budget_alert_sender,
     http::{build_router, state::AppState},
@@ -30,11 +30,18 @@ use local_demo_seed::{LOCAL_DEMO_USER_PASSWORD, seed_local_demo_data};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    let command = cli.command.unwrap_or(Command::Serve(ServeArgs::default()));
     let config = load_config(&cli.config)?;
+
+    if matches!(&command, Command::Config(ConfigCommand::Validate)) {
+        println!("gateway configuration `{}` is valid", cli.config);
+        return Ok(());
+    }
 
     let observability = observability::init_observability(&config.server)?;
 
-    let result = match cli.command.unwrap_or(Command::Serve(ServeArgs::default())) {
+    let result = match command {
+        Command::Config(ConfigCommand::Validate) => unreachable!("handled before runtime startup"),
         Command::Serve(args) => run_serve(&config, observability.metrics.clone(), args).await,
         Command::Migrate(args) => run_migrate(&config, args.action()?).await,
         Command::PurgeRequestLogs(args) => request_log_purge::run_command(&config, args).await,

--- a/deploy/helm/oceans-llm/README.md
+++ b/deploy/helm/oceans-llm/README.md
@@ -71,8 +71,10 @@ Bootstrap-admin and seed-config Jobs are opt-in through:
 - `bootstrapAdminJob.enabled`
 - `seedConfigJob.enabled`
 
-Gateway pods wait for `gateway migrate --check` when migrations run in a
-post-install or post-upgrade hook phase. Tune that wait with:
+Gateway pods validate the gateway configuration once, then wait for
+`gateway migrate --check` when migrations run in a post-install or post-upgrade
+hook phase. Invalid configuration stops the init container before migration
+polling starts. Tune the migration wait with:
 
 - `gateway.migrationWaiter.enabled`
 - `gateway.migrationWaiter.intervalSeconds`

--- a/deploy/helm/oceans-llm/templates/gateway-deployment.yaml
+++ b/deploy/helm/oceans-llm/templates/gateway-deployment.yaml
@@ -90,6 +90,7 @@ spec:
             - /bin/sh
             - -ec
             - |
+              gateway config validate
               deadline=$(( $(date +%s) + {{ .Values.gateway.migrationWaiter.timeoutSeconds }} ))
               until gateway migrate --check; do
                 if [ "$(date +%s)" -ge "$deadline" ]; then


### PR DESCRIPTION
## Description

Fix the Helm gateway migration waiter so permanent configuration errors fail before migration polling begins.

### Summary of changes

- Add a `gateway config validate` command that loads and validates the configured gateway file without starting observability or connecting to the database.
- Run configuration validation once at the start of the gateway migration init container.
- Document the validation and migration-wait sequence in the Helm chart README.

### Why this approach was chosen

The existing shell loop retried every non-zero result from `gateway migrate --check`. This treated invalid gateway configuration, such as a missing OIDC secret environment variable, as a temporary migration state and repeated the same error until each init-container timeout.

The new preflight keeps configuration ownership in the Rust gateway and preserves the existing migration retry policy. It avoids duplicating provider configuration rules in Helm templates.

### How it works

The init container first runs `gateway config validate`. A validation error exits the shell immediately because it runs with `sh -ec`. Valid configuration proceeds to the existing bounded `gateway migrate --check` polling loop.

### Risks, tradeoffs, and alternatives considered

A failed init container still follows Kubernetes restart and backoff behavior. This change removes the inner migration polling loop for permanent configuration errors and makes the failure immediate and clear. It does not change database migrations or gateway serving behavior.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [x] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:check`
- [x] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:test:postgres`
- [x] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:smoke:postgres`

Additional validation: `mise run helm-check`, focused CLI tests, rendered init-command inspection, valid configuration execution, missing-environment failure execution, Rust formatting, and `git diff --check`.
