### PR TITLE
fix(admin-ui): render harness icon masks

### DIFF
--- a/crates/admin-ui/web/src/components/icons/agent-harness-icon.test.tsx
+++ b/crates/admin-ui/web/src/components/icons/agent-harness-icon.test.tsx
@@ -6,8 +6,14 @@ import { AgentHarnessLabel } from '@/components/icons/agent-harness-icon'
 describe('AgentHarnessLabel', () => {
   it.each(['OpenCode', 'Pi', 'Claude Code', 'Codex'])('renders the %s harness icon', (label) => {
     const { container } = render(<AgentHarnessLabel harnessKey={label}>{label}</AgentHarnessLabel>)
+    const icon = container.querySelector<HTMLElement>('[data-agent-harness-icon]')
 
-    expect(container.querySelector('[data-agent-harness-icon]')).toBeInTheDocument()
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-image: url('))
+    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-position: center'))
+    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-repeat: no-repeat'))
+    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-size: contain'))
+    expect(icon).toHaveAttribute('style', expect.stringContaining('background-color: currentcolor'))
   })
 
   it('keeps unknown harness labels text-only', () => {

--- a/crates/admin-ui/web/src/components/icons/agent-harness-icon.test.tsx
+++ b/crates/admin-ui/web/src/components/icons/agent-harness-icon.test.tsx
@@ -9,11 +9,15 @@ describe('AgentHarnessLabel', () => {
     const icon = container.querySelector<HTMLElement>('[data-agent-harness-icon]')
 
     expect(icon).toBeInTheDocument()
-    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-image: url('))
-    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-position: center'))
-    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-repeat: no-repeat'))
-    expect(icon).toHaveAttribute('style', expect.stringContaining('mask-size: contain'))
-    expect(icon).toHaveAttribute('style', expect.stringContaining('background-color: currentcolor'))
+    expect(icon?.style.getPropertyValue('-webkit-mask-image')).toContain('url(')
+    expect(icon?.style.getPropertyValue('-webkit-mask-position')).toBe('center')
+    expect(icon?.style.getPropertyValue('-webkit-mask-repeat')).toBe('no-repeat')
+    expect(icon?.style.getPropertyValue('-webkit-mask-size')).toBe('contain')
+    expect(icon?.style.getPropertyValue('mask-image')).toContain('url(')
+    expect(icon?.style.getPropertyValue('mask-position')).toBe('center')
+    expect(icon?.style.getPropertyValue('mask-repeat')).toBe('no-repeat')
+    expect(icon?.style.getPropertyValue('mask-size')).toBe('contain')
+    expect(icon?.style.getPropertyValue('background-color')).toBe('currentcolor')
   })
 
   it('keeps unknown harness labels text-only', () => {

--- a/crates/admin-ui/web/src/components/icons/agent-harness-icon.tsx
+++ b/crates/admin-ui/web/src/components/icons/agent-harness-icon.tsx
@@ -1,9 +1,9 @@
 import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
 
-import claudeCodeIcon from '@lobehub/icons-static-svg/icons/claudecode.svg'
-import codexIcon from '@lobehub/icons-static-svg/icons/codex.svg'
-import openCodeIcon from '@lobehub/icons-static-svg/icons/opencode.svg'
-import piIcon from '@lobehub/icons-static-svg/icons/pi.svg'
+import claudeCodeIcon from '@lobehub/icons-static-svg/icons/claudecode.svg?url'
+import codexIcon from '@lobehub/icons-static-svg/icons/codex.svg?url'
+import openCodeIcon from '@lobehub/icons-static-svg/icons/opencode.svg?url'
+import piIcon from '@lobehub/icons-static-svg/icons/pi.svg?url'
 
 import { cn } from '@/lib/utils'
 
@@ -33,8 +33,14 @@ export function AgentHarnessIcon({
   }
 
   const maskStyle: CSSProperties = {
-    WebkitMask: `url(${source}) center / contain no-repeat`,
-    mask: `url(${source}) center / contain no-repeat`,
+    WebkitMaskImage: `url("${source}")`,
+    WebkitMaskPosition: 'center',
+    WebkitMaskRepeat: 'no-repeat',
+    WebkitMaskSize: 'contain',
+    maskImage: `url("${source}")`,
+    maskPosition: 'center',
+    maskRepeat: 'no-repeat',
+    maskSize: 'contain',
     backgroundColor: 'currentColor',
     height: size,
     width: size,


### PR DESCRIPTION
## Description

Fix harness icons that appeared as solid foreground-colour squares instead of transparent monochrome marks.

- Import the Claude Code, Codex, OpenCode, and Pi SVG assets as explicit Vite URLs.
- Replace the CSS mask shorthand with explicit standard and WebKit mask properties.
- Keep `currentColor` as the icon fill so each mark follows its surrounding text colour.
- Add regression checks for the mask image, position, repeat, size, and foreground colour.

The prior shorthand mask could be dropped or interpreted incorrectly. When that happened, the span's `currentColor` background remained visible across its full square bounds. Explicit asset URLs and mask longhands make the transparent mask contract clear across supported browsers.

This is a shared component fix. It updates every current `AgentHarnessIcon` and `AgentHarnessLabel` consumer without changing unknown-harness fallback behavior.

Risk is limited to harness icon rendering. No API, runtime, database, or release behavior changes.

## Release Readiness Checklist

- [ ] `mise run lint`
- [ ] `mise run test`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:check`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:test:postgres`
- [ ] If this PR touches runtime, store, migration, or release behavior: `mise run //crates/gateway-store:smoke:postgres`

Additional validation:

- [x] `mise run ui-check` — formatting, UI lint, 27 test files / 127 tests, and client and SSR production builds
- [x] Commit hooks — whitespace, file endings, YAML, large-file, and lint checks
- [x] `git diff --check`
