### PR TITLE
feat(observability): add configurable OTLP trace sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "libsql",
  "openidconnect",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest 0.12.28",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.20.1"
 dependencies = [
  "axum 0.8.9",
  "http 1.4.2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1420,7 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1695,7 +1695,7 @@ name = "gateway-mcp"
 version = "0.20.1"
 dependencies = [
  "futures-util",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1720,7 +1720,7 @@ dependencies = [
  "futures-util",
  "gateway-core",
  "jsonwebtoken",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -1749,7 +1749,7 @@ dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
  "rand 0.8.7",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2211,7 +2211,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2801,7 +2801,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2876,7 +2876,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.2",
  "rand 0.8.7",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2948,9 +2948,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2962,22 +2962,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.2",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.2",
  "opentelemetry",
@@ -2985,18 +2985,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.4",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.6",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3007,15 +3007,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.18",
  "tokio",
@@ -3255,6 +3256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3353,6 +3360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +3381,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.42",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3403,9 +3419,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3644,7 +3660,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.2",
@@ -3676,6 +3691,37 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.2",
+ "http-body 1.1.0",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3766,7 +3812,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4488,10 +4534,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4787,6 +4833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types",
+ "tonic 0.14.6",
+]
+
+[[package]]
 name = "tonic-web"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -5332,7 +5389,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ lettre = { version = "0.11", default-features = false, features = ["builder", "h
 libsql = "0.9"
 openidconnect = "4.0.1"
 opentelemetry = { version = "0.32", features = ["metrics", "trace"] }
+opentelemetry-http = "0.32"
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "metrics", "trace"] }
 opentelemetry_sdk = { version = "0.32", features = ["metrics", "rt-tokio", "trace"] }
 percent-encoding = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ itertools = "0.14"
 lettre = { version = "0.11", default-features = false, features = ["builder", "hostname", "pool", "smtp-transport", "tokio1", "tokio1-rustls-tls"] }
 libsql = "0.9"
 openidconnect = "4.0.1"
-opentelemetry = { version = "0.31", features = ["metrics", "trace"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "metrics", "trace"] }
-opentelemetry_sdk = { version = "0.31", features = ["metrics", "rt-tokio", "trace"] }
+opentelemetry = { version = "0.32", features = ["metrics", "trace"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "metrics", "trace"] }
+opentelemetry_sdk = { version = "0.32", features = ["metrics", "rt-tokio", "trace"] }
 percent-encoding = "2"
 rand = "0.8"
 refinery = "0.8"
@@ -55,7 +55,7 @@ toml = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["request-id", "trace", "util"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.32"
+tracing-opentelemetry = "0.33"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 utoipa = { version = "5", features = ["axum_extras", "time", "uuid"] }
 utoipa-axum = "0.2"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -23,6 +23,7 @@ http.workspace = true
 lettre.workspace = true
 openidconnect.workspace = true
 opentelemetry.workspace = true
+opentelemetry-http.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 reqwest.workspace = true

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -3335,14 +3335,30 @@ mod tests {
     }
 
     #[test]
-    fn parses_otel_trace_sample_ratio() {
+    fn otel_trace_sample_ratio_defaults_to_one() {
         let tmp = tempdir().expect("tempdir");
         let config_path = tmp.path().join("gateway.yaml");
-        write_config(&config_path, "server:\n  otel_trace_sample_ratio: 0.5\n");
+        write_config(&config_path, "server: {}\n");
 
         let config = GatewayConfig::from_path(&config_path).expect("config should parse");
 
-        assert_eq!(config.server.otel_trace_sample_ratio, 0.5);
+        assert_eq!(config.server.otel_trace_sample_ratio, 1.0);
+    }
+
+    #[test]
+    fn accepts_inclusive_otel_trace_sample_ratio_boundaries() {
+        for ratio in [0.0, 1.0] {
+            let tmp = tempdir().expect("tempdir");
+            let config_path = tmp.path().join("gateway.yaml");
+            write_config(
+                &config_path,
+                &format!("server:\n  otel_trace_sample_ratio: {ratio}\n"),
+            );
+
+            let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+
+            assert_eq!(config.server.otel_trace_sample_ratio, ratio);
+        }
     }
 
     #[test]

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1235,6 +1235,8 @@ pub struct ServerConfig {
     pub otel_endpoint: Option<String>,
     #[serde(default)]
     pub otel_metrics_endpoint: Option<String>,
+    #[serde(default = "default_otel_trace_sample_ratio")]
+    pub otel_trace_sample_ratio: f64,
     #[serde(default = "default_otel_export_interval_secs")]
     pub otel_export_interval_secs: u64,
 }
@@ -1246,6 +1248,7 @@ impl Default for ServerConfig {
             log_format: default_log_format(),
             otel_endpoint: None,
             otel_metrics_endpoint: None,
+            otel_trace_sample_ratio: default_otel_trace_sample_ratio(),
             otel_export_interval_secs: default_otel_export_interval_secs(),
         }
     }
@@ -1259,6 +1262,9 @@ impl ServerConfig {
             "server.otel_metrics_endpoint",
             self.otel_metrics_endpoint.as_deref(),
         )?;
+        if !(0.0..=1.0).contains(&self.otel_trace_sample_ratio) {
+            bail!("server.otel_trace_sample_ratio must be between 0.0 and 1.0 inclusive");
+        }
         Ok(())
     }
 
@@ -3133,6 +3139,10 @@ const fn default_otel_export_interval_secs() -> u64 {
     30
 }
 
+const fn default_otel_trace_sample_ratio() -> f64 {
+    1.0
+}
+
 fn default_db_path() -> String {
     "./gateway.db".to_string()
 }
@@ -3321,6 +3331,33 @@ mod tests {
             let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
 
             assert!(format!("{error:#}").contains(&format!("server.{field}")));
+        }
+    }
+
+    #[test]
+    fn parses_otel_trace_sample_ratio() {
+        let tmp = tempdir().expect("tempdir");
+        let config_path = tmp.path().join("gateway.yaml");
+        write_config(&config_path, "server:\n  otel_trace_sample_ratio: 0.5\n");
+
+        let config = GatewayConfig::from_path(&config_path).expect("config should parse");
+
+        assert_eq!(config.server.otel_trace_sample_ratio, 0.5);
+    }
+
+    #[test]
+    fn rejects_invalid_otel_trace_sample_ratio() {
+        for ratio in ["-0.1", "1.1", ".nan"] {
+            let tmp = tempdir().expect("tempdir");
+            let config_path = tmp.path().join("gateway.yaml");
+            write_config(
+                &config_path,
+                &format!("server:\n  otel_trace_sample_ratio: {ratio}\n"),
+            );
+
+            let error = GatewayConfig::from_path(&config_path).expect_err("config should fail");
+
+            assert!(format!("{error:#}").contains("server.otel_trace_sample_ratio"));
         }
     }
 

--- a/crates/gateway/src/http/mod.rs
+++ b/crates/gateway/src/http/mod.rs
@@ -24,10 +24,13 @@ use axum::{
     routing::{delete, get, patch, post},
 };
 use http::HeaderName;
+use opentelemetry::global;
+use opentelemetry_http::HeaderExtractor;
 use tower_http::{
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     trace::TraceLayer,
 };
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use self::{
     api_keys::*, handlers::*, identity::*, mcp_gateway::*, mcp_oauth::*, mcp_registry::*,
@@ -331,30 +334,96 @@ pub fn build_router(state: AppState, admin_ui: AdminUiConfig) -> Router {
             identity_guard_state,
             enforce_identity_mutation_admin,
         ))
-        .layer(
-            TraceLayer::new_for_http().make_span_with(|request: &http::Request<_>| {
-                let request_id = request
-                    .headers()
-                    .get("x-request-id")
-                    .and_then(|value| value.to_str().ok())
-                    .unwrap_or("missing");
-
-                tracing::info_span!(
-                    "http_request",
-                    method = %request.method(),
-                    uri = %request.uri().path(),
-                    request_id = %request_id,
-                    http.route = tracing::field::Empty,
-                    requested_model = tracing::field::Empty,
-                    resolved_model = tracing::field::Empty,
-                    provider = tracing::field::Empty,
-                    stream = tracing::field::Empty,
-                    ownership_kind = tracing::field::Empty
-                )
-            }),
-        )
+        .layer(TraceLayer::new_for_http().make_span_with(make_http_request_span))
         .layer(PropagateRequestIdLayer::new(request_id_header.clone()))
         .layer(SetRequestIdLayer::new(request_id_header, MakeRequestUuid));
 
     mount_admin_ui(api_router, admin_ui)
+}
+
+fn make_http_request_span<B>(request: &http::Request<B>) -> tracing::Span {
+    let request_id = request
+        .headers()
+        .get("x-request-id")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("missing");
+
+    let span = tracing::info_span!(
+        "http_request",
+        method = %request.method(),
+        uri = %request.uri().path(),
+        request_id = %request_id,
+        http.route = tracing::field::Empty,
+        requested_model = tracing::field::Empty,
+        resolved_model = tracing::field::Empty,
+        provider = tracing::field::Empty,
+        stream = tracing::field::Empty,
+        ownership_kind = tracing::field::Empty
+    );
+    let parent_context = global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(request.headers()))
+    });
+    let _ = span.set_parent(parent_context);
+
+    span
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::trace::{TraceContextExt, TracerProvider as _};
+    use opentelemetry_sdk::{
+        propagation::TraceContextPropagator,
+        trace::{Sampler, SdkTracerProvider},
+    };
+    use tracing_subscriber::{Registry, layer::SubscriberExt};
+
+    use super::*;
+
+    fn assert_remote_parent_sampling(
+        trace_flags: &str,
+        root_sample_ratio: f64,
+        expected_sampled: bool,
+    ) {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+                root_sample_ratio,
+            ))))
+            .build();
+        let tracer = tracer_provider.tracer("http-parent-test");
+        let subscriber =
+            Registry::default().with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let request = http::Request::builder()
+                .header(
+                    "traceparent",
+                    format!("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-{trace_flags}"),
+                )
+                .body(())
+                .expect("request");
+            let span = make_http_request_span(&request);
+            let context = span.context();
+            let otel_span = context.span();
+            let span_context = otel_span.span_context();
+
+            assert_eq!(span_context.is_sampled(), expected_sampled);
+            assert_eq!(
+                span_context.trace_id().to_string(),
+                "4bf92f3577b34da6a3ce929d0e0e4736"
+            );
+        });
+
+        tracer_provider.shutdown().expect("tracer shutdown");
+    }
+
+    #[test]
+    fn sampled_remote_parent_overrides_zero_root_sample_ratio() {
+        assert_remote_parent_sampling("01", 0.0, true);
+    }
+
+    #[test]
+    fn unsampled_remote_parent_overrides_full_root_sample_ratio() {
+        assert_remote_parent_sampling("00", 1.0, false);
+    }
 }

--- a/crates/gateway/src/observability.rs
+++ b/crates/gateway/src/observability.rs
@@ -13,7 +13,7 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
     metrics::{PeriodicReader, SdkMeterProvider},
-    trace::SdkTracerProvider,
+    trace::{Sampler, SdkTracerProvider},
 };
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -317,6 +317,9 @@ pub fn init_observability(config: &ServerConfig) -> anyhow::Result<Observability
 
         let tracer_provider = SdkTracerProvider::builder()
             .with_resource(resource.clone())
+            .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+                config.otel_trace_sample_ratio,
+            ))))
             .with_batch_exporter(exporter)
             .build();
         let tracer = tracer_provider.tracer("gateway");

--- a/crates/gateway/src/observability.rs
+++ b/crates/gateway/src/observability.rs
@@ -13,6 +13,7 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
     metrics::{PeriodicReader, SdkMeterProvider},
+    propagation::TraceContextPropagator,
     trace::{Sampler, SdkTracerProvider},
 };
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
@@ -294,6 +295,8 @@ fn base_attrs(labels: &ChatMetricLabels<'_>) -> Vec<KeyValue> {
 }
 
 pub fn init_observability(config: &ServerConfig) -> anyhow::Result<ObservabilityGuard> {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         "gateway=info,gateway_core=info,gateway_service=info,gateway_store=info,gateway_providers=info"
             .parse()

--- a/deploy/helm/oceans-llm/README.md
+++ b/deploy/helm/oceans-llm/README.md
@@ -102,6 +102,7 @@ Example values live in [examples](examples):
 - ingress with TLS and HPA behavior
 - CloudNativePG
 - observability sidecar wiring
+- direct OpenTelemetry export to an existing Datadog Agent DaemonSet
 
 ## Publishing
 

--- a/deploy/helm/oceans-llm/examples/observability-datadog-values.yaml
+++ b/deploy/helm/oceans-llm/examples/observability-datadog-values.yaml
@@ -1,0 +1,45 @@
+# This example sends OpenTelemetry traces and metrics directly to an existing
+# Datadog Agent DaemonSet. It does not deploy an OpenTelemetry Collector sidecar.
+# Enable the Agent's OTLP/gRPC receiver before applying these values. Keep the
+# Agent-wide probabilistic sampler disabled when the Agent is shared; this
+# gateway applies its own trace sampling ratio below.
+gateway:
+  config:
+    server:
+      bind: "0.0.0.0:8080"
+      log_format: "json"
+      # Replace the service name and namespace with the Service that exposes the
+      # Datadog Agent OTLP/gRPC receiver on port 4317. Configure that Service with
+      # internalTrafficPolicy: Local so telemetry stays on the gateway pod's node.
+      otel_endpoint: "http://datadog-agent.monitoring.svc.cluster.local:4317"
+      # Metrics use a separate setting so their destination can change without
+      # changing trace export. Both signals can use the same Agent OTLP receiver.
+      otel_metrics_endpoint: "http://datadog-agent.monitoring.svc.cluster.local:4317"
+      # Sample 50% of root traces in the gateway. ParentBased sampling preserves
+      # an upstream trace decision. This setting does not sample OTLP metrics.
+      otel_trace_sample_ratio: 0.5
+      # Export metric batches every 30 seconds.
+      otel_export_interval_secs: 30
+    database:
+      kind: postgres
+      url: env.POSTGRES_URL
+    auth:
+      bootstrap_admin:
+        enabled: false
+        email: admin@local
+        password: env.GATEWAY_BOOTSTRAP_ADMIN_PASSWORD
+        require_password_change: true
+
+database:
+  mode: external
+  external:
+    existingSecret:
+      name: oceans-llm-postgres
+      key: POSTGRES_URL
+
+observability:
+  # Unified service tags let Datadog correlate gateway telemetry consistently.
+  # Set the environment label to the deployment environment used in Datadog.
+  podLabels:
+    tags.datadoghq.com/service: oceans-llm-gateway
+    tags.datadoghq.com/env: production

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -79,6 +79,10 @@ const primarySidebar = [
         link: "/operations/observability-and-request-logs",
         items: [
           {
+            text: "Export Traces and Metrics",
+            link: "/operations/observability/export-traces-and-metrics",
+          },
+          {
             text: "Request Logs",
             link: "/operations/observability/request-logs",
           },

--- a/docs/.vitepress/theme/sidebar-icons.ts
+++ b/docs/.vitepress/theme/sidebar-icons.ts
@@ -55,6 +55,7 @@ const sidebarIcons: Record<string, readonly HugeIconNode[]> = {
   "/mcp/mcp-invocations": Activity01Icon,
   "/operations/tagging": Tag01Icon,
   "/operations/observability-and-request-logs": FileSearchIcon,
+  "/operations/observability/export-traces-and-metrics": Activity01Icon,
   "/operations/observability/request-logs": FileSearchIcon,
   "/operations/agent-harness-usage": RoboticIcon,
   "/operations/operator-runbooks": Book02Icon,

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -202,9 +202,10 @@ Important fields:
 - `log_format`
 - `otel_endpoint`
 - `otel_metrics_endpoint`
+- `otel_trace_sample_ratio` (`0.0` through `1.0`, default `1.0`)
 - `otel_export_interval_secs`
 
-For collector assumptions and request-log implications, see [observability-and-request-logs.md](../operations/observability-and-request-logs.md).
+For collector and Datadog setup, see [Export Traces and Metrics](../operations/observability/export-traces-and-metrics.md). For request-log storage, see [Observability and Request Logs](../operations/observability-and-request-logs.md).
 
 ## `request_logging`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ features:
     link: /access/budgets
     linkText: Manage budgets
   - title: Trace requests
-    details: Follow request logs, retention purge, MCP invocation records, observability payloads, failure modes, and provider compatibility edges.
-    link: /operations/observability/request-logs
+    details: Export traces and metrics through OTLP, then inspect request logs, MCP invocations, payload state, and failure details.
+    link: /operations/observability/export-traces-and-metrics
     linkText: Inspect observability
 ---

--- a/docs/operations/observability-and-request-logs.md
+++ b/docs/operations/observability-and-request-logs.md
@@ -1,6 +1,6 @@
 # Observability and Request Logs
 
-`See also`: [Request Logs](observability/request-logs.md), [MCP Invocations](../mcp/mcp-invocations.md), [MCP Registry and Discovery](../contributing/mcp/mcp-registry-and-discovery.md), [Tagging](tagging.md), [Agent Harness Usage](agent-harness-usage.md), [Data Relationships](../contributing/reference/data-relationships.md), [Service Accounts](../access/service-accounts.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Provider API Compatibility](../reference/provider-api-compatibility.md), [Request Lifecycle and Failure Modes](../reference/request-lifecycle-and-failure-modes.md), [Admin Control Plane](../access/admin-control-plane.md), [Deploy and Operations](../setup/deploy-and-operations.md), [ADR: Team Service Accounts for Non-Human Gateway Access](../adr/2026-05-10-team-service-accounts.md), [ADR: OTLP-First Observability and Payload-Backed Request Logs](../adr/2026-03-15-otlp-observability-and-request-log-payloads.md), [ADR: Route-Level Provider API Compatibility Profiles](../adr/2026-04-23-route-level-provider-api-compatibility-profiles.md), [ADR: MCP Tool Cardinality Observability](../adr/2026-04-28-mcp-tool-cardinality-observability.md), [ADR: External MCP Registry and Discovery Boundary](../adr/2026-05-26-external-mcp-registry-and-discovery.md)
+`See also`: [Export Traces and Metrics](observability/export-traces-and-metrics.md), [Request Logs](observability/request-logs.md), [MCP Invocations](../mcp/mcp-invocations.md), [MCP Registry and Discovery](../contributing/mcp/mcp-registry-and-discovery.md), [Tagging](tagging.md), [Agent Harness Usage](agent-harness-usage.md), [Data Relationships](../contributing/reference/data-relationships.md), [Service Accounts](../access/service-accounts.md), [Model Routing and API Behavior](../configuration/model-routing-and-api-behavior.md), [Provider API Compatibility](../reference/provider-api-compatibility.md), [Request Lifecycle and Failure Modes](../reference/request-lifecycle-and-failure-modes.md), [Admin Control Plane](../access/admin-control-plane.md), [Deploy and Operations](../setup/deploy-and-operations.md), [ADR: Team Service Accounts for Non-Human Gateway Access](../adr/2026-05-10-team-service-accounts.md), [ADR: OTLP-First Observability and Payload-Backed Request Logs](../adr/2026-03-15-otlp-observability-and-request-log-payloads.md), [ADR: Route-Level Provider API Compatibility Profiles](../adr/2026-04-23-route-level-provider-api-compatibility-profiles.md), [ADR: MCP Tool Cardinality Observability](../adr/2026-04-28-mcp-tool-cardinality-observability.md), [ADR: External MCP Registry and Discovery Boundary](../adr/2026-05-26-external-mcp-registry-and-discovery.md)
 
 This document describes the live observability contract for the gateway.
 
@@ -34,62 +34,12 @@ Current config knobs:
 
 - `server.otel_endpoint`
 - `server.otel_metrics_endpoint`
+- `server.otel_trace_sample_ratio`
 - `server.otel_export_interval_secs`
 
-The intended deploy path is collector-friendly OTLP export rather than an in-process Prometheus endpoint.
+`server.otel_trace_sample_ratio` defaults to `1.0` and accepts values from `0.0` through `1.0`. It uses parent-based sampling for traces and does not sample exported metrics. The intended deploy path is collector-friendly OTLP export rather than an in-process Prometheus endpoint.
 
-## Kubernetes Helm Wiring
-
-The Helm chart keeps observability generic. It does not install an OpenTelemetry Collector, Datadog Agent, or any other collector.
-
-Kubernetes installs can use:
-
-- `gateway.config.server.otel_endpoint`
-- `gateway.config.server.otel_metrics_endpoint`
-- `gateway.config.server.otel_export_interval_secs`
-- `observability.env`
-- `observability.podLabels`
-- `observability.podAnnotations`
-- `observability.volumes`
-- `observability.volumeMounts`
-- `observability.sidecars`
-
-Common shapes:
-
-- existing in-cluster collector `Service`: set OTLP endpoints in `gateway.config.server.*`
-- DaemonSet collector or vendor agent: point OTLP endpoints at the node-local or service DNS address documented by that deployment
-- sidecar collector: add the collector container with `observability.sidecars` and point OTLP endpoints at `localhost`
-- annotation-driven scraping or injection: set the required labels and annotations through `observability.podLabels` and `observability.podAnnotations`
-
-Use [Kubernetes and Helm](../setup/kubernetes-and-helm.md) for chart-level values and examples.
-
-OpenTelemetry Collector service example:
-
-```yaml
-gateway:
-  config:
-    server:
-      otel_endpoint: http://otel-collector.observability.svc:4317
-      otel_metrics_endpoint: http://otel-collector.observability.svc:4317
-observability:
-  env:
-    - name: OTEL_SERVICE_NAME
-      value: oceans-llm-gateway
-```
-
-Datadog Agent OTLP example:
-
-```yaml
-gateway:
-  config:
-    server:
-      otel_endpoint: http://datadog-agent.datadog.svc:4317
-      otel_metrics_endpoint: http://datadog-agent.datadog.svc:4317
-observability:
-  podLabels:
-    tags.datadoghq.com/service: oceans-llm-gateway
-    tags.datadoghq.com/env: production
-```
+Use [Export Traces and Metrics](observability/export-traces-and-metrics.md) to configure an OpenTelemetry Collector or Datadog Agent. The guide covers Helm wiring, shared-Agent sampling, and export checks.
 
 ## What Gets Recorded
 

--- a/docs/operations/observability/export-traces-and-metrics.md
+++ b/docs/operations/observability/export-traces-and-metrics.md
@@ -1,0 +1,139 @@
+# Export Traces and Metrics
+
+`See also`: [Observability and Request Logs](../observability-and-request-logs.md), [Request Logs](request-logs.md), [Kubernetes and Helm](../../setup/kubernetes-and-helm.md), [Configuration Reference](../../configuration/configuration-reference.md), [Admin Runbooks](../operator-runbooks.md)
+
+Oceans LLM sends traces and metrics with the OpenTelemetry Protocol (OTLP). Admins can send this data to an OpenTelemetry Collector or to a Datadog Agent that accepts OTLP.
+
+The gateway uses OTLP over gRPC. The examples use receiver port `4317`. You can set a different port in the endpoint URI. The Helm chart does not install a collector or an agent.
+
+## Understand the Data Flow
+
+The gateway creates telemetry and sends it to one OTLP receiver:
+
+```text
+Oceans LLM gateway -> OTLP/gRPC receiver -> observability backend
+```
+
+The receiver can be:
+
+- an OpenTelemetry Collector `Service`
+- an OpenTelemetry Collector sidecar
+- a node-local collector or vendor agent
+- a Datadog Agent `Service` backed by a DaemonSet
+
+OTLP export is separate from request-log storage. The gateway can store request logs when no OTLP receiver is present. Admins and users can still view allowed request logs in the admin UI. See [Observability and Request Logs](../observability-and-request-logs.md) for payload policy and retention.
+
+## Prerequisites
+
+Before you configure the gateway:
+
+1. Deploy an OTLP receiver that accepts gRPC traffic.
+2. Make the receiver address reachable from the gateway process or pod.
+3. Allow TCP traffic from the gateway to the receiver port.
+4. Configure the receiver to send data to its backend.
+
+Use an `http://` URI for an unencrypted in-cluster endpoint. Use the TLS address required by your receiver for traffic that leaves the trusted network.
+
+## Configure OTLP Export
+
+Add the receiver endpoints to the `server` section of `gateway.yaml`:
+
+```yaml
+server:
+  otel_endpoint: http://otel-collector.observability.svc:4317
+  otel_metrics_endpoint: http://otel-collector.observability.svc:4317
+  otel_trace_sample_ratio: 1.0
+  otel_export_interval_secs: 30
+```
+
+The fields have these effects:
+
+| Field | Effect |
+| --- | --- |
+| `otel_endpoint` | Enables trace export and sets the OTLP/gRPC trace endpoint. |
+| `otel_metrics_endpoint` | Enables metric export and sets the OTLP/gRPC metric endpoint. If absent, metrics use `otel_endpoint`. |
+| `otel_trace_sample_ratio` | Samples root traces from `0.0` through `1.0`. The default is `1.0`. An upstream parent decision is kept. |
+| `otel_export_interval_secs` | Sets the interval for metric export batches. |
+
+Trace sampling does not sample metrics. A value of `0.5` keeps about half of new root traces. All metric instruments remain active.
+
+Restart the gateway after you change these values. An invalid endpoint URI stops config validation. A sampling ratio outside `0.0` through `1.0` also stops validation.
+
+## Send Data to an OpenTelemetry Collector
+
+Point both endpoints at the collector OTLP/gRPC receiver. The collector can send traces and metrics to different backends after it receives them.
+
+For Kubernetes, use the collector `Service` DNS name:
+
+```yaml
+gateway:
+  config:
+    server:
+      otel_endpoint: http://otel-collector.observability.svc:4317
+      otel_metrics_endpoint: http://otel-collector.observability.svc:4317
+      otel_trace_sample_ratio: 1.0
+      otel_export_interval_secs: 30
+```
+
+If the collector runs as a sidecar, use `http://127.0.0.1:4317`. The checked-in [sidecar values example](../../../deploy/helm/oceans-llm/examples/observability-sidecar-values.yaml) shows the pod wiring. You must also create the referenced collector `ConfigMap`.
+
+## Send Data to Datadog
+
+Enable the OTLP/gRPC receiver on the existing Datadog Agent before you update the gateway. Expose that receiver through an in-cluster `Service` that the gateway pods can reach.
+
+Then point the gateway at the Agent:
+
+```yaml
+gateway:
+  config:
+    server:
+      otel_endpoint: http://datadog-agent.monitoring.svc.cluster.local:4317
+      otel_metrics_endpoint: http://datadog-agent.monitoring.svc.cluster.local:4317
+      otel_trace_sample_ratio: 0.5
+      otel_export_interval_secs: 30
+
+observability:
+  podLabels:
+    tags.datadoghq.com/service: oceans-llm-gateway
+    tags.datadoghq.com/env: production
+```
+
+Use [observability-datadog-values.yaml](../../../deploy/helm/oceans-llm/examples/observability-datadog-values.yaml) as a complete Helm values example. Replace its namespace, `Service` name, database secret, and environment label for your cluster.
+
+For a Datadog Agent DaemonSet, route each gateway pod to an Agent on the same node when possible. A `Service` with `internalTrafficPolicy: Local` can provide this route. Confirm that every node that can run the gateway also runs an Agent pod.
+
+Set the trace ratio in Oceans LLM when the Agent is shared with other services. An Agent-wide sampler can change trace intake for every service that sends data to that Agent. The gateway ratio changes only new root traces from Oceans LLM.
+
+The gateway sets these OpenTelemetry resource attributes:
+
+- `service.name=oceans-llm-gateway`
+- `service.namespace=oceans-llm`
+- `service.version=<gateway version>`
+
+The Datadog pod labels use the same service name so Datadog can join the telemetry under one service identity.
+
+## Verify the Export
+
+After the gateway restarts:
+
+1. Check the gateway startup logs for OTLP exporter errors.
+2. Send a normal model request through the gateway.
+3. Wait at least one configured metric export interval.
+4. Search the backend for the service name `oceans-llm-gateway`.
+5. Confirm that a trace and at least one gateway metric are present.
+
+Gateway metric names include:
+
+- `gateway.chat.requests`
+- `gateway.chat.request.duration`
+- `gateway.chat.tokens`
+- `gateway.chat.cost.usd`
+- `gateway.mcp.tool_invocations`
+
+For Datadog, check APM for the `oceans-llm-gateway` service. Use Metrics Explorer to find the gateway metrics. Datadog can map OpenTelemetry metric names during intake. Inspect the received names if an exact search returns no result.
+
+If request logs appear in the admin UI but OTLP data does not appear in the backend, check the receiver address, network policy, receiver logs, and backend exporter settings. The [Missing OTLP Collector](../operator-runbooks.md#missing-otlp-collector) runbook provides more checks.
+
+## Disable OTLP Export
+
+Remove `otel_endpoint` and `otel_metrics_endpoint`, then restart the gateway. This stops OTLP trace and metric export. It does not disable structured process logs or database-backed request logs.

--- a/docs/operations/observability/export-traces-and-metrics.md
+++ b/docs/operations/observability/export-traces-and-metrics.md
@@ -8,11 +8,14 @@ The gateway uses OTLP over gRPC. The examples use receiver port `4317`. You can 
 
 ## Understand the Data Flow
 
-The gateway creates telemetry and sends it to one OTLP receiver:
+The gateway creates telemetry and sends each configured signal to its OTLP receiver:
 
 ```text
-Oceans LLM gateway -> OTLP/gRPC receiver -> observability backend
+Oceans LLM gateway -- traces --> OTLP/gRPC receiver -- traces --> backend
+                   -- metrics -> OTLP/gRPC receiver -- metrics -> backend
 ```
+
+Traces and metrics can use the same receiver or separate receivers.
 
 The receiver can be:
 
@@ -32,7 +35,7 @@ Before you configure the gateway:
 3. Allow TCP traffic from the gateway to the receiver port.
 4. Configure the receiver to send data to its backend.
 
-Use an `http://` URI for an unencrypted in-cluster endpoint. Use the TLS address required by your receiver for traffic that leaves the trusted network.
+The current gateway exporter supports plaintext OTLP/gRPC endpoints. Use an `http://` URI on a trusted network. For secure external export, send plaintext traffic to a local or in-cluster collector and configure that collector to use TLS when it sends data to the external backend.
 
 ## Configure OTLP Export
 

--- a/docs/setup/deploy-and-operations.md
+++ b/docs/setup/deploy-and-operations.md
@@ -94,6 +94,7 @@ Relevant config knobs:
 
 - `server.otel_endpoint`
 - `server.otel_metrics_endpoint`
+- `server.otel_trace_sample_ratio`
 - `server.otel_export_interval_secs`
 
 The checked-in deploy path does not ship a collector by default.

--- a/docs/setup/kubernetes-and-helm.md
+++ b/docs/setup/kubernetes-and-helm.md
@@ -1,6 +1,6 @@
 # Kubernetes and Helm
 
-`See also`: [Deploy and Operations](deploy-and-operations.md), [Runtime Bootstrap and Access](runtime-bootstrap-and-access.md), [Admin Runbooks](../operations/operator-runbooks.md), [Observability and Request Logs](../operations/observability-and-request-logs.md), [Configuration Reference](../configuration/configuration-reference.md), [Release Process](../contributing/reference/release-process.md), [Deploy](../../deploy/README.md)
+`See also`: [Deploy and Operations](deploy-and-operations.md), [Runtime Bootstrap and Access](runtime-bootstrap-and-access.md), [Admin Runbooks](../operations/operator-runbooks.md), [Export Traces and Metrics](../operations/observability/export-traces-and-metrics.md), [Observability and Request Logs](../operations/observability-and-request-logs.md), [Configuration Reference](../configuration/configuration-reference.md), [Release Process](../contributing/reference/release-process.md), [Deploy](../../deploy/README.md)
 
 This page owns the Kubernetes and Helm deployment contract for Oceans LLM.
 
@@ -141,7 +141,9 @@ The chart does not install an OpenTelemetry Collector or vendor agent. It expose
 - `observability.volumeMounts`
 - `observability.sidecars`
 
-Use `gateway.config.server.otel_endpoint`, `gateway.config.server.otel_metrics_endpoint`, and `observability.env` to point the gateway at an existing collector, DaemonSet, sidecar, or vendor endpoint. Examples cover OpenTelemetry and Datadog Agent-style wiring without making either one a bundled dependency.
+Use `gateway.config.server.otel_endpoint`, `gateway.config.server.otel_metrics_endpoint`, `gateway.config.server.otel_trace_sample_ratio`, and `observability.env` to point the gateway at an existing collector, DaemonSet, sidecar, or vendor endpoint. Trace sampling is parent-based and does not sample exported metrics. Examples cover OpenTelemetry and Datadog Agent-style wiring without making either one a bundled dependency.
+
+Use [Export Traces and Metrics](../operations/observability/export-traces-and-metrics.md) for the complete setup and verification procedure.
 
 ## Example Values
 
@@ -153,6 +155,7 @@ Checked-in examples cover:
 - ingress with TLS and HPA behavior
 - CloudNativePG
 - observability sidecar wiring
+- direct OpenTelemetry export to an existing Datadog Agent DaemonSet
 
 Render them locally with:
 

--- a/docs/setup/kubernetes-and-helm.md
+++ b/docs/setup/kubernetes-and-helm.md
@@ -141,7 +141,7 @@ The chart does not install an OpenTelemetry Collector or vendor agent. It expose
 - `observability.volumeMounts`
 - `observability.sidecars`
 
-Use `gateway.config.server.otel_endpoint`, `gateway.config.server.otel_metrics_endpoint`, `gateway.config.server.otel_trace_sample_ratio`, and `observability.env` to point the gateway at an existing collector, DaemonSet, sidecar, or vendor endpoint. Trace sampling is parent-based and does not sample exported metrics. Examples cover OpenTelemetry and Datadog Agent-style wiring without making either one a bundled dependency.
+Use `gateway.config.server.otel_endpoint`, `gateway.config.server.otel_metrics_endpoint`, and `gateway.config.server.otel_trace_sample_ratio` to configure gateway OTLP export. Use `observability.env` for environment variables required by sidecars or vendor agents. Trace sampling is parent-based and does not sample exported metrics. Examples cover OpenTelemetry and Datadog Agent-style wiring without making either one a bundled dependency.
 
 Use [Export Traces and Metrics](../operations/observability/export-traces-and-metrics.md) for the complete setup and verification procedure.
 


### PR DESCRIPTION
## Description

This PR adds service-scoped OTLP trace sampling and documents how to export Oceans LLM telemetry to OpenTelemetry or Datadog.

- Upgrade `opentelemetry`, `opentelemetry-otlp`, and `opentelemetry_sdk` to `v0.32`, with the compatible `tracing-opentelemetry` release.
- Add `server.otel_trace_sample_ratio`, with a default of `1.0` and validation from `0.0` through `1.0`.
- Apply parent-based, trace-ID ratio sampling in the gateway so an upstream sampling decision is kept.
- Add a commented Helm values example for an existing Datadog Agent DaemonSet with a `0.5` gateway trace ratio.
- Add an admin-facing guide for OTLP Collector and Datadog Agent setup, data flow, verification, and shutdown.
- Add the guide to the primary documentation navigation and related canonical pages.

Gateway-level sampling limits the change to Oceans LLM traces. This avoids an Agent-wide sampling rule that could affect other services which share the same Datadog Agent. Trace sampling does not sample explicit OpenTelemetry metrics. The default ratio of `1.0` keeps existing behavior for deployments that do not set the new field.

The Helm chart still does not install an OpenTelemetry Collector or Datadog Agent. Admins must provide a reachable OTLP/gRPC receiver and enable its intake path.

The full docs site builds. The docs graph check still reports a pre-existing missing `See also` header in `docs/design-proposals/agent-sessions/README.md`, which is outside this change.

## Release Readiness Checklist

- [x] `mise run lint`
- [x] `mise run test`
- [x] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:check`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:test:postgres` (blocked: `TEST_POSTGRES_URL` is not set)
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:smoke:postgres` (blocked: `POSTGRES_URL` is not set)

Additional checks:

- `mise run //docs:build`
- `mise run helm-check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
